### PR TITLE
[codex] Pass Store runtime id in setup command

### DIFF
--- a/packages/extension/scripts/test-popup.mjs
+++ b/packages/extension/scripts/test-popup.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 const packageRoot = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const statusKey = "OBU_NATIVE_HOST_STATUS";
 const debugLogKey = "OBU_DEBUG_LOG";
+const runtimeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
 
 class EventTarget {
   listeners = [];
@@ -518,6 +519,7 @@ async function runPopupStoreSetupCommand() {
 
     assert.equal(harness.elements.setupPanel.hidden, false);
     assert.match(harness.elements.setupCommand.textContent, /obu setup --yes --all --skip-agents --channel=store/);
+    assert.match(harness.elements.setupCommand.textContent, new RegExp(`--extension-id=${runtimeExtensionId}`));
     assert.match(harness.elements.setupCommand.textContent, /obu doctor browser --repair --channel=store/);
   } finally {
     runBuild("unpacked-dev");
@@ -669,6 +671,7 @@ function installPopupHarness(responses, options = {}) {
   globalThis.chrome = {
     runtime: {
       getManifest: () => ({ version: "0.1.0" }),
+      id: runtimeExtensionId,
       async sendMessage(message) {
         sent.push(message);
         if (message?.type === "GET_DEBUG_LOG_STATUS") return debugState;

--- a/packages/extension/src/popup.ts
+++ b/packages/extension/src/popup.ts
@@ -2,7 +2,7 @@ const STATUS_KEY = "OBU_NATIVE_HOST_STATUS";
 const DEBUG_LOG_KEY = "OBU_DEBUG_LOG";
 const GITHUB_INSTALL_URL = "https://github.com/open-browser-use/open-browser-use/releases/latest/download/install.sh";
 const EXTENSION_CHANNEL = "__OBU_EXTENSION_CHANNEL__";
-const SETUP_COMMAND = setupCommandForChannel(EXTENSION_CHANNEL);
+const SETUP_COMMAND = setupCommandForChannel(EXTENSION_CHANNEL, chrome.runtime.id);
 
 type ExtensionChannel = "unpacked-dev" | "store";
 
@@ -361,13 +361,16 @@ function disconnectedPortObjectAdvice(): NativeHostAdvice {
   );
 }
 
-function setupCommandForChannel(channel: string): string {
+function setupCommandForChannel(channel: string, runtimeExtensionId?: string): string {
   const resolvedChannel: ExtensionChannel = channel === "store" ? "store" : "unpacked-dev";
   const channelSuffix = resolvedChannel === "store" ? " --channel=store" : "";
+  const extensionIdSuffix = resolvedChannel === "store" && isExtensionId(runtimeExtensionId)
+    ? ` --extension-id=${runtimeExtensionId}`
+    : "";
   return [
     `curl -fsSL ${GITHUB_INSTALL_URL} | sh && \\`,
-    `~/.obu/bin/obu setup --yes --all --skip-agents${channelSuffix} && \\`,
-    `~/.obu/bin/obu doctor browser --repair${channelSuffix}`,
+    `~/.obu/bin/obu setup --yes --all --skip-agents${channelSuffix}${extensionIdSuffix} && \\`,
+    `~/.obu/bin/obu doctor browser --repair${channelSuffix}${extensionIdSuffix}`,
   ].join("\n");
 }
 
@@ -403,6 +406,10 @@ function normalizeDiagnosis(status: HostStatus): HostDiagnosis | undefined {
 
 function isDisconnectedPortObject(message: string | undefined): boolean {
   return /disconnected port object/i.test(message ?? "");
+}
+
+function isExtensionId(value: string | undefined): value is string {
+  return typeof value === "string" && /^[a-p]{32}$/.test(value);
 }
 
 function joinSentences(parts: string[]): string {


### PR DESCRIPTION
## Summary
- include the current Chrome extension id in Store-channel setup and doctor commands
- keep unpacked-dev commands unchanged
- add popup test coverage for the Store command

## Validation
- pnpm -C packages/extension test
- node packages/extension/scripts/test-store-artifact.mjs
- pnpm -r typecheck
- git diff --check