### PR TITLE
[codex] Fix persistent takeover overlay control

### DIFF
--- a/crates/obu-node-repl/resources/js_tool_description.md
+++ b/crates/obu-node-repl/resources/js_tool_description.md
@@ -17,6 +17,12 @@ open-browser-use SDK. This is the browser automation surface: do not ask for sep
 `agent.browsers.get(...)` is async, so always write
 `const browser = await agent.browsers.get("chrome")`. `browser.tabs.create()`
 accepts either a URL string or `{ url }`; with no URL it creates `about:blank`.
+Keep the returned `Tab` handle and use `await tab.goto(url)` for repeated
+same-task or same-site navigation instead of creating a new tab for every URL.
+One browser session can hold multiple `Tab` handles; keep them in variables and
+move data explicitly between tabs.
+Use `browser.turnEnded()` when a turn is done but active tabs should remain
+controlled; `browser.finishTurn(...)` finalizes tabs before ending the turn.
 The WebExtension backend cannot drive `file://` pages. Serve local files over
 HTTP, for example `python3 -m http.server`, and navigate to
 `http://127.0.0.1:...`.
@@ -90,8 +96,10 @@ can stream as progress, but they are also included in the final result.
 const browser = await agent.browsers.get("cdp");
 const tab = await browser.tabs.create("https://example.com");
 await tab.attach();
+await tab.goto("https://example.com/docs");
 await tab.locator("h1").click();
 await tab.screenshotForModel({ clip: { x: 0, y: 0, width: 900, height: 700, scale: 0.5 } });
+await browser.turnEnded();
 ```
 
 ```js
@@ -99,6 +107,14 @@ const browser = await agent.browsers.get("chrome");
 const tab = await browser.tabs.create("data:text/html,<button>Save</button>");
 await tab.attach();
 await tab.getByRole("button", { name: "Save" }).click();
+```
+
+```js
+const browser = await agent.browsers.get("chrome");
+const source = await browser.tabs.create("https://example.com/source");
+const target = await browser.tabs.create("https://example.com/target");
+const text = await source.getByRole("main").innerText();
+await target.getByLabel("Notes").fill(text);
 ```
 
 ```js

--- a/crates/obu-node-repl/tests/snapshots/description_snapshot__js_tool_description.snap
+++ b/crates/obu-node-repl/tests/snapshots/description_snapshot__js_tool_description.snap
@@ -21,6 +21,12 @@ open-browser-use SDK. This is the browser automation surface: do not ask for sep
 `agent.browsers.get(...)` is async, so always write
 `const browser = await agent.browsers.get("chrome")`. `browser.tabs.create()`
 accepts either a URL string or `{ url }`; with no URL it creates `about:blank`.
+Keep the returned `Tab` handle and use `await tab.goto(url)` for repeated
+same-task or same-site navigation instead of creating a new tab for every URL.
+One browser session can hold multiple `Tab` handles; keep them in variables and
+move data explicitly between tabs.
+Use `browser.turnEnded()` when a turn is done but active tabs should remain
+controlled; `browser.finishTurn(...)` finalizes tabs before ending the turn.
 The WebExtension backend cannot drive `file://` pages. Serve local files over
 HTTP, for example `python3 -m http.server`, and navigate to
 `http://127.0.0.1:...`.
@@ -94,8 +100,10 @@ can stream as progress, but they are also included in the final result.
 const browser = await agent.browsers.get("cdp");
 const tab = await browser.tabs.create("https://example.com");
 await tab.attach();
+await tab.goto("https://example.com/docs");
 await tab.locator("h1").click();
 await tab.screenshotForModel({ clip: { x: 0, y: 0, width: 900, height: 700, scale: 0.5 } });
+await browser.turnEnded();
 ```
 
 ```js
@@ -103,6 +111,14 @@ const browser = await agent.browsers.get("chrome");
 const tab = await browser.tabs.create("data:text/html,<button>Save</button>");
 await tab.attach();
 await tab.getByRole("button", { name: "Save" }).click();
+```
+
+```js
+const browser = await agent.browsers.get("chrome");
+const source = await browser.tabs.create("https://example.com/source");
+const target = await browser.tabs.create("https://example.com/target");
+const text = await source.getByRole("main").innerText();
+await target.getByLabel("Notes").fill(text);
 ```
 
 ```js

--- a/docs/agent-browser-mcp-usage.md
+++ b/docs/agent-browser-mcp-usage.md
@@ -59,7 +59,7 @@ display({ title: snapshot.title, headings: snapshot.headings.slice(0, 3) });
 const shot = await tab.screenshotForModel({
   clip: { x: 0, y: 0, width: 900, height: 700, scale: 0.5 }
 });
-await browser.finishTurn();
+await browser.turnEnded();
 ({ snapshot, shot });
 ```
 
@@ -80,6 +80,21 @@ Use this order when possible:
 - `agent.browsers.get(...)` is async. Always `await` it before reading `.tabs`.
 - `browser.tabs.create()` accepts a URL string or `{ url }`. With no URL it uses
   `about:blank`.
+- Keep a `Tab` handle and use `await tab.goto(url)` for same-task or same-site
+  navigation instead of opening a new tab for every URL.
+- A single browser session can hold multiple `Tab` handles. Keep them in
+  variables and move data explicitly between tabs:
+
+  ```js
+  const source = await browser.tabs.create("https://example.com/source");
+  const target = await browser.tabs.create("https://example.com/target");
+  const text = await source.getByRole("main").innerText();
+  await target.getByLabel("Notes").fill(text);
+  ```
+
+- Use `browser.turnEnded()` to mark a turn boundary while keeping active tabs
+  controlled. `browser.finishTurn(...)` first finalizes tabs and should be used
+  only when closing, releasing, handing off, or producing deliverables.
 - WebExtension sessions cannot drive `file://` pages. Serve local files over
   HTTP, for example `python3 -m http.server 8000`.
 - `tab.evaluate()` exists and defaults to a capped JSON result. Prefer it over

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,16 +87,14 @@ const shot = await tab.screenshot({
 display({ __obuImage: true, mime_type: shot.mime_type, data: shot.data_base64 });
 ```
 
-`tab.evaluate()` is not a first-class SDK method. For page-level JavaScript,
-use CDP directly:
+For bounded page-level JavaScript, prefer the first-class `tab.evaluate()`
+helper:
 
 ```js
-const result = await tab.dev.cdp("Runtime.evaluate", {
-  expression: "document.title",
-  returnByValue: true,
-  awaitPromise: true
-});
+const title = await tab.evaluate(() => document.title);
 ```
+
+Keep raw `tab.dev.cdp(...)` for cases that need direct CDP protocol access.
 
 The Node kernel intentionally hides `process` / `node:process`; use
 `nodeRepl.cwd`, `nodeRepl.homeDir`, `nodeRepl.tmpDir`, and

--- a/packages/extension/scripts/test-background.mjs
+++ b/packages/extension/scripts/test-background.mjs
@@ -44,6 +44,7 @@ class FakePort {
 const ports = [];
 const runtimeMessages = new EventTarget();
 const alarmEvents = new EventTarget();
+const tabRemovedEvents = new EventTarget();
 const debuggerEvents = new EventTarget();
 const debuggerDetaches = new EventTarget();
 const downloadCreates = new EventTarget();
@@ -161,6 +162,7 @@ globalThis.chrome = {
     async remove(tabId) {
       calls.tabsRemove.push(tabId);
       tabs.delete(tabId);
+      tabRemovedEvents.emit(tabId, { windowId: 1, isWindowClosing: false });
     },
     async sendMessage(tabId, message) {
       if (message?.type === "OBU_CONTENT_PING") {
@@ -185,6 +187,7 @@ globalThis.chrome = {
       }
       return {};
     },
+    onRemoved: tabRemovedEvents,
   },
   windows: {
     async get(windowId) {
@@ -206,7 +209,7 @@ globalThis.chrome = {
         if (message?.type === "OBU_CURSOR_MOVE") {
           if (suppressNextCursorArrival) {
             suppressNextCursorArrival = false;
-            return [{}];
+            return [{ result: true }];
           }
           setTimeout(() => {
             runtimeMessages.emit({
@@ -217,6 +220,7 @@ globalThis.chrome = {
             }, {}, () => {});
           }, 1);
         }
+        return [{ result: true }];
       }
       return [{}];
     },
@@ -302,6 +306,24 @@ assert.equal(created.result.tab.tabId, 1);
 assert.equal(calls.tabsCreate.length, 1);
 assert.equal(calls.tabsCreate[0].url, "https://example.com/");
 assert.equal(calls.tabsGroup[0].tabIds, 1);
+assert.ok(calls.tabsSendMessage.some((call) =>
+  call.tabId === 1 &&
+  call.message.type === "OBU_TAKEOVER_STATE" &&
+  call.message.active === true &&
+  call.message.lockInputs === true &&
+  call.message.sessionId === "session" &&
+  call.message.turnId === "turn",
+));
+const reassertStart = calls.tabsSendMessage.length;
+assert.deepEqual(await runtimeMessage({ type: "OBU_CONTENT_READY" }, { tab: { id: 1 } }), { ok: true });
+assert.ok(calls.tabsSendMessage.slice(reassertStart).some((call) =>
+  call.tabId === 1 &&
+  call.message.type === "OBU_TAKEOVER_STATE" &&
+  call.message.active === true &&
+  call.message.lockInputs === true &&
+  call.message.sessionId === "session" &&
+  call.message.turnId === "turn",
+));
 
 const blankCreated = await hostRequest(port, "createTab", {
   session_id: "session",
@@ -349,8 +371,10 @@ staleOldPort.emit({
     timeoutMs: 20,
   },
 });
+const hideCountBeforeStaleDisconnect = calls.tabsSendMessage.filter((call) => call.message.type === "OBU_CURSOR_HIDE").length;
 staleOldPort.disconnect();
 await waitFor(() => storage[statusKey]?.state === "disconnected");
+await waitFor(() => calls.tabsSendMessage.filter((call) => call.message.type === "OBU_CURSOR_HIDE").length > hideCountBeforeStaleDisconnect);
 const staleReconnectPortCount = ports.length;
 alarmEvents.emit({ name: "obu.reconnectNativeHost" });
 const staleNewPort = await waitFor(() => ports[staleReconnectPortCount]);
@@ -509,8 +533,45 @@ assert.ok(calls.tabsSendMessage.some((call) => call.message.type === "OBU_CURSOR
 assert.ok(calls.tabsSendMessage.some((call) =>
   call.message.type === "OBU_INPUT_BYPASS" &&
   call.message.reason === "cdp-mouse" &&
+  call.message.eventFamilies?.join(",") === "pointer" &&
   call.message.sessionId === "session" &&
   call.message.turnId === "turn",
+));
+await hostRequest(port, "executeCdp", {
+  session_id: "session",
+  turn_id: "turn",
+  target: { tabId: 1 },
+  method: "Input.dispatchMouseEvent",
+  commandParams: { type: "mouseWheel", x: 33, y: 44, deltaX: 0, deltaY: 120 },
+});
+await hostRequest(port, "executeCdp", {
+  session_id: "session",
+  turn_id: "turn",
+  target: { tabId: 1 },
+  method: "Input.dispatchKeyEvent",
+  commandParams: { type: "keyDown", key: "A" },
+});
+await hostRequest(port, "executeCdp", {
+  session_id: "session",
+  turn_id: "turn",
+  target: { tabId: 1 },
+  method: "Input.insertText",
+  commandParams: { text: "a" },
+});
+assert.ok(calls.tabsSendMessage.some((call) =>
+  call.message.type === "OBU_INPUT_BYPASS" &&
+  call.message.reason === "cdp-mouse" &&
+  call.message.eventFamilies?.join(",") === "wheel"
+));
+assert.ok(calls.tabsSendMessage.some((call) =>
+  call.message.type === "OBU_INPUT_BYPASS" &&
+  call.message.reason === "cdp-keyboard" &&
+  call.message.eventFamilies?.join(",") === "keyboard,text"
+));
+assert.ok(calls.tabsSendMessage.some((call) =>
+  call.message.type === "OBU_INPUT_BYPASS" &&
+  call.message.reason === "cdp-text" &&
+  call.message.eventFamilies?.join(",") === "text"
 ));
 const mousePressCommandIndex = calls.debuggerSendCommand.findIndex((call) =>
   call.method === "Input.dispatchMouseEvent" &&
@@ -524,11 +585,13 @@ assert.ok(mouseBypassIndex >= 0);
 assert.ok(mousePressCommandIndex >= 0);
 
 const hideCountBeforeTurnEnd = calls.tabsSendMessage.filter((call) => call.message.type === "OBU_CURSOR_HIDE").length;
+const moveCountBeforeTurnEnd = calls.tabsSendMessage.filter((call) => call.message.type === "OBU_CURSOR_MOVE").length;
 await hostRequest(port, "turnEnded", {
   session_id: "session",
   turn_id: "turn",
 });
-assert.ok(calls.tabsSendMessage.filter((call) => call.message.type === "OBU_CURSOR_HIDE").length > hideCountBeforeTurnEnd);
+assert.equal(calls.tabsSendMessage.filter((call) => call.message.type === "OBU_CURSOR_HIDE").length, hideCountBeforeTurnEnd);
+assert.equal(calls.tabsSendMessage.filter((call) => call.message.type === "OBU_CURSOR_MOVE").length, moveCountBeforeTurnEnd);
 
 debuggerEvents.emit({ tabId: 1 }, "Page.downloadWillBegin", {
   url: "https://example.com/file.txt",
@@ -598,6 +661,26 @@ const releaseTabs = await hostRequest(port, "getTabs", {
 });
 assert.deepEqual(releaseTabs.result.tabs, []);
 
+const removeCreated = await hostRequest(port, "createTab", {
+  session_id: "remove-session",
+  turn_id: "turn",
+  url: "https://remove.example/",
+});
+const removedTabId = removeCreated.result.tab.tabId;
+const removedReassertStart = calls.tabsSendMessage.length;
+tabs.delete(removedTabId);
+tabRemovedEvents.emit(removedTabId, { windowId: 1, isWindowClosing: false });
+const removedTabs = await hostRequest(port, "getTabs", {
+  session_id: "remove-session",
+  turn_id: "turn",
+});
+assert.deepEqual(removedTabs.result.tabs, []);
+assert.deepEqual(await runtimeMessage({ type: "OBU_CONTENT_READY" }, { tab: { id: removedTabId } }), { ok: true });
+assert.equal(calls.tabsSendMessage.slice(removedReassertStart).some((call) =>
+  call.tabId === removedTabId &&
+  call.message.type === "OBU_TAKEOVER_STATE"
+), false);
+
 const handoffCreated = await hostRequest(port, "createTab", {
   session_id: "keep-session",
   turn_id: "turn",
@@ -646,6 +729,13 @@ const deliverableCdp = await hostRequest(port, "executeCdp", {
   method: "Runtime.evaluate",
 });
 assert.match(deliverableCdp.error.message, /not owned by this open-browser-use session/);
+const handoffCdp = await hostRequest(port, "executeCdp", {
+  session_id: "keep-session",
+  turn_id: "turn",
+  target: { tabId: handoffTabId },
+  method: "Runtime.evaluate",
+});
+assert.match(handoffCdp.error.message, /not actively controlled/);
 assert.deepEqual(
   sessionStateTabs("keep-session").map((tab) => [tab.tabId, tab.status]),
   [
@@ -1010,18 +1100,17 @@ async function hostRequest(targetPort, method, params) {
 }
 
 async function popupMessage(message) {
-  assert.ok(runtimeMessages.listeners[0]);
-  return new Promise((resolve) => {
-    const keepAlive = runtimeMessages.listeners[0](message, {}, resolve);
-    assert.equal(keepAlive, true);
-  });
+  return await runtimeMessage(message);
 }
 
 async function popupMessageFromLatest(message) {
-  const listener = runtimeMessages.listeners.at(-1);
+  return await runtimeMessage(message, {}, runtimeMessages.listeners.at(-1));
+}
+
+async function runtimeMessage(message, sender = {}, listener = runtimeMessages.listeners[0]) {
   assert.ok(listener);
   return new Promise((resolve) => {
-    const keepAlive = listener(message, {}, resolve);
+    const keepAlive = listener(message, sender, resolve);
     assert.equal(keepAlive, true);
   });
 }

--- a/packages/extension/scripts/test-cursor.mjs
+++ b/packages/extension/scripts/test-cursor.mjs
@@ -7,6 +7,7 @@ const packageRoot = path.dirname(fileURLToPath(new URL("../package.json", import
 const builtCursor = await readFile(path.join(packageRoot, "dist", "cursor.js"), "utf8");
 assert.doesNotMatch(builtCursor, /\bexport\s*\{\s*\}/);
 assert.match(builtCursor, /(?:^|\n)\(\(\) => \{/);
+assert.doesNotMatch(builtCursor, /__OBU_CURSOR_MESSAGE__/);
 
 class EventTarget {
   listeners = [];
@@ -32,6 +33,7 @@ class EventTarget {
   }
 
   emitDom(type, event) {
+    if (event && typeof event === "object" && event.type === undefined) event.type = type;
     for (const row of this.listeners) {
       if (row.type === type) row.listener(event);
     }
@@ -117,6 +119,7 @@ globalThis.chrome = {
 
 await import(`${pathToFileURL(path.join(packageRoot, "dist", "cursor.js")).href}?test=${Date.now()}`);
 
+await waitFor(() => sentRuntimeMessages.some((message) => message.type === "OBU_CONTENT_READY" && message.topFrame === true));
 assert.equal(runtimeMessages.emit({ type: "IGNORED" }).length, 0);
 assert.deepEqual(runtimeMessages.emit({ type: "OBU_CONTENT_PING" }), [{ ok: true }]);
 
@@ -137,7 +140,8 @@ const overlay = host.shadowChildren[1];
 assert.equal(overlay.style.opacity, "1");
 assert.match(overlay.style.background, /radial-gradient/);
 assert.match(overlay.style.background, /linear-gradient/);
-assert.match(overlay.style.backdropFilter, /blur\(1\.35px\)/);
+assert.equal(overlay.style.backdropFilter, undefined);
+assert.equal(overlay.style.webkitBackdropFilter, undefined);
 assert.equal(overlay.style.pointerEvents, "none");
 assert.equal(overlay.style.animation, "none");
 
@@ -146,17 +150,58 @@ documentEvents.emitDom("click", blocked);
 assert.equal(blocked.defaultPrevented, true);
 assert.equal(blocked.stopped, true);
 
-responses = runtimeMessages.emit({ type: "OBU_INPUT_BYPASS", durationMs: 100, sessionId: "session", turnId: "turn" });
+windowEvents.emitDom("__OBU_CURSOR_MESSAGE__", { detail: { type: "OBU_CURSOR_HIDE" } });
+assert.equal(documentElement.children.length, 1);
+const blockedAfterForgedHide = fakeDomEvent();
+documentEvents.emitDom("click", blockedAfterForgedHide);
+assert.equal(blockedAfterForgedHide.defaultPrevented, true);
+assert.equal(blockedAfterForgedHide.stopped, true);
+
+windowEvents.emitDom("__OBU_CURSOR_MESSAGE__", {
+  detail: { type: "OBU_INPUT_BYPASS", durationMs: 100, eventFamilies: ["pointer"] },
+});
+const blockedAfterForgedBypass = fakeDomEvent();
+documentEvents.emitDom("click", blockedAfterForgedBypass);
+assert.equal(blockedAfterForgedBypass.defaultPrevented, true);
+assert.equal(blockedAfterForgedBypass.stopped, true);
+
+responses = runtimeMessages.emit({
+  type: "OBU_INPUT_BYPASS",
+  durationMs: 100,
+  eventFamilies: ["pointer"],
+  sessionId: "session",
+  turnId: "turn",
+});
 assert.deepEqual(responses, [{ ok: true }]);
 const bypassed = fakeDomEvent();
 documentEvents.emitDom("click", bypassed);
 assert.equal(bypassed.defaultPrevented, false);
 assert.equal(bypassed.stopped, false);
+const keyboardDuringPointerBypass = fakeDomEvent();
+documentEvents.emitDom("keydown", keyboardDuringPointerBypass);
+assert.equal(keyboardDuringPointerBypass.defaultPrevented, true);
+assert.equal(keyboardDuringPointerBypass.stopped, true);
 await new Promise((resolve) => setTimeout(resolve, 120));
 const blockedAfterBypass = fakeDomEvent();
 documentEvents.emitDom("click", blockedAfterBypass);
 assert.equal(blockedAfterBypass.defaultPrevented, true);
 assert.equal(blockedAfterBypass.stopped, true);
+responses = runtimeMessages.emit({
+  type: "OBU_INPUT_BYPASS",
+  durationMs: 100,
+  eventFamilies: ["keyboard"],
+  sessionId: "session",
+  turnId: "turn",
+});
+assert.deepEqual(responses, [{ ok: true }]);
+const pointerDuringKeyboardBypass = fakeDomEvent();
+documentEvents.emitDom("click", pointerDuringKeyboardBypass);
+assert.equal(pointerDuringKeyboardBypass.defaultPrevented, true);
+assert.equal(pointerDuringKeyboardBypass.stopped, true);
+const keyboardBypassed = fakeDomEvent();
+documentEvents.emitDom("keydown", keyboardBypassed);
+assert.equal(keyboardBypassed.defaultPrevented, false);
+assert.equal(keyboardBypassed.stopped, false);
 
 responses = runtimeMessages.emit({ type: "OBU_CURSOR_MOVE", x: 10.2, y: 20.8, sequence: 1, sessionId: "session", turnId: "turn" });
 assert.deepEqual(responses, [{ ok: true, sequence: 1 }]);

--- a/packages/extension/scripts/test-takeover-browser.mjs
+++ b/packages/extension/scripts/test-takeover-browser.mjs
@@ -297,9 +297,12 @@ new Promise((resolve, reject) => {
     }
     chrome.scripting.executeScript({
       target: { tabId: tab.id, allFrames: true },
-      args: ["__OBU_CURSOR_MESSAGE__", ${JSON.stringify(message)}],
-      func: (eventName, payload) => {
-        globalThis.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
+      world: "ISOLATED",
+      args: ["__OBU_CURSOR_CONTENT_SCRIPT_HANDLE_MESSAGE__", ${JSON.stringify(message)}],
+      func: (handlerName, payload) => {
+        const handler = globalThis[handlerName];
+        if (typeof handler !== "function") throw new Error("open-browser-use cursor handler not installed");
+        handler(payload);
       },
     }).then(() => resolve({ ok: true }), reject);
   });

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -13,8 +13,7 @@ const RECONNECT_MAX_MS = 30_000;
 const RECONNECT_ALARM_NAME = "obu.reconnectNativeHost";
 const CURSOR_ARRIVAL_TIMEOUT_MS = 750;
 const CONTENT_PING_TIMEOUT_MS = 1_000;
-const TAKEOVER_IDLE_TIMEOUT_MS = 2_000;
-const CONTENT_SCRIPT_EVENT = "__OBU_CURSOR_MESSAGE__";
+const CONTENT_SCRIPT_HANDLER = "__OBU_CURSOR_CONTENT_SCRIPT_HANDLE_MESSAGE__";
 
 type HostStatus = {
   state: "disconnected" | "connecting" | "connected" | "version_mismatch" | "stopped" | "error";
@@ -90,19 +89,43 @@ let reconnectDelayMs = RECONNECT_INITIAL_MS;
 class OverlayCoordinator {
   private nextCursorSequence = 1;
   private cursorArrivalWaiters = new Map<number, CursorArrivalWaiter>();
-  private takeoverIdleTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  private activeTakeovers = new Map<number, ActiveTakeover>();
   private contentScriptPreparations = new Map<number, Promise<boolean>>();
 
   async activate(tabId: number, sessionParams: SessionParams): Promise<void> {
-    const sent = await this.sendContentMessage(tabId, {
-      type: "OBU_TAKEOVER_STATE",
-      active: true,
-      lockInputs: true,
+    const state: ActiveTakeover = {
       sessionId: sessionParams.session_id,
       turnId: sessionParams.turn_id,
+      lockInputs: true,
+    };
+    this.activeTakeovers.set(tabId, state);
+    await this.sendTakeoverState(tabId, state);
+  }
+
+  async reassert(tabId: number): Promise<void> {
+    const state = this.activeTakeovers.get(tabId);
+    if (!state) return;
+    await this.sendTakeoverState(tabId, state);
+  }
+
+  forget(tabId: number): void {
+    this.activeTakeovers.delete(tabId);
+    this.rejectWaitersForTab(tabId);
+  }
+
+  activeTabIds(): number[] {
+    return [...this.activeTakeovers.keys()];
+  }
+
+  private async sendTakeoverState(tabId: number, state: ActiveTakeover): Promise<boolean> {
+    return await this.sendContentMessage(tabId, {
+      type: "OBU_TAKEOVER_STATE",
+      active: true,
+      lockInputs: state.lockInputs,
+      sessionId: state.sessionId,
+      turnId: state.turnId,
       reason: "browser-control",
     });
-    if (sent) this.scheduleIdle(tabId);
   }
 
   async moveMouse(tabId: number, sessionParams: SessionParams, x: number, y: number): Promise<unknown> {
@@ -129,7 +152,7 @@ class OverlayCoordinator {
   }
 
   async sendCursorEvent(tabId: number, sessionParams: SessionParams, event: CursorVisualEvent): Promise<void> {
-    const sent = await this.sendContentMessage(tabId, {
+    await this.sendContentMessage(tabId, {
       type: "OBU_CURSOR_EVENT",
       kind: event.kind,
       x: event.x,
@@ -138,13 +161,13 @@ class OverlayCoordinator {
       sessionId: sessionParams.session_id,
       turnId: sessionParams.turn_id,
     });
-    if (sent) this.scheduleIdle(tabId);
   }
 
   async allowCdpInput(tabId: number, sessionParams: SessionParams, bypass: CdpInputBypass): Promise<void> {
     await this.sendContentMessage(tabId, {
       type: "OBU_INPUT_BYPASS",
       durationMs: bypass.durationMs,
+      eventFamilies: bypass.eventFamilies,
       sessionId: sessionParams.session_id,
       turnId: sessionParams.turn_id,
       reason: bypass.reason,
@@ -163,7 +186,7 @@ class OverlayCoordinator {
   }
 
   async hide(tabId: number): Promise<void> {
-    this.clearIdle(tabId);
+    this.activeTakeovers.delete(tabId);
     this.rejectWaitersForTab(tabId);
     await this.sendContentMessage(tabId, { type: "OBU_CURSOR_HIDE" }, { prepare: false });
   }
@@ -171,14 +194,18 @@ class OverlayCoordinator {
   private async sendContentMessage(tabId: number, message: unknown, options: { prepare?: boolean } = {}): Promise<boolean> {
     if (options.prepare !== false && !await this.prepareContentScript(tabId)) return false;
     try {
-      await chrome.scripting.executeScript({
+      const results = await chrome.scripting.executeScript({
         target: { tabId, allFrames: true },
-        args: [CONTENT_SCRIPT_EVENT, message],
-        func: (eventName: string, payload: unknown) => {
-          globalThis.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
+        world: "ISOLATED",
+        args: [CONTENT_SCRIPT_HANDLER, message],
+        func: (handlerName: string, payload: unknown) => {
+          const handler = (globalThis as Record<string, unknown>)[handlerName];
+          if (typeof handler !== "function") return false;
+          handler(payload);
+          return true;
         },
       });
-      return true;
+      return results.some((result) => result.result === true);
     } catch {
       return false;
     }
@@ -213,6 +240,7 @@ class OverlayCoordinator {
       await chrome.scripting.executeScript({
         files: ["cursor.js"],
         injectImmediately: true,
+        world: "ISOLATED",
         target: { tabId, allFrames: true },
       });
     } catch {
@@ -261,20 +289,6 @@ class OverlayCoordinator {
     waiter.resolve(value);
   }
 
-  private scheduleIdle(tabId: number): void {
-    this.clearIdle(tabId);
-    this.takeoverIdleTimers.set(tabId, scheduleTimer(() => {
-      this.takeoverIdleTimers.delete(tabId);
-      void this.hide(tabId);
-    }, TAKEOVER_IDLE_TIMEOUT_MS));
-  }
-
-  private clearIdle(tabId: number): void {
-    const timer = this.takeoverIdleTimers.get(tabId);
-    if (timer !== undefined) clearTimeout(timer);
-    this.takeoverIdleTimers.delete(tabId);
-  }
-
   private rejectWaitersForTab(tabId: number): void {
     for (const [sequence, waiter] of this.cursorArrivalWaiters) {
       if (waiter.tabId !== tabId) continue;
@@ -297,7 +311,11 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   }
 });
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void handleTabRemoved(tabId);
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   void (async () => {
     if (isMessage(message, "GET_NATIVE_HOST_STATUS")) {
       sendResponse(await getStatus());
@@ -330,6 +348,12 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }
     if (isMessage(message, "OBU_CURSOR_ARRIVED")) {
       overlayCoordinator.handleCursorArrived(message);
+      sendResponse({ ok: true });
+      return;
+    }
+    if (isMessage(message, "OBU_CONTENT_READY")) {
+      const tabId = sender.tab?.id;
+      if (Number.isInteger(tabId)) await overlayCoordinator.reassert(tabId!);
       sendResponse({ ok: true });
       return;
     }
@@ -464,6 +488,7 @@ async function connectNative(): Promise<void> {
         ),
         updatedAt: Date.now(),
       });
+      void releaseActiveTakeoverForUnavailableHost(wasConnecting ? "native_host_crashed" : "native_host_disconnected");
       scheduleReconnect();
     }
   });
@@ -523,6 +548,7 @@ async function handleNativeMessage(message: unknown, sourcePort: NativePort): Pr
     appendDebugLog("error", "native.version_mismatch", {
       message: typeof message.message === "string" ? message.message : "Version mismatch",
     });
+    await releaseActiveTakeoverForUnavailableHost("version_mismatch");
     await setStatus({
       state: "version_mismatch",
       message: typeof message.message === "string" ? message.message : "Version mismatch",
@@ -679,6 +705,7 @@ async function createSessionTab(sessionParams: SessionParams, params: unknown): 
   session.currentTurnId = sessionParams.turn_id;
   session.tabs.set(tabId, { tabId, origin: "agent", status: "active" });
   await addTabToSessionGroup(session, tabId);
+  await overlayCoordinator.activate(tabId, sessionParams);
   appendDebugLog("info", "tab.created", { sessionId: sessionParams.session_id, tabId });
   return tab;
 }
@@ -731,6 +758,7 @@ async function claimUserTab(sessionParams: SessionParams, params: unknown): Prom
   removeFinalizedTabFromAllSessions(tabId);
   session.tabs.set(tabId, { tabId, origin: "user", status: "active" });
   await addTabToSessionGroup(session, tabId);
+  await overlayCoordinator.activate(tabId, sessionParams);
   await persistSessionState();
   appendDebugLog("info", "tab.claimed", { sessionId: sessionParams.session_id, tabId });
   return tab;
@@ -779,6 +807,9 @@ async function finalizeTabs(sessionParams: SessionParams, params: unknown): Prom
         keptTabs.push(dto);
         deliverableTabs.push(dto);
       } else {
+        if (keepStatus === "handoff") {
+          await cleanupControlledTab(session, tabId);
+        }
         keptTabs.push(toTabDto(await chrome.tabs.get(tabId), row));
       }
     } catch {
@@ -813,7 +844,6 @@ async function nameSession(sessionParams: SessionParams, params: unknown): Promi
 async function markTurnEnded(sessionParams: SessionParams): Promise<void> {
   const session = sessionFor(sessionParams.session_id);
   session.currentTurnId = sessionParams.turn_id;
-  await hideSessionTakeover(session);
 }
 
 async function getUserHistory(params: unknown): Promise<HistoryItemDto[]> {
@@ -882,13 +912,18 @@ async function moveMouse(params: unknown): Promise<unknown> {
 
 function inputBypassFromCdp(params: Record<string, unknown>): CdpInputBypass | undefined {
   if (params.method === "Input.dispatchMouseEvent") {
-    return { durationMs: 600, reason: "cdp-mouse" };
+    const type = isRecord(params.commandParams) ? params.commandParams.type : undefined;
+    const eventFamilies: InputBypassEventFamily[] = type === "mouseWheel" ? ["wheel"] : ["pointer"];
+    return { durationMs: 600, reason: "cdp-mouse", eventFamilies };
   }
   if (params.method === "Input.dispatchTouchEvent") {
-    return { durationMs: 600, reason: "cdp-touch" };
+    return { durationMs: 600, reason: "cdp-touch", eventFamilies: ["touch"] };
   }
-  if (params.method === "Input.dispatchKeyEvent" || params.method === "Input.insertText") {
-    return { durationMs: 600, reason: "cdp-keyboard" };
+  if (params.method === "Input.dispatchKeyEvent") {
+    return { durationMs: 600, reason: "cdp-keyboard", eventFamilies: ["keyboard", "text"] };
+  }
+  if (params.method === "Input.insertText") {
+    return { durationMs: 600, reason: "cdp-text", eventFamilies: ["text"] };
   }
   return undefined;
 }
@@ -977,6 +1012,7 @@ function requireSessionTab(params: unknown): SessionTab {
   const session = requireSession(params);
   const row = session.tabs.get(tabId);
   if (!row) throw new Error(`tab ${tabId} is not owned by this open-browser-use session`);
+  if (row.status !== "active") throw new Error(`tab ${tabId} is ${row.status}, not actively controlled`);
   return row;
 }
 
@@ -1104,6 +1140,25 @@ function findSessionForTab(tabId: number): { sessionId: string; session: Browser
   return undefined;
 }
 
+async function handleTabRemoved(tabId: number): Promise<void> {
+  overlayCoordinator.forget(tabId);
+  let changed = false;
+  for (const session of sessions.values()) {
+    if (session.tabs.delete(tabId)) changed = true;
+    if (session.finalizedTabs.delete(tabId)) changed = true;
+    if (session.attachedTabIds.delete(tabId)) changed = true;
+    if (session.tabs.size === 0) session.groupId = undefined;
+  }
+  for (const [url, owner] of downloadOwnersByUrl) {
+    if (owner.tabId === tabId) downloadOwnersByUrl.delete(url);
+  }
+  for (const [id, owner] of downloadOwnersById) {
+    if (owner.tabId === tabId) downloadOwnersById.delete(id);
+  }
+  if (changed) await persistSessionState();
+  appendDebugLog("info", "tab.removed", { tabId });
+}
+
 function parseFinalizeKeep(params: unknown): Map<number, SessionTab["status"]> {
   const rows = isRecord(params) && Array.isArray(params.keep) ? params.keep : [];
   const keep = new Map<number, SessionTab["status"]>();
@@ -1122,6 +1177,7 @@ function parseFinalizeKeep(params: unknown): Map<number, SessionTab["status"]> {
 
 async function stopActiveBrowserControl(): Promise<void> {
   const controlledTabIds = new Set<number>();
+  for (const tabId of overlayCoordinator.activeTabIds()) controlledTabIds.add(tabId);
   for (const session of sessions.values()) {
     for (const tabId of session.tabs.keys()) controlledTabIds.add(tabId);
     for (const tabId of session.attachedTabIds) controlledTabIds.add(tabId);
@@ -1144,6 +1200,19 @@ async function stopActiveBrowserControl(): Promise<void> {
 
 async function hideCursor(tabId: number): Promise<void> {
   await overlayCoordinator.hide(tabId);
+}
+
+async function releaseActiveTakeoverForUnavailableHost(reason: string): Promise<void> {
+  appendDebugLog("warn", "takeover.release.unavailable_host", { reason });
+  const controlledTabIds = new Set<number>();
+  for (const tabId of overlayCoordinator.activeTabIds()) controlledTabIds.add(tabId);
+  for (const session of sessions.values()) {
+    for (const tabId of session.tabs.keys()) controlledTabIds.add(tabId);
+    for (const tabId of session.attachedTabIds) controlledTabIds.add(tabId);
+  }
+  for (const tabId of controlledTabIds) {
+    await hideCursor(tabId);
+  }
 }
 
 function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
@@ -1187,6 +1256,7 @@ async function bootstrapBackground(): Promise<void> {
   await restoreDebugLogs();
   appendDebugLog("info", "background.bootstrap");
   await restoreSessionState();
+  await releaseOrphanedTakeoverStateOnBootstrap();
   await bootstrapNativeConnection();
 }
 
@@ -1257,6 +1327,19 @@ async function restoreSessionState(): Promise<void> {
     }
   }
   if (changed) await persistSessionState();
+}
+
+async function releaseOrphanedTakeoverStateOnBootstrap(): Promise<void> {
+  let tabs: ChromeTab[];
+  try {
+    tabs = await chrome.tabs.query({});
+  } catch {
+    return;
+  }
+  for (const tab of tabs) {
+    if (!Number.isInteger(tab.id)) continue;
+    await overlayCoordinator.hide(tab.id!);
+  }
 }
 
 async function persistSessionState(): Promise<void> {
@@ -1409,6 +1492,7 @@ function scheduleHeartbeat(): void {
         port = null;
         failedPort?.disconnect();
         rejectPending(message);
+        void releaseActiveTakeoverForUnavailableHost("native_host_heartbeat_timeout");
         void setStatus({
           state: "disconnected",
           message,
@@ -1644,6 +1728,15 @@ type CursorVisualEvent = {
 type CdpInputBypass = {
   durationMs: number;
   reason: string;
+  eventFamilies: InputBypassEventFamily[];
+};
+
+type InputBypassEventFamily = "pointer" | "wheel" | "touch" | "keyboard" | "text";
+
+type ActiveTakeover = {
+  sessionId: string;
+  turnId: string;
+  lockInputs: boolean;
 };
 
 type BrowserSession = {

--- a/packages/extension/src/chrome.d.ts
+++ b/packages/extension/src/chrome.d.ts
@@ -50,6 +50,9 @@ declare const chrome: {
     group(options: { tabIds: number | number[]; groupId?: number }): Promise<number>;
     ungroup(tabIds: number | number[]): Promise<void>;
     sendMessage(tabId: number, message: unknown): Promise<unknown>;
+    onRemoved: {
+      addListener(listener: (tabId: number, removeInfo?: { windowId?: number; isWindowClosing?: boolean }) => void): void;
+    };
   };
   windows: {
     get(windowId: number): Promise<ChromeWindow>;
@@ -61,8 +64,9 @@ declare const chrome: {
       func?: (...args: any[]) => unknown;
       args?: unknown[];
       injectImmediately?: boolean;
+      world?: "ISOLATED" | "MAIN";
       target: { tabId: number; frameIds?: number[]; allFrames?: boolean };
-    }): Promise<unknown>;
+    }): Promise<Array<{ frameId?: number; result?: unknown }>>;
   };
   tabGroups: {
     update(groupId: number, updateProperties: { title?: string; color?: string }): Promise<unknown>;

--- a/packages/extension/src/cursor.ts
+++ b/packages/extension/src/cursor.ts
@@ -39,6 +39,7 @@ type ContentPingMessage = {
 type InputBypassMessage = {
   type: "OBU_INPUT_BYPASS";
   durationMs?: number;
+  eventFamilies?: InputBypassEventFamily[];
   sessionId?: string;
   turnId?: string;
   reason?: string;
@@ -53,6 +54,7 @@ type CursorMessage =
   | InputBypassMessage;
 
 type Point = { x: number; y: number };
+type InputBypassEventFamily = "pointer" | "wheel" | "touch" | "keyboard" | "text";
 
 const SHORT_MOVE_THRESHOLD = 196;
 const RESTING_ROTATION_DEG = -44;
@@ -62,7 +64,6 @@ const INPUT_BYPASS_MAX_MS = 1_000;
 const CURSOR_SIZE_PX = 42;
 const CURSOR_TIP_ORIGIN_PX = 4;
 const CLICK_PULSE_SIZE_PX = 36;
-const TAKEOVER_OVERLAY_BLUR = "blur(1.35px) saturate(1.06)";
 const TAKEOVER_OVERLAY_BACKGROUND = [
   "radial-gradient(circle at 18% 24%, rgba(125, 211, 252, 0.34) 0 1px, transparent 1.9px)",
   "radial-gradient(circle at 76% 18%, rgba(191, 219, 254, 0.24) 0 1.15px, transparent 2.3px)",
@@ -74,7 +75,7 @@ const TAKEOVER_OVERLAY_BACKGROUND_SIZE = "170px 170px, 230px 230px, 290px 290px,
 const TAKEOVER_OVERLAY_BACKGROUND_POSITION = "0 0, 44px 28px, 16px 78px, 92px 18px, 0 0";
 const REDUCED_MOTION = matchMediaSafe("(prefers-reduced-motion: reduce)");
 const INSTALL_KEY = "__OBU_CURSOR_CONTENT_SCRIPT_INSTALLED__";
-const SCRIPT_EVENT = "__OBU_CURSOR_MESSAGE__";
+const HANDLER_KEY = "__OBU_CURSOR_CONTENT_SCRIPT_HANDLE_MESSAGE__";
 const TOP_FRAME = isTopFrame();
 const LOCK_EVENTS = [
   "pointerdown",
@@ -116,20 +117,23 @@ let animationTurnId: string | undefined;
 let animationFrom: Point = { x: 24, y: 24 };
 let animationTo: Point = { x: 24, y: 24 };
 let animationControl: Point | undefined;
-let thinkingFrame: number | undefined;
-let thinkingStartedAt = 0;
 let arrivalTimer: ReturnType<typeof setTimeout> | undefined;
-let inputBypassUntil = 0;
+const inputBypassUntilByFamily = new Map<InputBypassEventFamily, number>();
 
 const installState = globalThis as typeof globalThis & Record<string, unknown>;
+Object.defineProperty(installState, HANDLER_KEY, {
+  value: (message: unknown) => handleCursorMessage(message),
+  configurable: true,
+  enumerable: false,
+  writable: false,
+});
+
 if (!installState[INSTALL_KEY]) {
   installState[INSTALL_KEY] = true;
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     handleCursorMessage(message, sendResponse);
   });
-  windowTarget()?.addEventListener(SCRIPT_EVENT, (event) => {
-    handleCursorMessage((event as CustomEvent).detail);
-  });
+  void chrome.runtime.sendMessage({ type: "OBU_CONTENT_READY", topFrame: TOP_FRAME }).catch(() => undefined);
 }
 
 function handleCursorMessage(message: unknown, sendResponse?: (response?: unknown) => void): void {
@@ -187,14 +191,12 @@ function moveCursor(message: CursorMoveMessage): void {
   animationSequence = message.sequence;
   animationSessionId = message.sessionId ?? lastSessionId;
   animationTurnId = message.turnId ?? lastTurnId;
-  stopThinking();
   clearArrivalTimer();
 
   if (REDUCED_MOTION) {
     currentPoint = targetPoint;
     renderCursor(currentPoint, RESTING_ROTATION_DEG, 1, 1);
     notifyArrived();
-    startThinking();
     return;
   }
 
@@ -210,7 +212,6 @@ function moveCursor(message: CursorMoveMessage): void {
     currentPoint = { ...targetPoint };
     renderCursor(currentPoint, RESTING_ROTATION_DEG, 1, 1);
     notifyArrived();
-    startThinking();
   }, ARRIVAL_TIMEOUT_MS);
 }
 
@@ -238,7 +239,6 @@ function tickMove(now: number): void {
   renderCursor(currentPoint, RESTING_ROTATION_DEG, 1, 1);
   clearArrivalTimer();
   notifyArrived();
-  startThinking();
 }
 
 function handleCursorEvent(message: CursorEventMessage): void {
@@ -262,13 +262,11 @@ function handleCursorEvent(message: CursorEventMessage): void {
 
 function hideCursor(): void {
   if (animationFrame !== undefined) cancelFrame(animationFrame);
-  if (thinkingFrame !== undefined) cancelFrame(thinkingFrame);
   clearArrivalTimer();
   animationFrame = undefined;
-  thinkingFrame = undefined;
   activeTakeover = false;
   lockInputs = false;
-  inputBypassUntil = 0;
+  inputBypassUntilByFamily.clear();
   updateInputLock();
   host?.remove();
   host = null;
@@ -303,8 +301,6 @@ function ensureCursor(): void {
   overlay.style.backgroundSize = TAKEOVER_OVERLAY_BACKGROUND_SIZE;
   overlay.style.backgroundPosition = TAKEOVER_OVERLAY_BACKGROUND_POSITION;
   overlay.style.backgroundBlendMode = "screen, screen, screen, screen, normal";
-  overlay.style.backdropFilter = TAKEOVER_OVERLAY_BLUR;
-  (overlay.style as CSSStyleDeclaration & { webkitBackdropFilter?: string }).webkitBackdropFilter = TAKEOVER_OVERLAY_BLUR;
   overlay.style.boxShadow = "inset 0 0 0 1px rgba(125, 211, 252, 0.16), inset 0 0 48px rgba(37, 99, 235, 0.18)";
   overlay.style.transition = "opacity 160ms ease-out";
   overlay.style.pointerEvents = "none";
@@ -383,7 +379,7 @@ function updateInputLock(): void {
 
 function blockHumanInput(event: Event): void {
   if (!lockInputs) return;
-  if (isInputBypassActive()) return;
+  if (isInputBypassActive(event)) return;
   event.preventDefault();
   event.stopImmediatePropagation();
 }
@@ -392,11 +388,43 @@ function allowInputBypass(message: InputBypassMessage): void {
   lastSessionId = message.sessionId ?? lastSessionId;
   lastTurnId = message.turnId ?? lastTurnId;
   const durationMs = clampNumber(message.durationMs, INPUT_BYPASS_DEFAULT_MS, 1, INPUT_BYPASS_MAX_MS);
-  inputBypassUntil = Math.max(inputBypassUntil, nowMs() + durationMs);
+  const until = nowMs() + durationMs;
+  for (const family of inputBypassFamilies(message.eventFamilies)) {
+    inputBypassUntilByFamily.set(family, Math.max(inputBypassUntilByFamily.get(family) ?? 0, until));
+  }
 }
 
-function isInputBypassActive(): boolean {
-  return nowMs() <= inputBypassUntil;
+function isInputBypassActive(event: Event): boolean {
+  const family = inputFamilyForEvent(event.type);
+  if (!family) return false;
+  return nowMs() <= (inputBypassUntilByFamily.get(family) ?? 0);
+}
+
+function inputBypassFamilies(value: unknown): InputBypassEventFamily[] {
+  if (!Array.isArray(value)) return ["pointer", "wheel", "touch", "keyboard", "text"];
+  const families = value.filter(isInputBypassEventFamily);
+  return families.length > 0 ? families : ["pointer", "wheel", "touch", "keyboard", "text"];
+}
+
+function isInputBypassEventFamily(value: unknown): value is InputBypassEventFamily {
+  return value === "pointer" || value === "wheel" || value === "touch" || value === "keyboard" || value === "text";
+}
+
+function inputFamilyForEvent(type: string): InputBypassEventFamily | undefined {
+  if (type === "wheel") return "wheel";
+  if (type.startsWith("touch")) return "touch";
+  if (type.startsWith("key")) return "keyboard";
+  if (type === "beforeinput") return "text";
+  if (
+    type.startsWith("pointer") ||
+    type.startsWith("mouse") ||
+    type === "click" ||
+    type === "dblclick" ||
+    type === "contextmenu"
+  ) {
+    return "pointer";
+  }
+  return undefined;
 }
 
 function renderCursor(point: Point, rotation: number, scaleX: number, scaleY: number): void {
@@ -427,30 +455,6 @@ function addPulse(point: Point): void {
     pulse.style.opacity = "0";
   });
   setTimeout(() => pulse.remove(), 340);
-}
-
-function startThinking(): void {
-  stopThinking();
-  thinkingStartedAt = nowMs();
-  thinkingFrame = requestFrame(tickThinking);
-}
-
-function stopThinking(): void {
-  if (thinkingFrame !== undefined) cancelFrame(thinkingFrame);
-  thinkingFrame = undefined;
-}
-
-function tickThinking(now: number): void {
-  const t = (now - thinkingStartedAt) / 1000;
-  if (t > 1.41) {
-    thinkingFrame = undefined;
-    renderCursor(currentPoint, RESTING_ROTATION_DEG, 1, 1);
-    return;
-  }
-  const envelope = Math.sin((t / 1.41) * Math.PI);
-  const carrier = Math.sin((t / 0.66) * Math.PI * 2);
-  renderCursor(currentPoint, RESTING_ROTATION_DEG + 8.5 * envelope * carrier, 1, 1);
-  thinkingFrame = requestFrame(tickThinking);
 }
 
 function notifyArrived(): void {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -15,8 +15,10 @@ through `import.meta.__obuNativePipe` on the trusted module. It does not read
 const browser = await agent.browsers.get("chrome");
 const tab = await browser.tabs.create("https://example.com");
 await tab.attach();
+await tab.goto("https://example.com/docs");
 await tab.locator("h1").click();
 await tab.screenshotForModel({ clip: { x: 0, y: 0, width: 900, height: 700, scale: 0.5 } });
+await browser.turnEnded();
 ```
 
 Backend discovery is lazy. `setupObuRuntime()` installs `agent` without opening
@@ -61,6 +63,19 @@ Call `agent.help()` for the live API table. Main layers:
 
 `browser.tabs.create()` accepts either a URL string or `{ url }`. With no URL it
 creates `about:blank`, not Chrome's extension-restricted new-tab page.
+Keep a `Tab` handle and use `tab.goto(url)` for repeated same-task navigation.
+`browser.turnEnded()` marks a turn boundary while preserving active control;
+`browser.finishTurn(...)` first finalizes tabs and is for close/release/handoff
+or deliverable workflows.
+One session can keep multiple `Tab` handles and move data between them:
+
+```js
+const source = await browser.tabs.create("https://example.com/source");
+const target = await browser.tabs.create("https://example.com/target");
+const text = await source.getByRole("main").innerText();
+await target.getByLabel("Notes").fill(text);
+```
+
 `tab.screenshot()` accepts the Playwright-shaped subset `{ type, quality, clip,
 fullPage }`. Prefer `tab.screenshotForModel()` for agent observations; it
 defaults to compressed JPEG and emits an MCP image resource when the kernel

--- a/packages/sdk/src/help.ts
+++ b/packages/sdk/src/help.ts
@@ -11,8 +11,11 @@ Browser:
   .tabs.create(urlOrOptions?) -> Tab   accepts "https://..." or {url}; defaults to "about:blank"
   .tabs.list() -> Tab[]
   .tabs.get(id) -> Tab
+  keep multiple Tab handles when a workflow needs more than one tab
   .user.openTabs() / .user.history() / .user.claimTab()
-  .name(label) / .turnEnded() / .finalizeTabs({keep?}) / .finalize() / .finishTurn({keep?}) / .clearLifecycleDiagnostics()
+  .name(label) / .turnEnded() to keep active tabs controlled
+  .finalizeTabs({keep?}) / .finalize() / .finishTurn({keep?}) to release/finalize tabs
+  .clearLifecycleDiagnostics()
 
 Tab:
   .goto(url) / .back() / .forward() / .reload() / .waitForURL() / .waitForLoadState() / .waitForNavigation()


### PR DESCRIPTION
## Summary

- Make takeover overlay ownership persistent across action boundaries and `turnEnded()` while preserving the final cursor position.
- Reassert takeover from content-script readiness, clean active takeover state on tab removal and host-loss paths, and keep explicit finalization/release paths as cleanup.
- Replace the page-forgeable DOM event bridge with an isolated-world content-script handler.
- Update agent-facing guidance to prefer `tab.goto(...)`, `browser.turnEnded()`, and multiple `Tab` handles.

## Validation

- `pnpm -C packages/extension test`
- `pnpm -C packages/sdk test`
- `cargo test -p obu-node-repl js_tool_description`
- `cargo test -p obu-host webext`
- `git diff --check`
- `pnpm -C packages/extension test:browser` skipped locally because no Chrome for Testing/Chromium was found

## Notes

`.gitignore` is intentionally left out of this PR.