### PR TITLE
[codex] clarify Store repair and setup probe guidance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "obu-host"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "obu-node-repl"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "obu-wire"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/obu-node-repl/resources/js_tool_description.md
+++ b/crates/obu-node-repl/resources/js_tool_description.md
@@ -21,9 +21,11 @@ Keep the returned `Tab` handle and use `await tab.goto(url)` for repeated
 same-task or same-site navigation instead of creating a new tab for every URL.
 One browser session can hold multiple `Tab` handles; keep them in variables and
 move data explicitly between tabs.
-Use `browser.finishTurn({ keep: [] })` when the task is complete and no page
-needs to be preserved. Use `browser.turnEnded()` only when a turn is done but
-active tabs should intentionally remain controlled for later work.
+For setup verification, browser readiness probes, and repeated work in the same
+browser session, use `browser.turnEnded()` so active tabs remain controlled.
+Use `browser.finishTurn({ keep: [] })` only when cleanup is intentional; it
+first finalizes tabs, which closes agent-created tabs or releases user-claimed
+tabs before ending the turn.
 The WebExtension backend cannot drive `file://` pages. Serve local files over
 HTTP, for example `python3 -m http.server`, and navigate to
 `http://127.0.0.1:...`.
@@ -100,7 +102,7 @@ await tab.attach();
 await tab.goto("https://example.com/docs");
 await tab.locator("h1").click();
 await tab.screenshotForModel({ clip: { x: 0, y: 0, width: 900, height: 700, scale: 0.5 } });
-await browser.finishTurn({ keep: [] });
+await browser.turnEnded();
 ```
 
 ```js
@@ -108,7 +110,7 @@ const browser = await agent.browsers.get("chrome");
 const tab = await browser.tabs.create("data:text/html,<button>Save</button>");
 await tab.attach();
 await tab.getByRole("button", { name: "Save" }).click();
-await browser.finishTurn({ keep: [] });
+await browser.turnEnded();
 ```
 
 ```js
@@ -119,7 +121,7 @@ await source.attach();
 await target.attach();
 const text = await source.getByRole("main").innerText();
 await target.getByLabel("Notes").fill(text);
-await browser.finishTurn({ keep: [] });
+await browser.turnEnded();
 ```
 
 ```js

--- a/crates/obu-node-repl/src/repl_manager/mod.rs
+++ b/crates/obu-node-repl/src/repl_manager/mod.rs
@@ -223,7 +223,7 @@ impl JsRuntimeManager {
         self.sync_backend_inventory_to_kernel(&inventory).await?;
         let (sdk_bootstrap, sdk_bootstrap_detail) = self.sdk_bootstrap_status();
         let doctor_hint = if inventory.backends.is_empty() {
-            "obu doctor browser --repair"
+            "No browser backend discovered. Run `obu doctor browser --repair` with the exact extension channel/id from the popup handoff, then open the extension popup and click Resume if no runtime descriptor is active."
         } else {
             "obu doctor browser"
         };

--- a/crates/obu-node-repl/tests/discover_backends.rs
+++ b/crates/obu-node-repl/tests/discover_backends.rs
@@ -56,7 +56,12 @@ async fn browser_status_reports_missing_sdk_and_no_backend() {
 
     assert_eq!(status["sdk_bootstrap"], json!("missing"));
     assert_eq!(status["backends"], json!([]));
-    assert_eq!(status["doctor_hint"], json!("obu doctor browser --repair"));
+    assert!(
+        status["doctor_hint"]
+            .as_str()
+            .unwrap()
+            .contains("exact extension channel/id")
+    );
 }
 
 #[tokio::test]

--- a/crates/obu-node-repl/tests/mcp_stdio.rs
+++ b/crates/obu-node-repl/tests/mcp_stdio.rs
@@ -180,12 +180,13 @@ async fn mcp_stdio_lists_tools_and_executes_js() {
     assert_eq!(status["id"], 5);
     assert!(status["result"]["structuredContent"]["sdk_bootstrap"].is_string());
     assert!(status["result"]["structuredContent"]["backends"].is_array());
-    assert!(
-        status["result"]["structuredContent"]["doctor_hint"]
-            .as_str()
-            .unwrap()
-            .starts_with("obu doctor browser")
-    );
+    let structured = &status["result"]["structuredContent"];
+    let doctor_hint = structured["doctor_hint"].as_str().unwrap();
+    if structured["backends"].as_array().unwrap().is_empty() {
+        assert!(doctor_hint.contains("exact extension channel/id"));
+    } else {
+        assert_eq!(doctor_hint, "obu doctor browser");
+    }
 
     send(
         &mut stdin,

--- a/crates/obu-node-repl/tests/snapshots/description_snapshot__js_tool_description.snap
+++ b/crates/obu-node-repl/tests/snapshots/description_snapshot__js_tool_description.snap
@@ -25,9 +25,11 @@ Keep the returned `Tab` handle and use `await tab.goto(url)` for repeated
 same-task or same-site navigation instead of creating a new tab for every URL.
 One browser session can hold multiple `Tab` handles; keep them in variables and
 move data explicitly between tabs.
-Use `browser.finishTurn({ keep: [] })` when the task is complete and no page
-needs to be preserved. Use `browser.turnEnded()` only when a turn is done but
-active tabs should intentionally remain controlled for later work.
+For setup verification, browser readiness probes, and repeated work in the same
+browser session, use `browser.turnEnded()` so active tabs remain controlled.
+Use `browser.finishTurn({ keep: [] })` only when cleanup is intentional; it
+first finalizes tabs, which closes agent-created tabs or releases user-claimed
+tabs before ending the turn.
 The WebExtension backend cannot drive `file://` pages. Serve local files over
 HTTP, for example `python3 -m http.server`, and navigate to
 `http://127.0.0.1:...`.
@@ -104,7 +106,7 @@ await tab.attach();
 await tab.goto("https://example.com/docs");
 await tab.locator("h1").click();
 await tab.screenshotForModel({ clip: { x: 0, y: 0, width: 900, height: 700, scale: 0.5 } });
-await browser.finishTurn({ keep: [] });
+await browser.turnEnded();
 ```
 
 ```js
@@ -112,7 +114,7 @@ const browser = await agent.browsers.get("chrome");
 const tab = await browser.tabs.create("data:text/html,<button>Save</button>");
 await tab.attach();
 await tab.getByRole("button", { name: "Save" }).click();
-await browser.finishTurn({ keep: [] });
+await browser.turnEnded();
 ```
 
 ```js
@@ -123,7 +125,7 @@ await source.attach();
 await target.attach();
 const text = await source.getByRole("main").innerText();
 await target.getByLabel("Notes").fill(text);
-await browser.finishTurn({ keep: [] });
+await browser.turnEnded();
 ```
 
 ```js

--- a/docs/install.md
+++ b/docs/install.md
@@ -77,6 +77,18 @@ curl -fsSL https://github.com/open-browser-use/open-browser-use/releases/latest/
 ~/.obu/bin/obu bootstrap --yes --all --agents=auto
 ```
 
+**Fresh install is better for preview releases.** The current installer does
+not compare the already installed payload version with the latest GitHub
+Release before deciding what to do. If the local install may be stale, rerun the
+fresh install command above so the latest release asset is downloaded and the
+native host, extension payload, and agent wiring are refreshed together.
+
+The future update path should make that decision explicitly: compare the local
+`obu --version` / payload metadata with the latest release version, download and
+install only when the release is newer, and otherwise keep the existing local
+install and reconnect or repair it with `obu bootstrap`, `obu setup`, or
+`obu doctor`.
+
 For a Chrome Web Store-installed extension, use the Store channel so native-host
 manifests allow the Store extension id instead of the unpacked-dev id:
 
@@ -88,6 +100,24 @@ curl -fsSL https://github.com/open-browser-use/open-browser-use/releases/latest/
 Store-channel setup requires a release payload with `storeExtensionId` metadata,
 or an explicit `OBU_STORE_EXTENSION_ID` / `--extension-id` override while
 testing a draft item.
+Use the exact id copied from the extension popup. Do not substitute the
+unpacked-dev id or infer an id from another profile; Chrome native messaging
+requires the manifest `allowed_origins` entry to match the installed extension:
+`chrome-extension://<store-extension-id>/`.
+
+If the CLI and MCP server are installed but browser automation is still
+unavailable, check both layers:
+
+```bash
+~/.obu/bin/obu doctor browser --channel=store --extension-id=<store-extension-id>
+~/.obu/bin/obu doctor browser --repair --channel=store --extension-id=<store-extension-id>
+```
+
+After repair, open the open-browser-use extension popup and click **Resume** if
+the browser is not connected yet. Repair can update native-host manifests and
+runtime descriptor permissions, but Chrome publishes the active WebExtension
+runtime descriptor only after the extension connects to the native host. Rerun
+doctor with the same channel/id after opening the popup.
 
 Manual GitHub Release installs can still pin a specific asset and checksum:
 
@@ -155,9 +185,15 @@ For Chrome Web Store installs, do not run `obu update-extension`; Chrome Web
 Store owns extension updates. Use:
 
 ```bash
-obu doctor browser --channel=store
-obu doctor browser --repair --channel=store
+obu doctor browser --channel=store --extension-id=<store-extension-id>
+obu doctor browser --repair --channel=store --extension-id=<store-extension-id>
 ```
+
+If `browser_status` in an MCP client reports that the SDK is available but
+`backends` is empty, MCP is configured but the browser backend is not connected.
+Run the Store-channel doctor command with the exact extension id, repair if
+needed, then open the extension popup and click **Resume** so Chrome reconnects
+the native host.
 
 ## Agent Configuration
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,6 +50,40 @@ obu doctor
 
 Then retry the MCP client.
 
+## MCP Server Ready But No Browser Backend
+
+MCP availability and browser availability are separate. An agent can have the
+`open-browser-use` MCP server configured and still see `browser_status` return
+an available SDK with `backends: []`. That means the MCP server can start, but
+no live browser backend descriptor is available yet.
+
+For a Store-channel extension, repair with the exact extension id copied from
+the extension popup:
+
+```bash
+obu doctor browser --repair --channel=store --extension-id=<STORE_EXTENSION_ID>
+```
+
+Do not infer this id from the unpacked extension manifest or another Chrome
+profile. The Chrome native messaging manifest must include the matching
+`allowed_origins` entry:
+
+```json
+["chrome-extension://<STORE_EXTENSION_ID>/"]
+```
+
+After repair, open the open-browser-use extension popup and click **Resume** if
+the popup is not connected. Static repair can make the native-host manifest and
+runtime descriptor directory valid, but the active WebExtension runtime
+descriptor is written only after the extension reconnects to the native host.
+Rerun:
+
+```bash
+obu doctor browser --channel=store --extension-id=<STORE_EXTENSION_ID>
+```
+
+Then retry `browser_status`.
+
 ## Agent JavaScript Pitfalls
 
 For agent setup and MCP wiring, use the popup's **Copy for Agent** handoff or
@@ -135,14 +169,15 @@ obu install-host --all
 For a Chrome Web Store-installed extension, repair with the Store channel:
 
 ```bash
-obu install-host --channel=store --browser chrome
-obu doctor browser --repair --channel=store
+obu install-host --channel=store --browser chrome --extension-id <STORE_EXTENSION_ID>
+obu doctor browser --repair --channel=store --extension-id <STORE_EXTENSION_ID>
 ```
 
 If the Store channel reports that the Store extension id is not configured,
 install a release payload that records `storeExtensionId`, use the Store popup
 agent handoff, or pass `--extension-id <STORE_EXTENSION_ID>` while testing a
-draft item.
+draft item. Prefer the id from the popup handoff over any guessed id; repair
+will write that exact origin into `allowed_origins`.
 
 The manifest path should point at an open-browser-use wrapper under
 `~/.obu/native-host/dev.obu.host/<browser>/obu-host-wrapper`, not directly at a

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -183,6 +183,20 @@ The manifest path should point at an open-browser-use wrapper under
 `~/.obu/native-host/dev.obu.host/<browser>/obu-host-wrapper`, not directly at a
 source-tree helper or versioned payload binary.
 
+## Turn Cleanup During Setup Probes
+
+For setup verification or short browser probes, end the SDK turn with:
+
+```js
+await browser.turnEnded();
+```
+
+`browser.turnEnded()` keeps active tabs controlled and preserves the browser
+session for follow-up checks. `browser.finishTurn({ keep: [] })` first finalizes
+tabs; on WebExtension sessions that closes agent-created tabs or releases
+user-claimed tabs before ending the turn. Use `finishTurn` only when that
+cleanup is intentional, not as the default connection probe closeout.
+
 ## Extension Debug Logs
 
 The unpacked extension popup has local debug logging controls. Open the

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "open-browser-use user-facing command line tools.",
   "license": "MIT",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "open-browser-use Chromium MV3 extension.",
   "license": "MIT",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "default_locale": "en",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA19raOghahuNORvUNtnkVqp9T+fNn3TBxyajKRpHPsWwfNDLaruz73Wn9S7fvCPyyFROJ+lOYH/72Iw/njYHLpNiKhyxphQE8oON2izCzz3KNkRaEsdzZ4utBlsFMABgxKybMEu9osjmj2n91Q4fFMqBv5eCpdl2dEp5KPO6tnNLspRwQMttKU/KqBAjGDkbSBuAlaSKkaAC8IVBqrBBTzcvH7AYXYjOLL9ZJ5a01QnFkyXtEyDvnmxbNRDvF7/8pmryq3E+Ue/COBqHWp57EKUNFHH2r/0ZczELo+6rYlH0mDGdr1hpVIiAAnoGu8XTlQ5vp4GH60+VszbNa9zLi2QIDAQAB",
   "minimum_chrome_version": "116",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -66,7 +66,9 @@ creates `about:blank`, not Chrome's extension-restricted new-tab page.
 Keep a `Tab` handle and use `tab.goto(url)` for repeated same-task navigation.
 `browser.turnEnded()` marks a turn boundary while preserving active control;
 `browser.finishTurn(...)` first finalizes tabs and is for close/release/handoff
-or deliverable workflows.
+or deliverable workflows. For setup verification and browser readiness probes,
+prefer `turnEnded()` so follow-up checks keep using the same WebExtension
+session.
 One session can keep multiple `Tab` handles and move data between them:
 
 ```js

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "open-browser-use agent-facing SDK: Playwright-shaped API over the open-browser-use broker wire.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "0.1.3";
+export const SDK_VERSION = "0.1.4";

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -11,6 +11,12 @@ The user should paste a handoff block from the extension popup with:
 Use those exact values when native-host repair or browser pairing is needed. Do
 not infer a different extension id.
 
+For the Store channel, the pasted `Extension id` is part of the security
+boundary. Native messaging only works when the browser-owned manifest contains
+`chrome-extension://<that exact id>/` in `allowed_origins`. Do not derive an id
+from the unpacked manifest key, a previous local config, or another Chrome
+profile when the handoff includes a concrete Store id.
+
 ## Goal
 
 Make `open-browser-use` work as the user's primary BrowserUse/browser automation
@@ -198,20 +204,41 @@ contract above is enough to adapt other MCP-capable AI clients.
    ```
 
    For the Store channel, include the exact Store extension id from the handoff
-   unless it is already configured. If verification reports a browser UI
-   boundary, tell the user the exact action needed, such as clicking Resume or
-   reloading the unpacked extension.
+   unless it is already configured. If `browser_status` says the SDK is
+   available but `backends` is empty, the MCP server is reachable but the
+   browser backend is not. Run the doctor command above; for Store repair, use
+   the exact handoff id:
+
+   ```sh
+   ~/.obu/bin/obu doctor browser --repair --channel=store --extension-id=<extension-id>
+   ```
+
+   Repair can fix the native-host manifest and runtime descriptor directory, but
+   it cannot force Chrome to reconnect the extension. If doctor still reports
+   no active WebExtension runtime descriptor after repair, tell the user to open
+   the open-browser-use extension popup and click Resume. Then rerun doctor with
+   the same channel/id and retry `browser_status`.
 
 5. Verify MCP from inside the target agent when possible:
 
    - Restart or reload the client if its MCP config is only read at startup.
    - Confirm the `open-browser-use` MCP server appears in the client's MCP tool
      list.
+   - If the OBU MCP tools are not visible in a client that supports deferred tool
+     discovery, search/load the `open-browser-use` MCP tools before concluding
+     setup failed.
    - Prefer a read-only first call such as `browser_status`.
    - Before the first browser action, call `browser_status`; use the `js` MCP
      tool for browser automation.
+   - Treat MCP availability and browser availability as separate checks:
+     `browser_status` must show at least one backend before browser automation
+     can work.
    - If the MCP server starts but browser state is stale, run
      `~/.obu/bin/obu doctor browser` with the handoff channel/id when needed.
+   - For setup probes, prefer `await browser.turnEnded()` after the probe so the
+     browser session stays controlled. Do not use
+     `await browser.finishTurn({ keep: [] })` unless you intentionally want to
+     close agent-created tabs or release user tabs.
 
 6. Add a short persistent instruction when the project or agent has an
    appropriate core instruction file. Prefer the repo-root `AGENTS.md`,
@@ -233,7 +260,7 @@ contract above is enough to adapt other MCP-capable AI clients.
    for Claude Code, or the equivalent project instruction surface for Cursor.
    Do not create or edit unrelated repository files just to store this note. If
    there is no obvious persistent instructions file, show the snippet to the
-   user.
+   user and state that no project-level instruction file was available to update.
 
 ## Safety Rules
 

--- a/scripts/cargo-dist-smoke.mjs
+++ b/scripts/cargo-dist-smoke.mjs
@@ -24,7 +24,7 @@ const plan = JSON.parse(run(cargoDist, [
   "plan",
   "--output-format=json",
   "--tag",
-  "v0.1.3",
+  "v0.1.4",
   "--allow-dirty",
 ]).stdout);
 


### PR DESCRIPTION
## Summary
- Clarify Store-channel native-host repair around exact extension ids and popup Resume/runtime descriptor recovery.
- Make `browser_status` missing-backend guidance actionable for agents.
- Update MCP/SDK lifecycle guidance to prefer `turnEnded()` for setup probes and reserve `finishTurn({ keep: [] })` for intentional cleanup.
- Bump release version to 0.1.4.

## Validation
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- `cargo fmt --all -- --check`
- `cargo test -p obu-wire -p obu-node-repl -p obu-host --lib --tests --no-fail-fast`
- `node scripts/p4-release-readiness-smoke.mjs`
- `CARGO_DIST_BIN="$PWD/.cache/cargo-dist-home/bin/cargo-dist" node scripts/cargo-dist-smoke.mjs`
- `git diff --check`
