### PR TITLE
[codex] Close agent instruction setup loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "obu-host"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "obu-node-repl"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "obu-wire"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/docs/install.md
+++ b/docs/install.md
@@ -149,9 +149,12 @@ agent to choose the right install/repair, verification, MCP wiring, and
 persistent instruction steps for the current client. The agent should make
 open-browser-use the primary BrowserUse/browser automation tool in the core
 `AGENTS.md`, `AGENT.md`, `CLAUDE.md`, Cursor/Claude/Codex project instructions,
-or equivalent agent memory when one exists. The OBU adapter commands are
-secondary helpers for known clients. The popup keeps this entry available after
-the native host connects so users can connect another agent later.
+or equivalent agent memory when one exists. Agents should also check known
+global instruction files before falling back to a snippet, especially
+`~/.codex/AGENTS.md` for Codex and `~/.claude/CLAUDE.md` for Claude Code.
+The OBU adapter commands are secondary helpers for known clients. The popup
+keeps this entry available after the native host connects so users can connect
+another agent later.
 
 ## Setup
 
@@ -160,9 +163,15 @@ After installing an `obu` shim:
 ```bash
 eval "$("$HOME/.obu/bin/obu" shellenv zsh)"
 obu bootstrap --yes --all --agents=auto
-obu setup --yes --agents=codex-cli,claude-code
+obu setup --yes --agents=codex-cli,claude-code --write-instructions
 obu doctor
 ```
+
+`--write-instructions` is opt-in. It appends the primary-browser instruction to
+an existing project instruction file when one is present, otherwise it uses the
+known global instruction file for supported agents such as Codex
+(`~/.codex/AGENTS.md`) and Claude Code (`~/.claude/CLAUDE.md`). It preserves
+existing content and skips reruns when the instruction is already present.
 
 `obu repl` is deferred in P4a. Use `obu mcp stdio` through an MCP client; a
 direct debug REPL will need its own tested command contract before it is
@@ -201,6 +210,12 @@ Inspect the exact MCP config for any supported client:
 
 ```bash
 obu mcp-config --agent=codex-cli --print
+```
+
+Verify that an agent has both MCP wiring and the primary browser instruction:
+
+```bash
+obu agent doctor --agent=codex-cli
 ```
 
 Supported adapter IDs are `codex-cli`, `claude-code`, `gemini-cli`, `vscode`,

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -154,8 +154,9 @@ Verify installer support for:
   arbitrary current-`PATH` shims.
 - packaged `obu doctor --json` payload integrity checks and `obu mcp stdio`
   initialize/list-tools through the installed shim.
-- installed-payload `obu setup --yes --skip-agents` and
-  `obu setup --yes --agents=codex-cli` using a fake Codex CLI.
+- installed-payload `obu setup --yes --skip-agents`,
+  `obu setup --yes --agents=codex-cli --write-instructions` using a fake Codex
+  CLI, and `obu agent doctor --agent=codex-cli`.
 
 Payload metadata must include `extensionZip`, `extensionZipSha256`,
 `extensionId`, and `extensionChannel`; `node scripts/payload-self-check.mjs`
@@ -211,7 +212,7 @@ Required draft checks:
 
    ```bash
    obu bootstrap --yes --all --channel=store --extension-id <STORE_EXTENSION_ID> --agents=auto
-   obu doctor browser --channel=store --json
+   obu doctor browser --channel=store --extension-id <STORE_EXTENSION_ID> --json
    ```
 
 Verify:
@@ -220,8 +221,9 @@ Verify:
   `storeExtensionId`.
 - native-host manifests include
   `chrome-extension://<STORE_EXTENSION_ID>/`.
-- `doctor browser --channel=store --json` reports channel, extension id, and id
-  source.
+- `doctor browser --channel=store --extension-id <STORE_EXTENSION_ID> --json`
+  reports channel, extension id, id source, and `resume_required` on the runtime
+  descriptor probe.
 - the popup agent handoff preserves `Extension channel: store`, the exact Store
   extension id, and does not expose a Terminal command.
 - the popup agent handoff links to the version-tagged
@@ -256,7 +258,8 @@ Then load or reload the unpacked extension from:
 The extension must publish a WebExtension runtime descriptor, and
 `agent.browsers.get("chrome")` must complete a browser task.
 The automated `setup-webext-e2e.mjs` path also wires a fake Codex CLI with
-`obu setup --yes --agents=codex-cli` before launching Chrome for Testing.
+`obu setup --yes --agents=codex-cli --write-instructions` before launching
+Chrome for Testing.
 `obu doctor --strict` must exit nonzero on warnings as well as failures; use the
 non-strict command for interactive troubleshooting where warnings are advisory.
 Before manual testing, enable extension popup Debug logs, reproduce one browser
@@ -268,9 +271,10 @@ task, copy the JSON report, and confirm it includes status changes plus
 At minimum, test:
 
 ```bash
-obu setup --yes --agents=codex-cli
-obu setup --yes --agents=claude-code
+obu setup --yes --agents=codex-cli --write-instructions
+obu setup --yes --agents=claude-code --write-instructions
 obu setup --yes --agents=cursor
+obu agent doctor --agent=codex-cli
 ```
 
 For direct-edit adapters, rerun setup and confirm unchanged configs do not

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,7 +82,9 @@ Rerun:
 obu doctor browser --channel=store --extension-id=<STORE_EXTENSION_ID>
 ```
 
-Then retry `browser_status`.
+Then retry `browser_status`. Current `doctor browser` output includes
+`resume required: yes/no` on the runtime descriptor probe so agents do not need
+to infer popup state from deliverable counts or low-level descriptor details.
 
 ## Agent JavaScript Pitfalls
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "open-browser-use user-facing command line tools.",
   "license": "MIT",

--- a/packages/cli/src/agents/configure.test.ts
+++ b/packages/cli/src/agents/configure.test.ts
@@ -211,6 +211,56 @@ test("configureAgents reports unreadable direct-edit files as manual actions", a
   assert.equal(steps[0]?.details?.code, "EACCES");
 });
 
+test("configureAgents writes primary-browser instructions only when requested", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const steps = await configureAgents({
+    agents: ["codex-cli"],
+    server: server(root),
+    env: { PATH: "" },
+    homeDir: root,
+    writeInstructions: true,
+  });
+
+  assert.equal(steps.find((step) => step.id === "agent-codex-cli")?.status, "manual_action_required");
+  const instructionStep = steps.find((step) => step.id === "agent-codex-cli-instructions");
+  assert.equal(instructionStep?.status, "applied");
+  assert.match(await readFile(path.join(root, ".codex", "AGENTS.md"), "utf8"), /primary BrowserUse\/browser automation tool/);
+
+  const rerun = await configureAgents({
+    agents: ["codex-cli"],
+    server: server(root),
+    env: { PATH: "" },
+    homeDir: root,
+    writeInstructions: true,
+  });
+  assert.equal(rerun.find((step) => step.id === "agent-codex-cli-instructions")?.status, "skipped");
+});
+
+test("configureAgents prefers an existing project instruction file over the global file", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const projectDir = path.join(root, "project");
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(path.join(projectDir, "AGENTS.md"), "# Project\n", "utf8");
+
+  const steps = await configureAgents({
+    agents: ["codex-cli"],
+    server: server(root),
+    env: { PATH: "" },
+    homeDir: root,
+    projectDir,
+    writeInstructions: true,
+  });
+
+  const instructionStep = steps.find((step) => step.id === "agent-codex-cli-instructions");
+  assert.equal(instructionStep?.status, "applied");
+  assert.equal(instructionStep?.details?.kind, "project");
+  assert.match(await readFile(path.join(projectDir, "AGENTS.md"), "utf8"), /primary BrowserUse\/browser automation tool/);
+  await assert.rejects(() => readFile(path.join(root, ".codex", "AGENTS.md"), "utf8"), { code: "ENOENT" });
+});
+
 test("configureAgents uses Cursor shell adapter only when --add-mcp is available", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/packages/cli/src/agents/configure.ts
+++ b/packages/cli/src/agents/configure.ts
@@ -11,6 +11,7 @@ import {
   writeDirectEditAgentConfig,
   type DirectEditOptions,
 } from "./direct-edit.js";
+import { configureAgentInstructions } from "./instructions.js";
 
 export type AgentConfigureStep = {
   id: string;
@@ -32,6 +33,8 @@ export type ConfigureAgentsOptions = {
   now?: Date;
   commandPrefix?: string;
   adapterTimeoutMs?: number;
+  writeInstructions?: boolean;
+  projectDir?: string;
 };
 
 export type DetectInstalledAgentsOptions = Pick<ConfigureAgentsOptions, "env" | "homeDir" | "platform">;
@@ -76,8 +79,9 @@ export async function configureAgents(options: ConfigureAgentsOptions): Promise<
       kind: "command" as const,
       value: appendShellArgs(options.commandPrefix ?? "obu", ["mcp-config", `--agent=${agent}`, "--print"]),
     };
+    let step: AgentConfigureStep;
     if (agent === "cursor") {
-      steps.push(await configureCursor(
+      step = await configureCursor(
         config,
         options.server,
         env,
@@ -85,24 +89,30 @@ export async function configureAgents(options: ConfigureAgentsOptions): Promise<
         directEditOptions,
         manualAction,
         options.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS,
-      ));
+      );
+      steps.push(step);
+      steps.push(...await maybeConfigureInstructions(options, agent));
       continue;
     }
     if (config.mode !== "shell") {
       if (config.mode === "json" && isDirectEditAgentId(agent)) {
-        steps.push(await configureDirectEdit(agent, options.server, options.dryRun === true, directEditOptions, manualAction));
+        step = await configureDirectEdit(agent, options.server, options.dryRun === true, directEditOptions, manualAction);
+        steps.push(step);
+        steps.push(...await maybeConfigureInstructions(options, agent));
         continue;
       }
-      steps.push({
+      step = {
         id: `agent-${agent}`,
         status: "manual_action_required",
         message: `manual MCP configuration is required for ${agent}`,
         details: { mode: config.mode, config },
         nextActions: [manualAction],
-      });
+      };
+      steps.push(step);
+      steps.push(...await maybeConfigureInstructions(options, agent));
       continue;
     }
-    steps.push(await configureShell(
+    step = await configureShell(
       agent,
       config,
       env,
@@ -110,9 +120,23 @@ export async function configureAgents(options: ConfigureAgentsOptions): Promise<
       manualAction,
       undefined,
       options.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS,
-    ));
+    );
+    steps.push(step);
+    steps.push(...await maybeConfigureInstructions(options, agent));
   }
   return steps;
+}
+
+async function maybeConfigureInstructions(options: ConfigureAgentsOptions, agent: AgentId): Promise<AgentConfigureStep[]> {
+  if (!options.writeInstructions) return [];
+  return [
+    await configureAgentInstructions({
+      agent,
+      ...(options.dryRun === undefined ? {} : { dryRun: options.dryRun }),
+      ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+      ...(options.projectDir ? { projectDir: options.projectDir } : {}),
+    }),
+  ];
 }
 
 async function isAgentInstalled(agent: AgentId, env: NodeJS.ProcessEnv, directEditOptions: DirectEditOptions): Promise<boolean> {

--- a/packages/cli/src/agents/doctor.ts
+++ b/packages/cli/src/agents/doctor.ts
@@ -1,0 +1,208 @@
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+import {
+  findPrimaryInstruction,
+  PRIMARY_BROWSER_INSTRUCTION,
+  primaryInstructionTargets,
+} from "./instructions.js";
+import { renderAgentMcpConfig, type AgentId, type McpServerInvocation } from "./registry.js";
+
+export type AgentDoctorStatus = "pass" | "warn" | "fail";
+
+export type AgentDoctorCheck = {
+  id: string;
+  label: string;
+  status: AgentDoctorStatus;
+  message: string;
+  details?: Record<string, unknown>;
+};
+
+export type AgentDoctorReport = {
+  agent: AgentId;
+  checks: AgentDoctorCheck[];
+};
+
+export type AgentDoctorOptions = {
+  agent: AgentId;
+  server: McpServerInvocation;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  projectDir?: string;
+  adapterTimeoutMs?: number;
+};
+
+const DEFAULT_ADAPTER_TIMEOUT_MS = 5_000;
+
+export async function doctorAgent(options: AgentDoctorOptions): Promise<AgentDoctorReport> {
+  const checks = [
+    await checkMcpServer(options),
+    await checkPrimaryInstruction(options),
+  ];
+  return { agent: options.agent, checks };
+}
+
+export function formatAgentDoctorReport(report: AgentDoctorReport): string {
+  const counts = {
+    pass: report.checks.filter((check) => check.status === "pass").length,
+    warn: report.checks.filter((check) => check.status === "warn").length,
+    fail: report.checks.filter((check) => check.status === "fail").length,
+  };
+  return [
+    `open-browser-use agent doctor: ${report.agent}`,
+    `${counts.pass} passed, ${counts.warn} warning${counts.warn === 1 ? "" : "s"}, ${counts.fail} failed.`,
+    "",
+    ...report.checks.map((check) => `${check.status.toUpperCase().padEnd(4)} ${check.label}: ${check.message}`),
+  ].join("\n");
+}
+
+export function hasAgentDoctorFailures(report: AgentDoctorReport): boolean {
+  return report.checks.some((check) => check.status === "fail");
+}
+
+async function checkMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorCheck> {
+  const config = renderAgentMcpConfig(options.agent, options.server);
+  if (config.mode !== "shell") {
+    return warn("agent-mcp-server", "MCP server", `automatic MCP doctor is not implemented for ${options.agent}`, {
+      mode: config.mode,
+    });
+  }
+  const executable = await findExecutable(config.executable, options.env ?? process.env);
+  if (!executable) {
+    return warn("agent-mcp-server", "MCP server", `${config.executable} was not found on PATH`, {
+      executable: config.executable,
+    });
+  }
+  const probe = await runAdapter(executable, ["mcp", "list"], options.env ?? process.env, options.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS);
+  if (probe.timedOut) {
+    return warn("agent-mcp-server", "MCP server", `${config.executable} mcp list timed out`, {
+      executable,
+      timeout_ms: options.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS,
+    });
+  }
+  if (probe.code !== 0) {
+    return warn("agent-mcp-server", "MCP server", `${config.executable} mcp list did not complete`, {
+      executable,
+      code: probe.code,
+      stderr: probe.stderr.trim(),
+    });
+  }
+  const output = `${probe.stdout}\n${probe.stderr}`;
+  if (!output.includes(options.server.name)) {
+    return warn("agent-mcp-server", "MCP server", `${options.agent} does not list ${options.server.name}`, {
+      executable,
+    });
+  }
+  const expectedParts = [options.server.command, ...options.server.args];
+  if (!expectedParts.every((part) => output.includes(part))) {
+    return fail("agent-mcp-server", "MCP server", `${options.agent} lists ${options.server.name} with different settings`, {
+      executable,
+      expected: options.server,
+    });
+  }
+  return pass("agent-mcp-server", "MCP server", `${options.agent} lists ${options.server.name}`, {
+    executable,
+  });
+}
+
+async function checkPrimaryInstruction(options: AgentDoctorOptions): Promise<AgentDoctorCheck> {
+  const found = await findPrimaryInstruction({
+    agent: options.agent,
+    ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+    ...(options.projectDir ? { projectDir: options.projectDir } : {}),
+  });
+  if (found) {
+    return pass("agent-primary-instruction", "Primary browser instruction", `found in ${found.path}`, found);
+  }
+  const targets = primaryInstructionTargets({
+    agent: options.agent,
+    ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+    ...(options.projectDir ? { projectDir: options.projectDir } : {}),
+  });
+  if (targets.length === 0) {
+    return warn("agent-primary-instruction", "Primary browser instruction", `instruction check is not implemented for ${options.agent}`);
+  }
+  return warn("agent-primary-instruction", "Primary browser instruction", "open-browser-use primary instruction not found", {
+    checked: targets.map((target) => target.path),
+    remediation: PRIMARY_BROWSER_INSTRUCTION,
+  });
+}
+
+async function findExecutable(name: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {
+  const pathValue = env.PATH ?? "";
+  const candidates = pathValue.split(path.delimiter).filter(Boolean).map((entry) => path.join(entry, name));
+  for (const candidate of candidates) {
+    if (await access(candidate, constants.X_OK).then(() => true).catch(() => false)) return candidate;
+  }
+  return undefined;
+}
+
+function runAdapter(
+  executable: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): Promise<{ code: number | null; stdout: string; stderr: string; timedOut?: boolean }> {
+  return new Promise((resolve) => {
+    const child = spawn(executable, args, { env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timeout: NodeJS.Timeout | undefined;
+    const finish = (result: { code: number | null; stdout: string; stderr: string; timedOut?: boolean }) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve(result);
+    };
+    timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish({ code: null, stdout, stderr, timedOut: true });
+    }, Math.max(1, timeoutMs));
+    timeout.unref?.();
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      finish({ code: 1, stdout, stderr: error.message });
+    });
+    child.on("exit", (code) => {
+      finish({ code, stdout, stderr });
+    });
+  });
+}
+
+function pass(id: string, label: string, message: string, details?: Record<string, unknown>): AgentDoctorCheck {
+  return check(id, label, "pass", message, details);
+}
+
+function warn(id: string, label: string, message: string, details?: Record<string, unknown>): AgentDoctorCheck {
+  return check(id, label, "warn", message, details);
+}
+
+function fail(id: string, label: string, message: string, details?: Record<string, unknown>): AgentDoctorCheck {
+  return check(id, label, "fail", message, details);
+}
+
+function check(
+  id: string,
+  label: string,
+  status: AgentDoctorStatus,
+  message: string,
+  details?: Record<string, unknown>,
+): AgentDoctorCheck {
+  return {
+    id,
+    label,
+    status,
+    message,
+    ...(details && Object.keys(details).length > 0 ? { details } : {}),
+  };
+}

--- a/packages/cli/src/agents/doctor.ts
+++ b/packages/cli/src/agents/doctor.ts
@@ -1,8 +1,11 @@
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { constants } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 
+import { parse, type ParseError } from "jsonc-parser";
+
+import { directEditConfigPath, isDirectEditAgentId } from "./direct-edit.js";
 import {
   findPrimaryInstruction,
   PRIMARY_BROWSER_INSTRUCTION,
@@ -35,6 +38,7 @@ export type AgentDoctorOptions = {
 };
 
 const DEFAULT_ADAPTER_TIMEOUT_MS = 5_000;
+const MCP_LIST_AGENT_IDS = new Set<AgentId>(["codex-cli", "claude-code", "gemini-cli"]);
 
 export async function doctorAgent(options: AgentDoctorOptions): Promise<AgentDoctorReport> {
   const checks = [
@@ -64,6 +68,14 @@ export function hasAgentDoctorFailures(report: AgentDoctorReport): boolean {
 
 async function checkMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorCheck> {
   const config = renderAgentMcpConfig(options.agent, options.server);
+  if (isDirectEditAgentId(options.agent)) {
+    return checkDirectEditMcpConfig(options);
+  }
+  if (!MCP_LIST_AGENT_IDS.has(options.agent)) {
+    return warn("agent-mcp-server", "MCP server", `automatic MCP doctor is not implemented for ${options.agent}`, {
+      mode: config.mode,
+    });
+  }
   if (config.mode !== "shell") {
     return warn("agent-mcp-server", "MCP server", `automatic MCP doctor is not implemented for ${options.agent}`, {
       mode: config.mode,
@@ -71,19 +83,19 @@ async function checkMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorC
   }
   const executable = await findExecutable(config.executable, options.env ?? process.env);
   if (!executable) {
-    return warn("agent-mcp-server", "MCP server", `${config.executable} was not found on PATH`, {
+    return fail("agent-mcp-server", "MCP server", `${config.executable} was not found on PATH`, {
       executable: config.executable,
     });
   }
   const probe = await runAdapter(executable, ["mcp", "list"], options.env ?? process.env, options.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS);
   if (probe.timedOut) {
-    return warn("agent-mcp-server", "MCP server", `${config.executable} mcp list timed out`, {
+    return fail("agent-mcp-server", "MCP server", `${config.executable} mcp list timed out`, {
       executable,
       timeout_ms: options.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS,
     });
   }
   if (probe.code !== 0) {
-    return warn("agent-mcp-server", "MCP server", `${config.executable} mcp list did not complete`, {
+    return fail("agent-mcp-server", "MCP server", `${config.executable} mcp list did not complete`, {
       executable,
       code: probe.code,
       stderr: probe.stderr.trim(),
@@ -91,7 +103,7 @@ async function checkMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorC
   }
   const output = `${probe.stdout}\n${probe.stderr}`;
   if (!output.includes(options.server.name)) {
-    return warn("agent-mcp-server", "MCP server", `${options.agent} does not list ${options.server.name}`, {
+    return fail("agent-mcp-server", "MCP server", `${options.agent} does not list ${options.server.name}`, {
       executable,
     });
   }
@@ -105,6 +117,74 @@ async function checkMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorC
   return pass("agent-mcp-server", "MCP server", `${options.agent} lists ${options.server.name}`, {
     executable,
   });
+}
+
+async function checkDirectEditMcpConfig(options: AgentDoctorOptions): Promise<AgentDoctorCheck> {
+  const agent = options.agent;
+  if (!isDirectEditAgentId(agent)) {
+    return warn("agent-mcp-server", "MCP server", `automatic MCP doctor is not implemented for ${agent}`);
+  }
+  const configPath = directEditConfigPath(agent, {
+    ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+  });
+  const raw = await readOptionalFile(configPath).catch((error): ReadConfigResult => {
+    const nodeError = error as NodeJS.ErrnoException;
+    return {
+      status: "error",
+      error: nodeError.message ?? String(error),
+      ...(nodeError.code ? { code: nodeError.code } : {}),
+    };
+  });
+  if (raw.status === "missing") {
+    return fail("agent-mcp-server", "MCP server", `${options.agent} MCP config not found at ${configPath}`, {
+      path: configPath,
+    });
+  }
+  if (raw.status === "error") {
+    return fail("agent-mcp-server", "MCP server", `${options.agent} MCP config could not be read`, {
+      path: configPath,
+      ...raw,
+    });
+  }
+  const errors: ParseError[] = [];
+  const parsed = parse(raw.content, errors, { allowTrailingComma: true, disallowComments: false });
+  if (errors.length > 0) {
+    return fail("agent-mcp-server", "MCP server", `${options.agent} MCP config could not be parsed`, {
+      path: configPath,
+      errors: errors.map((error) => `parse error ${error.error} at offset ${error.offset}`),
+    });
+  }
+  const serverConfig = directEditServerConfig(parsed, options.agent, options.server.name);
+  if (!isRecord(serverConfig)) {
+    return fail("agent-mcp-server", "MCP server", `${options.agent} does not configure ${options.server.name}`, {
+      path: configPath,
+    });
+  }
+  if (!equivalentServerConfig(serverConfig, options.server, options.agent)) {
+    return fail("agent-mcp-server", "MCP server", `${options.agent} configures ${options.server.name} with different settings`, {
+      path: configPath,
+      expected: options.server,
+      actual: serverConfig,
+    });
+  }
+  return pass("agent-mcp-server", "MCP server", `${options.agent} configures ${options.server.name}`, {
+    path: configPath,
+  });
+}
+
+type ReadConfigResult =
+  | { status: "ok"; content: string }
+  | { status: "missing" }
+  | { status: "error"; error: string; code?: string };
+
+async function readOptionalFile(file: string): Promise<ReadConfigResult> {
+  try {
+    return { status: "ok", content: await readFile(file, "utf8") };
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") return { status: "missing" };
+    throw error;
+  }
 }
 
 async function checkPrimaryInstruction(options: AgentDoctorOptions): Promise<AgentDoctorCheck> {
@@ -124,10 +204,33 @@ async function checkPrimaryInstruction(options: AgentDoctorOptions): Promise<Age
   if (targets.length === 0) {
     return warn("agent-primary-instruction", "Primary browser instruction", `instruction check is not implemented for ${options.agent}`);
   }
-  return warn("agent-primary-instruction", "Primary browser instruction", "open-browser-use primary instruction not found", {
+  return fail("agent-primary-instruction", "Primary browser instruction", "open-browser-use primary instruction not found", {
     checked: targets.map((target) => target.path),
     remediation: PRIMARY_BROWSER_INSTRUCTION,
   });
+}
+
+function directEditServerConfig(config: unknown, agent: AgentId, serverName: string): unknown {
+  if (!isRecord(config)) return undefined;
+  if (agent === "zed") {
+    return isRecord(config.context_servers) ? config.context_servers[serverName] : undefined;
+  }
+  return isRecord(config.mcpServers) ? config.mcpServers[serverName] : undefined;
+}
+
+function equivalentServerConfig(config: Record<string, unknown>, server: McpServerInvocation, agent: AgentId): boolean {
+  const expectedName = agent === "zed" ? undefined : server.name;
+  return (
+    (expectedName === undefined || config.name === expectedName) &&
+    config.command === server.command &&
+    Array.isArray(config.args) &&
+    config.args.length === server.args.length &&
+    config.args.every((arg, index) => arg === server.args[index])
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function findExecutable(name: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {

--- a/packages/cli/src/agents/doctor.ts
+++ b/packages/cli/src/agents/doctor.ts
@@ -219,7 +219,7 @@ function directEditServerConfig(config: unknown, agent: AgentId, serverName: str
 }
 
 function equivalentServerConfig(config: Record<string, unknown>, server: McpServerInvocation, agent: AgentId): boolean {
-  const expectedName = agent === "zed" ? undefined : server.name;
+  const expectedName = agent === "zed" || config.name === undefined ? undefined : server.name;
   return (
     (expectedName === undefined || config.name === expectedName) &&
     config.command === server.command &&

--- a/packages/cli/src/agents/instructions.ts
+++ b/packages/cli/src/agents/instructions.ts
@@ -1,0 +1,165 @@
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { AgentId } from "./registry.js";
+
+export type AgentInstructionStep = {
+  id: string;
+  status: "applied" | "skipped" | "would_apply" | "manual_action_required" | "failed";
+  message: string;
+  details?: Record<string, unknown>;
+  nextActions?: Array<{ kind: "manual"; value: string }>;
+};
+
+export type AgentInstructionOptions = {
+  agent: AgentId;
+  dryRun?: boolean;
+  homeDir?: string;
+  projectDir?: string;
+};
+
+const PRIMARY_INSTRUCTION_NEEDLE = "Use open-browser-use as the primary BrowserUse/browser automation tool.";
+
+export const PRIMARY_BROWSER_INSTRUCTION = [
+  "## Browser Automation",
+  "",
+  PRIMARY_INSTRUCTION_NEEDLE,
+  "Prefer the `open-browser-use` MCP server for browser tasks. Check `browser_status`",
+  "before the first browser action, use the `js` tool for browser automation, and",
+  "run `~/.obu/bin/obu doctor browser` if setup appears stale.",
+].join("\n");
+
+export async function configureAgentInstructions(options: AgentInstructionOptions): Promise<AgentInstructionStep> {
+  const target = await resolveInstructionTarget(options);
+  const id = `agent-${options.agent}-instructions`;
+  if (!target) {
+    return {
+      id,
+      status: "skipped",
+      message: `no known instruction target for ${options.agent}`,
+    };
+  }
+
+  if (options.dryRun) {
+    return {
+      id,
+      status: "would_apply",
+      message: `would update ${target.kind} instructions at ${target.path}`,
+      details: { path: target.path, kind: target.kind, dryRun: true },
+    };
+  }
+
+  let current: string | undefined;
+  try {
+    current = await readOptionalFile(target.path);
+  } catch (error) {
+    return ioFailure(id, target.path, error);
+  }
+  if (current?.includes(PRIMARY_INSTRUCTION_NEEDLE)) {
+    return {
+      id,
+      status: "skipped",
+      message: `${target.kind} instructions already mention open-browser-use as primary`,
+      details: { path: target.path, kind: target.kind },
+    };
+  }
+
+  try {
+    await mkdir(path.dirname(target.path), { recursive: true, mode: 0o700 });
+    await writeFile(target.path, appendInstruction(current), { encoding: "utf8", mode: 0o600 });
+  } catch (error) {
+    return ioFailure(id, target.path, error);
+  }
+  return {
+    id,
+    status: "applied",
+    message: `updated ${target.kind} instructions at ${target.path}`,
+    details: { path: target.path, kind: target.kind },
+  };
+}
+
+export function primaryInstructionTargets(options: AgentInstructionOptions): Array<{ path: string; kind: "project" | "global" }> {
+  const projectDir = options.projectDir ?? process.cwd();
+  const targets: Array<{ path: string; kind: "project" | "global" }> = projectInstructionCandidates(options.agent, projectDir)
+    .map((candidate) => ({ path: candidate, kind: "project" as const }));
+  const globalPath = globalInstructionPath(options.agent, options.homeDir ?? os.homedir());
+  if (globalPath) targets.push({ path: globalPath, kind: "global" });
+  return targets;
+}
+
+export async function findPrimaryInstruction(options: AgentInstructionOptions): Promise<{ path: string; kind: "project" | "global" } | undefined> {
+  for (const target of primaryInstructionTargets(options)) {
+    const current = await readOptionalFile(target.path).catch(() => undefined);
+    if (current?.includes(PRIMARY_INSTRUCTION_NEEDLE)) return target;
+  }
+  return undefined;
+}
+
+async function resolveInstructionTarget(options: AgentInstructionOptions): Promise<{ path: string; kind: "project" | "global" } | undefined> {
+  for (const target of primaryInstructionTargets(options)) {
+    if (target.kind === "project" && await exists(target.path)) return target;
+    if (target.kind === "global") return target;
+  }
+  return undefined;
+}
+
+function projectInstructionCandidates(agent: AgentId, projectDir: string): string[] {
+  switch (agent) {
+    case "codex-cli":
+      return [
+        path.join(projectDir, "AGENTS.md"),
+        path.join(projectDir, "AGENT.md"),
+      ];
+    case "claude-code":
+      return [path.join(projectDir, "CLAUDE.md")];
+    default:
+      return [];
+  }
+}
+
+function globalInstructionPath(agent: AgentId, homeDir: string): string | undefined {
+  switch (agent) {
+    case "codex-cli":
+      return path.join(homeDir, ".codex", "AGENTS.md");
+    case "claude-code":
+      return path.join(homeDir, ".claude", "CLAUDE.md");
+    default:
+      return undefined;
+  }
+}
+
+async function readOptionalFile(file: string): Promise<string | undefined> {
+  try {
+    return await readFile(file, "utf8");
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function exists(file: string): Promise<boolean> {
+  return access(file, constants.F_OK).then(() => true).catch(() => false);
+}
+
+function appendInstruction(current: string | undefined): string {
+  if (!current || current.trim().length === 0) return `${PRIMARY_BROWSER_INSTRUCTION}\n`;
+  const normalized = current.endsWith("\n") ? current : `${current}\n`;
+  return `${normalized}\n${PRIMARY_BROWSER_INSTRUCTION}\n`;
+}
+
+function ioFailure(id: string, file: string, error: unknown): AgentInstructionStep {
+  const nodeError = error as NodeJS.ErrnoException;
+  return {
+    id,
+    status: "failed",
+    message: `could not update instruction file ${file}: ${nodeError.message ?? String(error)}`,
+    details: {
+      path: file,
+      ...(nodeError.code ? { code: nodeError.code } : {}),
+    },
+  };
+}

--- a/packages/cli/src/doctor-browser.test.ts
+++ b/packages/cli/src/doctor-browser.test.ts
@@ -52,6 +52,7 @@ test("doctorBrowser reports a valid local browser setup without failures", async
   assert.equal(checks["runtime-dir"]?.status, "pass");
   assert.equal(checks["runtime-descriptor-dir"]?.status, "pass");
   assert.equal(checks["runtime-descriptor-probe"]?.status, "warn");
+  assert.equal(checks["runtime-descriptor-probe"]?.details?.resume_required, true);
   assert.match(String(checks["runtime-descriptor-probe"]?.details?.repair ?? ""), /click Resume/);
   assert.equal(hasDoctorFailures(report), false);
 
@@ -59,6 +60,7 @@ test("doctorBrowser reports a valid local browser setup without failures", async
   assert.match(formatted, /open-browser-use browser doctor: chrome/);
   assert.match(formatted, /PASS Native host manifest:/);
   assert.match(formatted, /WARN Runtime descriptor probe:/);
+  assert.match(formatted, /resume required: yes/);
   assert.match(formatted, /repair: .*click Resume/);
 });
 

--- a/packages/cli/src/doctor-browser.ts
+++ b/packages/cli/src/doctor-browser.ts
@@ -196,6 +196,14 @@ function formatCheckDetails(check: DoctorCheck): string[] {
   if (typeof deliverableRecovery === "string" && deliverableRecovery.length > 0) {
     rows.push(`  recover deliverables: ${deliverableRecovery}`);
   }
+  const resumeRequired = check.details?.resume_required;
+  if (typeof resumeRequired === "boolean") {
+    rows.push(`  resume required: ${resumeRequired ? "yes" : "no"}`);
+  }
+  const resumeAction = check.details?.resume_action;
+  if (typeof resumeAction === "string" && resumeAction.length > 0) {
+    rows.push(`  resume action: ${resumeAction}`);
+  }
   const repair = check.details?.repair;
   if (typeof repair === "string" && repair.length > 0) rows.push(`  repair: ${repair}`);
   return rows;
@@ -764,7 +772,7 @@ async function checkRuntimeDescriptors(descriptorDir: string): Promise<DoctorChe
   const files = await readdir(descriptorDir).catch(() => []);
   const descriptors = files.filter((file) => file.endsWith(".json"));
   if (descriptors.length === 0) {
-    return warn("runtime-descriptor-probe", "Runtime descriptor probe", "no active WebExtension descriptor found");
+    return warn("runtime-descriptor-probe", "Runtime descriptor probe", "no active WebExtension descriptor found", resumeRequiredDetails());
   }
   const errors: string[] = [];
   for (const file of descriptors) {
@@ -783,6 +791,7 @@ async function checkRuntimeDescriptors(descriptorDir: string): Promise<DoctorChe
     if (result.ok) {
       const details = {
         descriptor: file,
+        resume_required: false,
         ...result.details,
       };
       const staleLifecycle = staleLifecycleSummary(result.details.lifecycle);
@@ -798,7 +807,17 @@ async function checkRuntimeDescriptors(descriptorDir: string): Promise<DoctorChe
     }
     errors.push(`${file}: ${result.message}`);
   }
-  return fail("runtime-descriptor-probe", "Runtime descriptor probe", errors.join("; "));
+  return fail("runtime-descriptor-probe", "Runtime descriptor probe", errors.join("; "), {
+    ...resumeRequiredDetails(),
+    descriptor_errors: errors,
+  });
+}
+
+function resumeRequiredDetails(): Record<string, unknown> {
+  return {
+    resume_required: true,
+    resume_action: "open the open-browser-use extension popup and click Resume",
+  };
 }
 
 async function probeDescriptor(descriptor: Record<string, unknown>): Promise<RuntimeDescriptorProbeResult> {

--- a/packages/cli/src/human-output.test.ts
+++ b/packages/cli/src/human-output.test.ts
@@ -35,6 +35,7 @@ test("doctor summary hides ordinary passing checks and keeps actionable recovery
         status: "pass",
         message: "chrome.json responded to getInfo",
         details: {
+          resume_required: false,
           lifecycle: {
             stale_sessions: 0,
             stale_tabs: 0,
@@ -57,6 +58,7 @@ test("doctor summary hides ordinary passing checks and keeps actionable recovery
   assert.match(formatted, /repair: Run `obu setup`/);
   assert.match(formatted, /WARN Profile path: profile root not found/);
   assert.match(formatted, /PASS Runtime descriptor probe: chrome\.json responded to getInfo/);
+  assert.match(formatted, /resume required: no/);
   assert.match(formatted, /deliverable tabs: 8:Deliverable \(session\)/);
   assert.match(formatted, /recover deliverables: .*browser\.deliverables\(\).*claim\(\)/);
   assert.match(formatted, /For full diagnostics, run: obu doctor --verbose/);

--- a/packages/cli/src/human-output.ts
+++ b/packages/cli/src/human-output.ts
@@ -195,9 +195,11 @@ function countDoctorStatuses(checks: DoctorCheck[]): Record<DoctorCheck["status"
 function hasActionableDetails(check: DoctorCheck): boolean {
   const repair = check.details?.repair;
   const deliverableRecovery = check.details?.deliverable_recovery;
+  const resumeRequired = check.details?.resume_required;
   return (
     (typeof repair === "string" && repair.length > 0) ||
-    (typeof deliverableRecovery === "string" && deliverableRecovery.length > 0)
+    (typeof deliverableRecovery === "string" && deliverableRecovery.length > 0) ||
+    typeof resumeRequired === "boolean"
   );
 }
 
@@ -221,6 +223,14 @@ function formatCheckDetails(check: DoctorCheck): string[] {
   const deliverableRecovery = check.details?.deliverable_recovery;
   if (typeof deliverableRecovery === "string" && deliverableRecovery.length > 0) {
     rows.push(`recover deliverables: ${deliverableRecovery}`);
+  }
+  const resumeRequired = check.details?.resume_required;
+  if (typeof resumeRequired === "boolean") {
+    rows.push(`resume required: ${resumeRequired ? "yes" : "no"}`);
+  }
+  const resumeAction = check.details?.resume_action;
+  if (typeof resumeAction === "string" && resumeAction.length > 0) {
+    rows.push(`resume action: ${resumeAction}`);
   }
   const repair = check.details?.repair;
   if (typeof repair === "string" && repair.length > 0) rows.push(`repair: ${repair}`);

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -134,6 +134,29 @@ test("agent doctor reads Cursor direct-edit MCP config instead of running mcp li
   assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.status, "warn");
 });
 
+test("agent doctor accepts generic mcpServers entries without a nested name", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".cursor"), { recursive: true });
+  await writeFile(path.join(home, ".cursor", "mcp.json"), JSON.stringify({
+    mcpServers: {
+      "open-browser-use": {
+        command: process.execPath,
+        args: [cliEntry, "mcp", "stdio"],
+      },
+    },
+  }, null, 2), "utf8");
+
+  const result = await runCli(["agent", "doctor", "--agent=cursor", "--json"], {
+    HOME: home,
+    PATH: "",
+  });
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "pass");
+});
+
 test("agent doctor does not run unsupported VS Code mcp-list probes", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -88,6 +88,72 @@ exit 1
   assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.status, "pass");
 });
 
+test("agent doctor fails when supported MCP or instruction checks are missing", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+
+  const result = await runCli(["agent", "doctor", "--agent=codex-cli", "--json"], {
+    HOME: home,
+    PATH: "",
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "fail");
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.status, "fail");
+});
+
+test("agent doctor reads Cursor direct-edit MCP config instead of running mcp list", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".cursor"), { recursive: true });
+  await writeFile(path.join(home, ".cursor", "mcp.json"), JSON.stringify({
+    mcpServers: {
+      "open-browser-use": {
+        name: "open-browser-use",
+        command: process.execPath,
+        args: [cliEntry, "mcp", "stdio"],
+      },
+    },
+  }, null, 2), "utf8");
+  const cursor = path.join(bin, "cursor");
+  await writeFile(cursor, "#!/bin/sh\nexit 17\n", "utf8");
+  await chmod(cursor, 0o755);
+
+  const result = await runCli(["agent", "doctor", "--agent=cursor", "--json"], {
+    HOME: home,
+    PATH: bin,
+  });
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "pass");
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.status, "warn");
+});
+
+test("agent doctor does not run unsupported VS Code mcp-list probes", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  const code = path.join(bin, "code");
+  await writeFile(code, "#!/bin/sh\nexit 17\n", "utf8");
+  await chmod(code, 0o755);
+
+  const result = await runCli(["agent", "doctor", "--agent=vscode", "--json"], {
+    HOME: home,
+    PATH: bin,
+  });
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "warn");
+  assert.match(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.message ?? "", /not implemented/);
+});
+
 test("shellenv emits packaged install environment snippets", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   t.after(() => rm(home, { recursive: true, force: true }));

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -52,6 +52,42 @@ test("mcp-config rejects unknown agents", async (t) => {
   assert.match(result.stderr, /unsupported agent/);
 });
 
+test("agent doctor verifies shell MCP config and primary instructions", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".codex"), { recursive: true });
+  await writeFile(path.join(home, ".codex", "AGENTS.md"), [
+    "## Browser Automation",
+    "",
+    "Use open-browser-use as the primary BrowserUse/browser automation tool.",
+    "",
+  ].join("\n"), "utf8");
+  const codex = path.join(bin, "codex");
+  await writeFile(codex, `#!/bin/sh
+if [ "$1 $2" = "mcp list" ]; then
+  echo "open-browser-use ${shellEscapeForDoubleQuotes(process.execPath)} ${shellEscapeForDoubleQuotes(cliEntry)} mcp stdio"
+  exit 0
+fi
+exit 1
+`, "utf8");
+  await chmod(codex, 0o755);
+
+  const result = await runCli(["agent", "doctor", "--agent=codex-cli", "--json"], {
+    HOME: home,
+    PATH: bin,
+  });
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.command, "agent doctor");
+  assert.equal(payload.agent, "codex-cli");
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "pass");
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.status, "pass");
+});
+
 test("shellenv emits packaged install environment snippets", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -276,7 +312,7 @@ test("setup summary preserves manual agent next actions", async (t) => {
   assert.equal(result.stderr, "");
   assert.match(result.stdout, /Setup needs 1 follow-up step\./);
   assert.match(result.stdout, new RegExp(`${escapeRegExp(obuCommand)} mcp-config --agent=continue --print`));
-  assert.match(result.stdout, new RegExp(`${escapeRegExp(obuCommand)} doctor browser --channel=store`));
+  assert.match(result.stdout, new RegExp(`${escapeRegExp(obuCommand)} doctor browser --channel=store --extension-id=${storeExtensionId}`));
   assert.doesNotMatch(result.stdout, /agent-continue:/);
 
   const recovery = await runCli(["setup", "--yes", "--recovery", "--channel=store", "--extension-id", storeExtensionId, "--agents=continue"], {
@@ -507,6 +543,46 @@ test("setup CLI supports Store channel without staging an unpacked extension", a
   assert.equal(config.storeExtensionId, storeExtensionId);
 });
 
+test("setup can write Codex and Claude primary-browser instructions explicitly", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  const hostBin = path.join(bin, "obu-host");
+  await writeFile(hostBin, "#!/bin/sh\n", "utf8");
+  await chmod(hostBin, 0o755);
+  const codex = path.join(bin, "codex");
+  await writeFile(codex, "#!/bin/sh\nexit 0\n", "utf8");
+  await chmod(codex, 0o755);
+  const claude = path.join(bin, "claude");
+  await writeFile(claude, "#!/bin/sh\nexit 0\n", "utf8");
+  await chmod(claude, 0o755);
+  const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+
+  const result = await runCli([
+    "setup",
+    "--yes",
+    "--channel=store",
+    "--extension-id",
+    storeExtensionId,
+    "--agents=codex-cli,claude-code",
+    "--write-instructions",
+    "--json",
+  ], {
+    HOME: home,
+    PATH: bin,
+    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_HOST_BIN: hostBin,
+  });
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.steps.find((step: any) => step.id === "agent-codex-cli-instructions")?.status, "applied");
+  assert.equal(payload.steps.find((step: any) => step.id === "agent-claude-code-instructions")?.status, "applied");
+  assert.match(await readFile(path.join(home, ".codex", "AGENTS.md"), "utf8"), /primary BrowserUse\/browser automation tool/);
+  assert.match(await readFile(path.join(home, ".claude", "CLAUDE.md"), "utf8"), /primary BrowserUse\/browser automation tool/);
+});
+
 test("setup CLI rejects unknown requested agents before writing", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -671,4 +747,8 @@ function runCli(args: string[], env: NodeJS.ProcessEnv = {}): Promise<{ code: nu
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function shellEscapeForDoubleQuotes(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("$", "\\$").replaceAll("`", "\\`");
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 
+import { doctorAgent, formatAgentDoctorReport, hasAgentDoctorFailures } from "./agents/doctor.js";
 import { isAgentId, renderAgentMcpConfig, supportedAgentIds, type AgentId, type McpServerInvocation } from "./agents/registry.js";
 import { appendShellArgs, formatShellCommand } from "./command-line.js";
 import { doctorAggregate, formatAggregateDoctorReport } from "./doctor.js";
@@ -46,6 +47,7 @@ type ParsedArgs = {
   agents: string[];
   skipExtension: boolean;
   skipAgents: boolean;
+  writeInstructions: boolean;
 };
 
 async function main(argv: string[]): Promise<number> {
@@ -63,6 +65,9 @@ async function main(argv: string[]): Promise<number> {
   }
   if (args.command === "mcp-config") {
     return runMcpConfig(args);
+  }
+  if (args.command === "agent" && args.subject === "doctor") {
+    return runAgentDoctor(args);
   }
   if (args.command === "shellenv") {
     return runShellenv(args);
@@ -144,8 +149,10 @@ async function runBootstrap(args: ParsedArgs): Promise<number> {
     dryRun: args.dryRun,
     skipExtension: args.skipExtension,
     skipAgents: args.skipAgents,
+    writeInstructions: args.writeInstructions,
     env: process.env,
     commandPrefix,
+    projectDir: process.cwd(),
     ...(args.extensionPath ? { extensionPath: args.extensionPath } : {}),
   });
 
@@ -245,8 +252,10 @@ async function runSetup(args: ParsedArgs): Promise<number> {
     dryRun: args.dryRun,
     skipExtension: args.skipExtension,
     skipAgents: args.skipAgents,
+    writeInstructions: args.writeInstructions,
     env: process.env,
     commandPrefix,
+    projectDir: process.cwd(),
     ...(args.extensionPath ? { extensionPath: args.extensionPath } : {}),
   });
   if (args.json) {
@@ -465,6 +474,37 @@ async function runMcpConfig(args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+async function runAgentDoctor(args: ParsedArgs): Promise<number> {
+  if (!args.agent) throw new Error("agent doctor requires --agent=<id>");
+  if (!isAgentId(args.agent)) {
+    throw new Error(`unsupported agent: ${args.agent}. Supported agents: ${supportedAgentIds().join(", ")}`);
+  }
+  const layout = await resolveRuntimeLayout();
+  const invocation = await resolveMcpInvocation(layout.openBrowserUseCommand, layout.cliEntry);
+  const server: McpServerInvocation = {
+    name: "open-browser-use",
+    command: invocation.command,
+    args: invocation.args,
+  };
+  const report = await doctorAgent({
+    agent: args.agent,
+    server,
+    env: process.env,
+    homeDir: path.dirname(path.dirname(layout.userConfigPath)),
+    projectDir: process.cwd(),
+  });
+  if (args.json) {
+    console.log(JSON.stringify({
+      schemaVersion: 1,
+      command: "agent doctor",
+      ...report,
+    }, null, 2));
+  } else {
+    console.log(formatAgentDoctorReport(report));
+  }
+  return hasAgentDoctorFailures(report) ? 1 : 0;
+}
+
 async function resolveHumanCommandPrefix(layout: Awaited<ReturnType<typeof resolveRuntimeLayout>>): Promise<string> {
   const command = layout.openBrowserUseCommand;
   if (!path.isAbsolute(command) && !command.includes(path.sep)) return formatShellCommand(command);
@@ -562,7 +602,9 @@ function formatBootstrapSummary(setupReport: SetupJson, browserReport: DoctorRep
 }
 
 function bootstrapAgentSummary(setupReport: SetupJson): string | undefined {
-  const agentSteps = setupReport.steps.filter((step) => step.id.startsWith("agent-"));
+  const agentSteps = setupReport.steps.filter((step) =>
+    step.id.startsWith("agent-") && !step.id.endsWith("-instructions")
+  );
   const manualAgents = agentSteps
     .filter((step) => step.status === "manual_action_required")
     .map((step) => step.id.replace(/^agent-/, ""));
@@ -623,6 +665,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     agents: [],
     skipExtension: false,
     skipAgents: false,
+    writeInstructions: false,
     help: false,
     version: false,
   };
@@ -708,6 +751,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         args.agents = [];
         args.skipAgents = true;
         break;
+      case "--write-instructions":
+        args.writeInstructions = true;
+        break;
       case "--version":
       case "-V":
         args.version = true;
@@ -736,12 +782,13 @@ function parseBrowser(value: string): BrowserKind {
 function printHelp(): void {
   console.log(`Usage:
   obu --version
-  obu bootstrap [--yes] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--agents=auto|none|<list>] [--channel unpacked-dev|store] [--extension-id <id>] [--skip-extension] [--dry-run] [--json]
-  obu setup [--yes] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--agents=auto|none|<list>] [--channel unpacked-dev|store] [--extension-id <id>] [--skip-extension] [--skip-agents] [--dry-run] [--recovery] [--verbose] [--json]
+  obu bootstrap [--yes] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--agents=auto|none|<list>] [--channel unpacked-dev|store] [--extension-id <id>] [--skip-extension] [--write-instructions] [--dry-run] [--json]
+  obu setup [--yes] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--agents=auto|none|<list>] [--channel unpacked-dev|store] [--extension-id <id>] [--skip-extension] [--skip-agents] [--write-instructions] [--dry-run] [--recovery] [--verbose] [--json]
   obu doctor [browser] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium] [--channel unpacked-dev|store] [--extension-id <id>] [--verbose] [--json] [--strict] [--repair] [--clean-backups]
   obu install-host [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--channel unpacked-dev|store] [--extension-id <id>] [--dry-run] [--verbose] [--json]
   obu update-extension [--path <dir>] [--channel unpacked-dev] [--no-wait] [--dry-run] [--verbose] [--json]
   obu mcp-config --agent=<id> --print
+  obu agent doctor --agent=<id> [--json]
   obu shellenv [shell]
   obu mcp stdio`);
 }

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -101,7 +101,9 @@ test("setupOpenBrowserUse skips extension staging for Store channel", async (t) 
   await assert.rejects(readFile(path.join(layout.extensionCurrentDir, "marker.txt"), "utf8"));
   const nativeHostStep = result.steps.find((step) => step.id === "native-host-chrome");
   assert.equal(nativeHostStep?.details?.extensionId, storeExtensionId);
-  assert.ok(result.nextActions.some((action) => action.value === `${layout.openBrowserUseCommand} doctor browser --channel=store`));
+  assert.ok(result.nextActions.some((action) =>
+    action.value === `${layout.openBrowserUseCommand} doctor browser --channel=store --extension-id=${storeExtensionId}`
+  ));
 });
 
 async function extensionSource(root: string, version: string): Promise<string> {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -41,9 +41,11 @@ export type SetupOptions = {
   dryRun?: boolean;
   skipExtension?: boolean;
   skipAgents?: boolean;
+  writeInstructions?: boolean;
   extensionPath?: string;
   env?: NodeJS.ProcessEnv;
   commandPrefix?: string;
+  projectDir?: string;
 };
 
 export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJson> {
@@ -150,6 +152,8 @@ export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJ
       ...(options.env ? { env: options.env } : {}),
       homeDir: agentHomeDir,
       ...(options.commandPrefix ? { commandPrefix: options.commandPrefix } : {}),
+      ...(options.writeInstructions ? { writeInstructions: options.writeInstructions } : {}),
+      ...(options.projectDir ? { projectDir: options.projectDir } : {}),
     });
     for (const step of agentSteps) {
       steps.push({
@@ -164,11 +168,14 @@ export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJ
 
   nextActions.push({
     kind: "command",
-    value: formatSetupCommand(options, options.extensionChannel === "store"
-      ? ["doctor", "browser", "--channel=store"]
-      : ["doctor"]),
+    value: formatSetupCommand(options, doctorCommandArgs(options)),
   });
   return finalize(options, steps, dedupeActions(nextActions));
+}
+
+function doctorCommandArgs(options: SetupOptions): string[] {
+  if (options.extensionChannel !== "store") return ["doctor"];
+  return ["doctor", "browser", "--channel=store", `--extension-id=${options.extensionId}`];
 }
 
 function formatSetupCommand(options: SetupOptions, args: string[]): string {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/extension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "open-browser-use Chromium MV3 extension.",
   "license": "MIT",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "default_locale": "en",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA19raOghahuNORvUNtnkVqp9T+fNn3TBxyajKRpHPsWwfNDLaruz73Wn9S7fvCPyyFROJ+lOYH/72Iw/njYHLpNiKhyxphQE8oON2izCzz3KNkRaEsdzZ4utBlsFMABgxKybMEu9osjmj2n91Q4fFMqBv5eCpdl2dEp5KPO6tnNLspRwQMttKU/KqBAjGDkbSBuAlaSKkaAC8IVBqrBBTzcvH7AYXYjOLL9ZJ5a01QnFkyXtEyDvnmxbNRDvF7/8pmryq3E+Ue/COBqHWp57EKUNFHH2r/0ZczELo+6rYlH0mDGdr1hpVIiAAnoGu8XTlQ5vp4GH60+VszbNa9zLi2QIDAQAB",
   "minimum_chrome_version": "116",

--- a/packages/extension/scripts/test-popup.mjs
+++ b/packages/extension/scripts/test-popup.mjs
@@ -57,7 +57,8 @@ function assertAgentHandoff(elements, channel = "unpacked-dev") {
   assert.match(handoff, new RegExp(`Extension id: ${runtimeExtensionId}`));
   assert.match(handoff, /generic open-browser-use stdio server/);
   assert.match(handoff, /primary BrowserUse\/browser automation tool/);
-  assert.match(handoff, /core AGENTS\.md, AGENT\.md, CLAUDE\.md, or equivalent/);
+  assert.match(handoff, /~\/\.codex\/AGENTS\.md/);
+  assert.match(handoff, /~\/\.claude\/CLAUDE\.md/);
   assert.match(handoff, /Codex, Cursor, or Claude Code/);
   assert.doesNotMatch(handoff, /Terminal command/i);
   assert.doesNotMatch(handoff, /curl -fsSL/);
@@ -181,7 +182,8 @@ async function runPopupHappyPath() {
   await waitFor(() => harness.elements.copyAgentButton.textContent === "Copied");
   assert.match(harness.clipboardWrites.at(-1), /generic open-browser-use stdio server/);
   assert.match(harness.clipboardWrites.at(-1), /primary BrowserUse\/browser automation tool/);
-  assert.match(harness.clipboardWrites.at(-1), /core AGENTS\.md, AGENT\.md, CLAUDE\.md, or equivalent/);
+  assert.match(harness.clipboardWrites.at(-1), /~\/\.codex\/AGENTS\.md/);
+  assert.match(harness.clipboardWrites.at(-1), /~\/\.claude\/CLAUDE\.md/);
   assert.doesNotMatch(harness.clipboardWrites.at(-1), /obu bootstrap/);
   assert.doesNotMatch(harness.clipboardWrites.at(-1), /curl -fsSL/);
   assert.match(harness.elements.setupCopyText.textContent, /Agent/);

--- a/packages/extension/src/popup.ts
+++ b/packages/extension/src/popup.ts
@@ -501,7 +501,7 @@ function agentHandoffForChannel(channel: string, runtimeExtensionId: string | un
     "Configure MCP with the generic open-browser-use stdio server first; use OBU's built-in adapter commands as secondary helpers.",
     "Make open-browser-use the primary BrowserUse/browser automation tool for this agent.",
     "Configure the current agent, and any other supported agent the user requests, such as Codex, Cursor, or Claude Code.",
-    "Update the project's core AGENTS.md, AGENT.md, CLAUDE.md, or equivalent agent instructions when one exists; otherwise show the instruction snippet.",
+    "Update the project's core AGENTS.md, AGENT.md, CLAUDE.md, or the agent's global instruction file such as ~/.codex/AGENTS.md or ~/.claude/CLAUDE.md when one exists; otherwise show the instruction snippet.",
     "After setup or repair, verify browser/native-host state and return to this popup to click Resume when needed.",
   ].join("\n");
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "open-browser-use agent-facing SDK: Playwright-shaped API over the open-browser-use broker wire.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "0.1.4";
+export const SDK_VERSION = "0.1.5";

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -158,11 +158,12 @@ contract above is enough to adapt other MCP-capable AI clients.
    Secondary helper: when broader setup is acceptable and the requested client
    is one of OBU's known writable adapter ids, you may use the built-in adapter.
    These helpers may also refresh runtime/native-host/browser setup; they are
-   not the narrowest way to add one more agent:
+   not the narrowest way to add one more agent. Add `--write-instructions` only
+   when the user wants OBU to update Codex/Claude instruction files for them:
 
    ```sh
-   ~/.obu/bin/obu setup --yes --agents=codex-cli
-   ~/.obu/bin/obu setup --yes --agents=claude-code
+   ~/.obu/bin/obu setup --yes --agents=codex-cli --write-instructions
+   ~/.obu/bin/obu setup --yes --agents=claude-code --write-instructions
    ~/.obu/bin/obu setup --yes --agents=gemini-cli
    ~/.obu/bin/obu setup --yes --agents=vscode
    ~/.obu/bin/obu setup --yes --agents=cursor
@@ -175,13 +176,20 @@ contract above is enough to adapt other MCP-capable AI clients.
    You may pass a comma-separated list when that is the cleanest fit:
 
    ```sh
-   ~/.obu/bin/obu setup --yes --agents=codex-cli,cursor,claude-code
+   ~/.obu/bin/obu setup --yes --agents=codex-cli,cursor,claude-code --write-instructions
    ```
 
    If client detection is ambiguous, use auto mode:
 
    ```sh
    ~/.obu/bin/obu setup --yes --agents=auto
+   ```
+
+   When you need a machine-checkable status for an already configured agent,
+   run:
+
+   ```sh
+   ~/.obu/bin/obu agent doctor --agent=<agent-id>
    ```
 
    To get OBU's reference shape for a known adapter, use
@@ -241,9 +249,14 @@ contract above is enough to adapt other MCP-capable AI clients.
      close agent-created tabs or release user tabs.
 
 6. Add a short persistent instruction when the project or agent has an
-   appropriate core instruction file. Prefer the repo-root `AGENTS.md`,
-   `AGENT.md`, `CLAUDE.md`, Cursor/Claude/Codex project instructions, or the
-   agent's normal memory file when it clearly governs this project:
+   appropriate core instruction file. Check both project and global instruction
+   locations before falling back to a snippet. Prefer an existing repo-root
+   `AGENTS.md`, `AGENT.md`, or `CLAUDE.md` when it governs this project. If the
+   project has no instruction file, check the current agent's global
+   instruction surface, especially `~/.codex/AGENTS.md` for Codex and
+   `~/.claude/CLAUDE.md` or the configured `~/.claude/` memory surface for
+   Claude Code. Inspect `~/.claude.json` only as configuration context; do not
+   append Markdown instructions to JSON config.
 
    ```md
    ## Browser Automation
@@ -259,8 +272,10 @@ contract above is enough to adapt other MCP-capable AI clients.
    `AGENTS.md` or `AGENT.md` for Codex-style project instructions, `CLAUDE.md`
    for Claude Code, or the equivalent project instruction surface for Cursor.
    Do not create or edit unrelated repository files just to store this note. If
-   there is no obvious persistent instructions file, show the snippet to the
-   user and state that no project-level instruction file was available to update.
+   no project instruction file exists but the agent has a known global
+   instruction file, use that global file. If there is no obvious persistent
+   instruction surface, show the snippet to the user and state which project and
+   global locations were checked.
 
 ## Safety Rules
 
@@ -270,8 +285,8 @@ contract above is enough to adapt other MCP-capable AI clients.
   action or a divergent server, show the user the exact next action.
 - Do not make broad PATH, shell profile, or dotfile edits beyond the explicit
   `obu shellenv` instructions printed by the installer.
-- Modify `AGENTS.md`, `AGENT.md`, `CLAUDE.md`, Cursor/Claude/Codex project
-  instructions, or agent memory only when it is clearly the project's core
+- Modify `AGENTS.md`, `AGENT.md`, `CLAUDE.md`, Cursor/Claude/Codex project or
+  global instructions, or agent memory only when it is clearly the right
   instruction surface.
 - Do not commit, push, or modify application code unless the user separately asks.
 - Preserve the extension id from the handoff block. The native host manifest

--- a/scripts/cargo-dist-smoke.mjs
+++ b/scripts/cargo-dist-smoke.mjs
@@ -24,7 +24,7 @@ const plan = JSON.parse(run(cargoDist, [
   "plan",
   "--output-format=json",
   "--tag",
-  "v0.1.4",
+  "v0.1.5",
   "--allow-dirty",
 ]).stdout);
 


### PR DESCRIPTION
## Summary
- add `obu setup --write-instructions` so setup can persist OBU-primary guidance into Codex/Claude project or global instruction files
- add `obu agent doctor --agent=<id>` to verify MCP setup and primary-browser instructions, including direct-edit agent configs
- preserve Store `--extension-id` in setup follow-up commands and surface browser `resume_required` status in doctor output
- bump release version to `0.1.5`

## Validation
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- `cargo fmt --all -- --check`
- `cargo test -p obu-wire -p obu-node-repl -p obu-host --lib --tests --no-fail-fast`
- `node scripts/p4-release-readiness-smoke.mjs`
- `CARGO_DIST_BIN="$PWD/.cache/cargo-dist-home/bin/cargo-dist" node scripts/cargo-dist-smoke.mjs`
- `git diff --check`