### PR TITLE
[codex] Harden agent install readiness closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "obu-host"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "obu-node-repl"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "obu-wire"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for driving an installed browser profile without `--remote-debugging-port`.
 | `crates/obu-host` | Per-session broker daemon and browser backend dispatcher. |
 | `crates/obu-node-repl` | MCP JavaScript runtime with trusted SDK/native-pipe support. |
 | `packages/sdk` | Agent-facing TypeScript SDK. |
-| `packages/cli` | User-facing setup and diagnostics commands such as `obu doctor browser`. |
+| `packages/cli` | User-facing setup, readiness, and diagnostics commands such as `obu verify`. |
 | `packages/extension` | Chromium MV3 extension and dev native-host manifest writer. |
 | `docs/install.md` | Preview install, setup, and agent wiring guide. |
 
@@ -145,34 +145,37 @@ The scripted gate can also install/use that binary automatically:
 OBU_WEBEXT_E2E_AUTO_INSTALL=1 scripts/p3-webext-e2e.sh
 ```
 
-To diagnose browser/profile/extension/native-host setup and reconnect issues,
-build the CLI and run the browser doctor:
+To verify browser/profile/extension/native-host setup and reconnect state for a
+selected agent/browser pair, build the CLI and run `obu verify`:
 
 ```bash
 pnpm -C packages/cli build
-node packages/cli/dist/index.js doctor browser --browser chrome
-node packages/cli/dist/index.js doctor browser --browser chrome --json
-node packages/cli/dist/index.js doctor browser --browser chrome --repair
+node packages/cli/dist/index.js verify --agent=codex-cli --browser chrome
+node packages/cli/dist/index.js verify --agent=codex-cli --browser chrome --json
+node packages/cli/dist/index.js verify --repair --agent=codex-cli --browser chrome
 ```
 
-The human output includes repair hints for warnings and failures. The JSON
-output includes check details for automation, including runtime descriptor
-lifecycle diagnostics from `getInfo`; stale session reasons, compact
-deliverable tab summaries, and deliverable recovery hints are also summarized in
-the human report. A reachable
+`obu verify` returns one readiness result and one next action. Use
+`doctor browser` as a lower-level diagnostic when you need browser-only details.
+`verify --repair` delegates browser-side repair to `doctor browser`, refreshes
+agent MCP wiring for the selected agent, and then re-evaluates readiness for the
+same target.
+The browser doctor JSON output includes runtime descriptor lifecycle diagnostics
+from `getInfo`; stale session reasons, compact deliverable tab summaries, and
+deliverable recovery hints are also summarized in the human report. A reachable
 runtime descriptor is reported as `WARN`, not `PASS`, when host lifecycle
 diagnostics contain stale sessions, tabs, file chooser handles, or download
-handles. `--repair` performs conservative local repairs: it can regenerate an
-invalid native-host manifest through a wrapper script, create the runtime
-descriptor directory, and chmod descriptor directories/files back to owner-only
-modes. It can also remove stale WebExtension runtime descriptors whose recorded
-process is gone, whose socket path is clearly invalid, whose descriptor auth is
-rejected, or whose `getInfo` probe is inconsistent. When a live descriptor
-reports stale lifecycle diagnostics, `--repair` asks the host to clear those
-acknowledged stale diagnostic tombstones and then probes again.
+handles. Browser doctor repair performs conservative local repairs: it can
+regenerate an invalid native-host manifest through a wrapper script, create the
+runtime descriptor directory, and chmod descriptor directories/files back to
+owner-only modes. It can also remove stale WebExtension runtime descriptors
+whose recorded process is gone, whose socket path is clearly invalid, whose
+descriptor auth is rejected, or whose `getInfo` probe is inconsistent. When a
+live descriptor reports stale lifecycle diagnostics, repair asks the host to
+clear those acknowledged stale diagnostic tombstones and then probes again.
 Inside the SDK, `agent.browsers.diagnostics()` returns ignored runtime
 descriptor reasons surfaced by `obu-node-repl`, and no-backend errors include
-those reasons before pointing back to `obu doctor browser`. Durable tabs
+those reasons before pointing back to `obu verify`. Durable tabs
 finalized as deliverables can be inspected and reclaimed with
 `await browser.deliverables()` and each returned handle's `claim()` method.
 Acknowledged stale lifecycle diagnostics can also be cleared from host apps with

--- a/crates/obu-node-repl/src/mcp_server.rs
+++ b/crates/obu-node-repl/src/mcp_server.rs
@@ -126,7 +126,7 @@ static JS_OUTPUT_SCHEMA: LazyLock<Arc<rmcp::model::JsonObject>> = LazyLock::new(
 static BROWSER_STATUS_OUTPUT_SCHEMA: LazyLock<Arc<rmcp::model::JsonObject>> = LazyLock::new(|| {
     Arc::new(schema_object(json!({
         "type": "object",
-        "required": ["sdk_bootstrap", "backends", "diagnostics", "runtime_dir", "doctor_hint"],
+        "required": ["sdk_bootstrap", "backends", "diagnostics", "runtime_dir", "verify_hint", "doctor_hint"],
         "properties": {
             "sdk_bootstrap": {
                 "type": "string",
@@ -142,6 +142,9 @@ static BROWSER_STATUS_OUTPUT_SCHEMA: LazyLock<Arc<rmcp::model::JsonObject>> = La
                 "type": "array"
             },
             "runtime_dir": {
+                "type": "string"
+            },
+            "verify_hint": {
                 "type": "string"
             },
             "doctor_hint": {

--- a/crates/obu-node-repl/src/repl_manager/mod.rs
+++ b/crates/obu-node-repl/src/repl_manager/mod.rs
@@ -222,7 +222,7 @@ impl JsRuntimeManager {
         let inventory = self.backend_inventory();
         self.sync_backend_inventory_to_kernel(&inventory).await?;
         let (sdk_bootstrap, sdk_bootstrap_detail) = self.sdk_bootstrap_status();
-        let doctor_hint = if inventory.backends.is_empty() {
+        let verify_hint = if inventory.backends.is_empty() {
             "No browser backend discovered. Run `obu verify --repair --agent=<agent-id> --browser=<browser> --channel=<extension-channel> --extension-id=<extension-id>` with the exact extension channel/id from the popup handoff, then open the extension popup and click Resume if no runtime descriptor is active."
         } else {
             "obu verify --agent=<agent-id> --browser=<browser> --channel=<extension-channel> --extension-id=<extension-id>"
@@ -233,7 +233,8 @@ impl JsRuntimeManager {
             "backends": inventory.backends,
             "diagnostics": inventory.diagnostics,
             "runtime_dir": runtime_dir().to_string_lossy(),
-            "doctor_hint": doctor_hint,
+            "verify_hint": verify_hint,
+            "doctor_hint": verify_hint,
         }))
     }
 

--- a/crates/obu-node-repl/src/repl_manager/mod.rs
+++ b/crates/obu-node-repl/src/repl_manager/mod.rs
@@ -223,9 +223,9 @@ impl JsRuntimeManager {
         self.sync_backend_inventory_to_kernel(&inventory).await?;
         let (sdk_bootstrap, sdk_bootstrap_detail) = self.sdk_bootstrap_status();
         let doctor_hint = if inventory.backends.is_empty() {
-            "No browser backend discovered. Run `obu doctor browser --repair` with the exact extension channel/id from the popup handoff, then open the extension popup and click Resume if no runtime descriptor is active."
+            "No browser backend discovered. Run `obu verify --repair --agent=<agent-id> --browser=<browser> --channel=<extension-channel> --extension-id=<extension-id>` with the exact extension channel/id from the popup handoff, then open the extension popup and click Resume if no runtime descriptor is active."
         } else {
-            "obu doctor browser"
+            "obu verify --agent=<agent-id> --browser=<browser> --channel=<extension-channel> --extension-id=<extension-id>"
         };
         Ok(json!({
             "sdk_bootstrap": sdk_bootstrap,

--- a/crates/obu-node-repl/tests/discover_backends.rs
+++ b/crates/obu-node-repl/tests/discover_backends.rs
@@ -56,18 +56,10 @@ async fn browser_status_reports_missing_sdk_and_no_backend() {
 
     assert_eq!(status["sdk_bootstrap"], json!("missing"));
     assert_eq!(status["backends"], json!([]));
-    assert!(
-        status["doctor_hint"]
-            .as_str()
-            .unwrap()
-            .contains("obu verify --repair")
-    );
-    assert!(
-        status["doctor_hint"]
-            .as_str()
-            .unwrap()
-            .contains("exact extension channel/id")
-    );
+    let verify_hint = status["verify_hint"].as_str().unwrap();
+    assert!(verify_hint.contains("obu verify --repair"));
+    assert!(verify_hint.contains("exact extension channel/id"));
+    assert_eq!(status["doctor_hint"], status["verify_hint"]);
 }
 
 #[tokio::test]

--- a/crates/obu-node-repl/tests/discover_backends.rs
+++ b/crates/obu-node-repl/tests/discover_backends.rs
@@ -60,6 +60,12 @@ async fn browser_status_reports_missing_sdk_and_no_backend() {
         status["doctor_hint"]
             .as_str()
             .unwrap()
+            .contains("obu verify --repair")
+    );
+    assert!(
+        status["doctor_hint"]
+            .as_str()
+            .unwrap()
             .contains("exact extension channel/id")
     );
 }

--- a/crates/obu-node-repl/tests/mcp_stdio.rs
+++ b/crates/obu-node-repl/tests/mcp_stdio.rs
@@ -183,9 +183,10 @@ async fn mcp_stdio_lists_tools_and_executes_js() {
     let structured = &status["result"]["structuredContent"];
     let doctor_hint = structured["doctor_hint"].as_str().unwrap();
     if structured["backends"].as_array().unwrap().is_empty() {
+        assert!(doctor_hint.contains("obu verify --repair"));
         assert!(doctor_hint.contains("exact extension channel/id"));
     } else {
-        assert_eq!(doctor_hint, "obu doctor browser");
+        assert!(doctor_hint.contains("obu verify"));
     }
 
     send(

--- a/crates/obu-node-repl/tests/mcp_stdio.rs
+++ b/crates/obu-node-repl/tests/mcp_stdio.rs
@@ -181,12 +181,13 @@ async fn mcp_stdio_lists_tools_and_executes_js() {
     assert!(status["result"]["structuredContent"]["sdk_bootstrap"].is_string());
     assert!(status["result"]["structuredContent"]["backends"].is_array());
     let structured = &status["result"]["structuredContent"];
-    let doctor_hint = structured["doctor_hint"].as_str().unwrap();
+    let verify_hint = structured["verify_hint"].as_str().unwrap();
+    assert_eq!(structured["doctor_hint"], structured["verify_hint"]);
     if structured["backends"].as_array().unwrap().is_empty() {
-        assert!(doctor_hint.contains("obu verify --repair"));
-        assert!(doctor_hint.contains("exact extension channel/id"));
+        assert!(verify_hint.contains("obu verify --repair"));
+        assert!(verify_hint.contains("exact extension channel/id"));
     } else {
-        assert!(doctor_hint.contains("obu verify"));
+        assert!(verify_hint.contains("obu verify"));
     }
 
     send(

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -133,7 +133,7 @@ same evidence that produced the result.
 
 ## Verification Layers
 
-Readiness spans nine layers. `obu verify` must evaluate them in a stable order
+Readiness spans ten layers. `obu verify` must evaluate them in a stable order
 and report each layer in JSON.
 
 1. **CLI install state**
@@ -228,13 +228,23 @@ and report each layer in JSON.
      `obu setup` writes instruction files only when the user explicitly requests
      that mutation.
 
-Layers 1, 2, 8, and 9 are mostly file/config state. Layer 3 depends on
-browser profile discovery. Layer 4 depends on the resolved browser profile's
-extension preferences. Layers 5 and 6 depend on the selected browser's extension
-runtime activation. Layer 7 depends on packaged runtime dependencies, SDK
-bootstrap state, and backend discovery. The CLI can repair deterministic
-file/config state, but it cannot force the browser to keep an MV3 service worker
-alive.
+10. **Agent runtime state**
+    - Required only for `verificationTarget: "agent_runtime"`.
+    - The selected running agent process or session has reloaded the
+      `open-browser-use` MCP server.
+    - Agent-runtime status came through a trusted first-class hook for the
+      selected agent, not through a user-edited file or arbitrary command.
+    - The hook status is fresh, challenge-bound, target-bound, and reports at
+      least one usable backend with verified extension identity.
+
+Layers 1, 2, 8, and 9 are mostly file/config state. Layer 3 depends on browser
+profile discovery. Layer 4 depends on the resolved browser profile's extension
+preferences. Layers 5 and 6 depend on the selected browser's extension runtime
+activation. Layer 7 depends on packaged runtime dependencies, SDK bootstrap
+state, and backend discovery. Layer 10 depends on a trusted selected-agent
+runtime integration. The CLI can repair deterministic file/config state, but it
+cannot force the browser to keep an MV3 service worker alive or force an agent
+process to reload MCP tools.
 
 For CLI verification, extension runtime state is considered active when a
 runtime descriptor for the selected browser responds to `getInfo` and
@@ -285,18 +295,21 @@ Profile resolution order:
    return `needs_manual_action` with `nextAction.kind: "select_profile"`.
 5. If exactly one candidate profile contains the target extension id, resolve
    that profile and continue with extension enabled/runtime checks.
-6. If multiple candidate profiles contain the target extension id, sort them
-   deterministically, report all candidates in JSON, and record the first enabled
-   matching profile as `browser.profile.suggestedPath`. Do not treat that
-   suggestion as the resolved profile unless runtime evidence is `profile_verified`
-   for that same profile.
-7. If an explicit profile is supplied but does not contain the target extension
+6. If multiple candidate profiles contain the target extension id and runtime
+   evidence is `profile_verified`, resolve the verified profile.
+7. If multiple candidate profiles contain the target extension id and runtime
+   evidence is not `profile_verified`, sort them deterministically, report all
+   candidates in JSON, and record a non-authoritative
+   `browser.profile.suggestedPath`. Prefer the first enabled matching profile;
+   if none are enabled, use the first installed matching profile. Do not treat
+   that suggestion as the resolved profile.
+8. If an explicit profile is supplied but does not contain the target extension
    id, keep that profile path in JSON and return `needs_manual_action` with
    `nextAction.kind: "install_extension"`.
-8. If default discovery finds exactly one inspectable profile but it does not
+9. If default discovery finds exactly one inspectable profile but it does not
    contain the target extension id, resolve that profile and return
    `needs_manual_action` with `nextAction.kind: "install_extension"`.
-9. If default discovery finds multiple inspectable profiles but none contains the
+10. If default discovery finds multiple inspectable profiles but none contains the
    target extension id, report all candidates, record the deterministic first
    inspectable profile as `browser.profile.suggestedPath`, and return
    `needs_manual_action` with `nextAction.kind: "select_profile"`.
@@ -309,6 +322,26 @@ Default discovery must sort candidate profile directories deterministically:
 `Default` first, `Profile <number>` in numeric order, then all other profile
 directories lexicographically by absolute path. `readdir` order is not a product
 contract.
+
+Profile action derivation uses this matrix:
+
+| Default-discovered profile state | `browser.profile.path` | `browser.profile.suggestedPath` | Next action |
+| --- | --- | --- | --- |
+| `0` inspectable profiles | `null` | `null` | `select_profile` |
+| `1` inspectable profile, target extension missing | resolved profile | `null` | `install_extension` |
+| `N` inspectable profiles, target extension missing everywhere | `null` | first inspectable profile | `select_profile` |
+| `1` profile with target extension installed but disabled | resolved profile | `null` | `enable_extension` |
+| `N` profiles with target extension installed, none enabled | `null` | first installed matching profile | `select_profile` |
+| `N` profiles with target extension installed, one or more enabled, no `profile_verified` runtime proof | `null` | first enabled matching profile | `select_profile` |
+| `N` profiles with target extension installed and `profile_verified` runtime proof | verified profile | `null` | continue runtime readiness checks |
+
+The invariant is that `N` profile ambiguity returns `select_profile` unless
+runtime evidence identifies one verified profile. `install_extension` and
+`enable_extension` are emitted only after a single profile has been resolved.
+`browser.profile.path` and `browser.profile.suggestedPath` are mutually
+exclusive: when `browser.profile.path` is non-null,
+`browser.profile.suggestedPath` must be `null`. Diagnostic alternatives belong
+in `browser.profile.candidates[]`, not in `suggestedPath`.
 
 This requires a verify-specific profile resolver. Reusing lower-level browser
 doctor code is acceptable only if the resulting implementation supports explicit
@@ -325,8 +358,10 @@ The JSON response must include:
 - `browser.profile.suggestedPath`: string path or `null`; deterministic first
   profile OBU can suggest when default discovery is ambiguous. For multiple
   matching extensions this is the first enabled matching candidate. For multiple
-  inspectable profiles with no installed target extension this is the first
-  inspectable profile. It is not a resolved profile.
+  matching extensions with no enabled candidate this is the first installed
+  matching candidate. For multiple inspectable profiles with no installed target
+  extension this is the first inspectable profile. It is not a resolved profile
+  and must be `null` whenever `browser.profile.path` is non-null.
 - `browser.profile.source`: `explicit | default_discovery`
 - `browser.profile.candidates`: array of candidate objects with `path`,
   `profileExists`, `extensionInstalled`, `extensionEnabled`, and optional
@@ -340,7 +375,8 @@ profile cannot be inspected, both fields must be `not_checked` with
 `browser.reasons.extensionInstalled` and `browser.reasons.extensionEnabled`. If a
 resolved profile lacks the extension, `browser.extensionInstalled` must be
 `missing`, `browser.extensionEnabled` must be `not_checked`, and both fields must
-have browser-level reasons.
+have `browser.reasons.extensionInstalled` and
+`browser.reasons.extensionEnabled`.
 
 `browser.profile.runtimeBinding` values mean:
 
@@ -359,9 +395,10 @@ be `explicit`, `browser.profile.suggestedPath` must be `null`, and
 `browser.profile.candidates` must contain only that path with
 `profileExists: "missing"`, `extensionInstalled: "not_checked"`, and
 `extensionEnabled: "not_checked"`. The candidate must include
-`reasons.profileExists`, `reasons.extensionInstalled`, and
-`reasons.extensionEnabled` explaining that extension state cannot be inspected
-until the profile exists.
+`browser.profile.candidates[].reasons.profileExists`,
+`browser.profile.candidates[].reasons.extensionInstalled`, and
+`browser.profile.candidates[].reasons.extensionEnabled` explaining that extension
+state cannot be inspected until the profile exists.
 `nextAction.kind` must be `select_profile`.
 
 If an explicit profile path exists but cannot be inspected,
@@ -377,19 +414,23 @@ If an explicit profile is supplied and does not contain the target extension id,
 `browser.profile.source` must be `explicit`, `browser.profile.candidates` must
 contain only that path with `profileExists: "pass"`,
 `extensionInstalled: "missing"`, and `extensionEnabled: "not_checked"`. The
-candidate must include `reasons.extensionInstalled` and
-`reasons.extensionEnabled` explaining that enablement was not inspected because
-the extension is missing. Top-level `extensionInstalled` must be `missing`, and
-top-level `extensionEnabled` must be `not_checked`, with browser-level reasons
-for both fields. `nextAction.kind` must be `install_extension`.
+candidate must include
+`browser.profile.candidates[].reasons.extensionInstalled` and
+`browser.profile.candidates[].reasons.extensionEnabled` explaining that
+enablement was not inspected because the extension is missing. Top-level
+`extensionInstalled` must be `missing`, and top-level `extensionEnabled` must be
+`not_checked`, with `browser.reasons.extensionInstalled` and
+`browser.reasons.extensionEnabled`. `nextAction.kind` must be
+`install_extension`.
 
 If default discovery cannot find or inspect the selected browser profile root,
 `browser.profile.path` must be `null`, `browser.profile.source` must be
 `default_discovery`, `browser.profile.suggestedPath` must be `null`,
 `browser.profile.candidates` must be an empty array, `extensionInstalled` must be
-`not_checked`, `extensionEnabled` must be `not_checked`, browser-level reasons
-must explain that no profile can be inspected, and the blocking
-`browser_profile` check must include `reason: "profile_root_missing"`,
+`not_checked`, `extensionEnabled` must be `not_checked`,
+`browser.reasons.extensionInstalled` and `browser.reasons.extensionEnabled` must
+explain that no profile can be inspected, and the blocking `browser_profile`
+check must include `reason: "profile_root_missing"`,
 `reason: "profile_root_unreadable"`, or a more specific inspection failure
 reason. `nextAction.kind` must be `select_profile`.
 
@@ -398,8 +439,9 @@ not contain the target extension id, `browser.profile.path` must contain that
 profile path, `browser.profile.source` must be `default_discovery`,
 `browser.profile.suggestedPath` must be `null`, `browser.profile.candidates`
 must include that profile, `extensionInstalled` must be `missing`, and
-`extensionEnabled` must be `not_checked`, with browser-level reasons for both
-fields. `nextAction.kind` must be `install_extension`.
+`extensionEnabled` must be `not_checked`, with
+`browser.reasons.extensionInstalled` and `browser.reasons.extensionEnabled`.
+`nextAction.kind` must be `install_extension`.
 
 If default discovery finds multiple inspectable browser profiles but no
 candidate profile containing the target extension id, `browser.profile.path` must
@@ -407,20 +449,24 @@ be `null`, `browser.profile.source` must be `default_discovery`,
 `browser.profile.suggestedPath` must contain the deterministic first inspectable
 profile, `browser.profile.candidates` must include all inspected profile paths,
 `extensionInstalled` must be `not_checked`, `extensionEnabled` must be
-`not_checked`, browser-level reasons must explain that profile choice is
-ambiguous, and `nextAction.kind` must be `select_profile`. The human message
-should ask the user to choose the profile before installing the extension.
+`not_checked`, `browser.reasons.extensionInstalled` and
+`browser.reasons.extensionEnabled` must explain that profile choice is ambiguous,
+and `nextAction.kind` must be `select_profile`. The human message should ask the
+user to choose the profile before installing the extension.
 
 If default discovery finds multiple matching profiles and no profile-bound
 runtime proof is available, `browser.profile.path` must be `null`,
 `browser.profile.suggestedPath` must contain the deterministic first enabled
-matching profile, all candidates must be reported, and `nextAction.kind` must be
-`select_profile`.
+matching profile, or the deterministic first installed matching profile when no
+matching profile is enabled. All candidates must be reported, and
+`nextAction.kind` must be `select_profile`.
 
 If a matching extension is present but disabled in the resolved profile,
 `extensionInstalled` must be `pass`, `extensionEnabled` must be `disabled`, and
-the candidate or browser summary must include `reasons.extensionEnabled`.
-`nextAction.kind` must be `enable_extension`.
+the candidate must include
+`browser.profile.candidates[].reasons.extensionEnabled`. The browser summary
+must include `browser.reasons.extensionEnabled`. `nextAction.kind` must be
+`enable_extension`.
 
 When `--profile=<path>` is supplied, every generated rerun, repair, or follow-up
 command must preserve that exact `--profile` value. Default-discovery commands
@@ -552,13 +598,32 @@ obu verify --require-agent-runtime \
 
 This sets `verificationTarget: "agent_runtime"`. If OBU cannot obtain status
 from that agent process, the command must return a non-ready result with a
-single action such as restarting/reloading the agent or checking the agent's OBU
-MCP status from inside the client.
+single action such as restarting/reloading the agent or running the registered
+agent-runtime hook from inside the selected client.
 
 Agent-runtime proof must come from a first-class agent-runtime status hook, not
-from a direct OBU MCP probe. The hook payload is the selected agent process's raw
-`browser_status` structured content plus envelope fields for freshness,
-provenance, and target binding:
+from a direct OBU MCP probe and not from a user-supplied status file.
+
+A trusted hook is a compiled or registered OBU agent-adapter capability for the
+selected canonical agent id. It is not read from the agent's MCP config, project
+instructions, shell aliases, or a user-editable JSON path. A hook is trusted only
+when all of these are true:
+
+- OBU knows the hook implementation for the selected `agentId`.
+- The hook communicates with the selected running agent process or session
+  through a first-class transport such as `agent_connector`, `agent_owned_ipc`,
+  or `in_process_adapter`.
+- The hook receives the verification challenge and target from OBU, causes that
+  selected agent process to call `browser_status` through its configured
+  `open-browser-use` MCP server, and returns the resulting status envelope to
+  OBU through the same trusted transport.
+- The transport is not an arbitrary command from user config and is not a file
+  whose contents can be produced or edited outside the selected agent-runtime
+  hook.
+
+The hook payload is the selected agent process's raw `browser_status` structured
+content plus envelope fields for freshness, provenance, hook identity, trust
+transport, and target binding:
 
 ```json
 {
@@ -566,6 +631,10 @@ provenance, and target binding:
   "agentId": "codex-cli",
   "mcpServerName": "open-browser-use",
   "provenance": "agent_runtime_hook",
+  "hook": {
+    "id": "codex-cli-runtime-status",
+    "transport": "agent_connector"
+  },
   "generatedAt": "2026-05-19T12:34:56.000Z",
   "challenge": {
     "nonce": "verify-issued-random-nonce",
@@ -603,6 +672,10 @@ of these are true:
 - `provenance` is `agent_runtime_hook`, and the CLI can trust the transport or
   integration that supplied that provenance. A field in a user-edited file is not
   sufficient by itself.
+- `hook.id` names a registered OBU hook for `agentId`, and `hook.transport` is
+  one of the trusted transports for that hook. `hook.trusted` is derived by OBU
+  from registry and transport validation; it must not be accepted from the
+  payload.
 - `agentId`, `mcpServerName`, browser, channel, extension id, and explicit
   profile value match the verification target.
 - At least one WebExtension backend in the status payload has normalized
@@ -614,7 +687,23 @@ Raw `browser_status` output or a standalone status JSON without a fresh matching
 challenge is diagnostic evidence only; it must not produce
 `verificationTarget: "agent_runtime"` / `result: "ready"`.
 
-The initial user-mediated CLI surface for collecting this evidence is:
+When a trusted hook is available, the normal command is still:
+
+```bash
+obu verify --require-agent-runtime \
+  --agent=codex-cli \
+  --browser=chrome \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+OBU invokes the registered hook for `codex-cli`, validates the returned envelope,
+derives `agent.runtimeStatus.hook.trusted: true`, and reports
+`mcpRuntime.source: "agent_runtime"` only for trusted hook evidence.
+
+Some hooks may need a user-mediated in-agent collection step after CLI readiness
+passes. In that case OBU issues a challenge for the trusted hook, not for an
+arbitrary status file:
 
 ```bash
 obu verify --require-agent-runtime \
@@ -624,9 +713,42 @@ obu verify --require-agent-runtime \
   --channel=store \
   --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
 
-# The selected agent process calls browser_status through its configured OBU MCP
-# server and writes an envelope with the challenge nonce.
+# The selected agent runs the registered OBU agent-runtime hook for this
+# challenge. The hook calls browser_status through the selected agent's configured
+# OBU MCP server and returns the envelope through the trusted hook transport.
+```
 
+A later verification pass may reference the challenge, but readiness can become
+`ready` only when the registered hook supplies the matching envelope through its
+trusted transport. The `--agent-runtime-status-json` flag is not that mechanism.
+
+Trusted hook result retrieval uses the hook registry, not a user-provided status
+file. A registered hook may satisfy verification in either of these ways:
+
+- `invokeStatus(challenge, target)` returns the status envelope synchronously
+  through the trusted transport.
+- `readChallengeResult(challenge, target)` retrieves a result that the hook
+  previously delivered through the trusted transport into OBU-owned runtime
+  state. The state must be bound to the challenge nonce, selected `agentId`,
+  target browser/channel/extension/profile, hook id, and trusted transport. OBU
+  must ignore result files or handles that were not created by the registered
+  hook transport.
+
+The follow-up command for a user-mediated trusted hook collection is:
+
+```bash
+obu verify --require-agent-runtime \
+  --agent-runtime-challenge-json=/path/to/challenge.json \
+  --agent=codex-cli \
+  --browser=chrome \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+The file-based status surface is diagnostic only. It exists for development,
+tests, and support bundles:
+
+```bash
 obu verify --require-agent-runtime \
   --agent-runtime-challenge-json=/path/to/challenge.json \
   --agent-runtime-status-json=/path/to/status.json \
@@ -639,16 +761,16 @@ obu verify --require-agent-runtime \
 `--agent-runtime-status-json` is a file transport, not a trust mechanism. If the
 payload is only a user-supplied status file, verification must report
 `agent.runtimeStatus.provenance: "user_supplied_status_file"` and
-`mcpRuntime.source: "agent_runtime_status_file"`, then treat it as diagnostic or
-pending evidence. Only a trusted first-class hook can report
+`mcpRuntime.source: "agent_runtime_status_file"`, then treat it as diagnostic
+evidence only. Only a trusted first-class hook can report
 `agent.runtimeStatus.provenance: "agent_runtime_hook"` and
 `mcpRuntime.source: "agent_runtime"` to make `readiness.agentRuntime` ready.
 
-The first command is a challenge-issuance verification pass. If CLI-level
+The challenge-out command is a challenge-issuance verification pass. If CLI-level
 readiness is blocked, it returns the normal blocking result and may omit the
 challenge file. If CLI-level readiness is complete and the challenge file is
-written, but no valid agent-runtime status payload has been supplied yet, the
-command returns:
+written, but no valid trusted hook payload has been supplied yet, the command
+returns:
 
 - exit code `1`;
 - `result: "needs_manual_action"`;
@@ -658,12 +780,17 @@ command returns:
 - `agent.runtimeStatus.reason: "agent_runtime_challenge_issued"`;
 - `nextAction.kind: "collect_agent_runtime_status"`;
 - `nextAction.challenge.path`: the challenge JSON path.
+- `nextAction.trustedHook.id`: the hook that must collect the status.
 
 This is a pending agent-runtime proof state, not a failed local setup state.
 
 If `--require-agent-runtime` is set and no valid hook payload is supplied,
 `agent.runtimeStatus.status` must be `not_checked`,
 `readiness.agentRuntime` must be `blocked`, and the result must not be `ready`.
+The blocking check must use `checks[].layer: "agent_runtime"`,
+`blocks: ["agent_runtime"]`, and an `actionCandidate` for
+`collect_agent_runtime_status`, `restart_agent`, or `configure_agent` as
+appropriate.
 
 ### Explicit Repair
 
@@ -737,8 +864,23 @@ doctor verifies a different path.
 
 ## Result Precedence
 
-When multiple layers are non-ready, `obu verify` chooses the highest-priority
-result using this order:
+Result selection is dependency-gated before result priority is applied.
+
+First, `obu verify` resolves all CLI-level blockers. If any check with
+`blocks` containing `cli` is blocking, the selected result and `nextAction` must
+come only from CLI-blocking checks. This remains true even when
+`verificationTarget: "agent_runtime"` and agent-runtime evidence is missing.
+Agent-runtime actions are not actionable until CLI readiness is complete.
+
+Second, if `readiness.cli` is `ready` and
+`verificationTarget: "agent_runtime"`, `obu verify` evaluates
+agent-runtime blockers and chooses from checks with `blocks` containing
+`agent_runtime`.
+
+Third, if every required readiness level is `ready`, the result is `ready`.
+
+Within the eligible blocker set, `obu verify` chooses the highest-priority result
+using this order:
 
 1. `needs_manual_action`
 2. `needs_repair`
@@ -807,6 +949,9 @@ Examples:
 - Descriptor responds and agent MCP config is equivalent, but
   `--require-agent-runtime` cannot check the running agent:
   `needs_manual_action`.
+- CLI readiness passes and a trusted agent-runtime hook has issued a challenge
+  but has not returned status yet: `needs_manual_action` with
+  `collect_agent_runtime_status`.
 
 ## Next Action Contract
 
@@ -842,10 +987,30 @@ Result/action mapping:
 | Direct MCP runtime cannot start, SDK bootstrap is unavailable, or backend count is zero for a reason outside safe CLI repair after descriptor activation has been ruled out | `needs_manual_action` | `configure_agent` |
 | Agent MCP config is missing but cannot be safely written by OBU | `needs_manual_action` | `configure_agent` |
 | Existing agent MCP config for `open-browser-use` is divergent or unreadable | `needs_manual_action` | `resolve_config_conflict` |
-| CLI-level readiness passes and an agent-runtime challenge has been issued but no valid status payload is available yet | `needs_manual_action` | `collect_agent_runtime_status` |
+| CLI-level readiness passes and an agent-runtime challenge has been issued but no valid trusted hook payload is available yet | `needs_manual_action` | `collect_agent_runtime_status` |
 | CLI-level readiness passes but `verificationTarget: "agent_runtime"` cannot be proved until the client reloads | `needs_manual_action` | `restart_agent` |
 | Local setup is correct but no fresh runtime descriptor is active | `needs_browser_popup` | `open_popup` |
 | A syntactically valid platform, browser, or agent target is unsupported by this OBU build | `needs_manual_action` | `unsupported` |
+
+Action derivation sources:
+
+| Next action kind | Required source check layer | Required status | Required `blocks` | Candidate result |
+| --- | --- | --- | --- | --- |
+| `install_cli` | `cli_install` | `fail` | `["cli"]` | `needs_manual_action` |
+| `unsupported` | `target_support` | `fail` | `["cli"]` or `["agent_runtime"]` | `needs_manual_action` |
+| `resolve_config_conflict` | `agent_mcp` | `fail` | `["cli"]` | `needs_manual_action` |
+| `select_profile` | `browser_profile` | `fail` | `["cli"]` | `needs_manual_action` |
+| `install_extension` | `browser_extension` | `fail` | `["cli"]` | `needs_manual_action` |
+| `enable_extension` | `browser_extension` | `fail` | `["cli"]` | `needs_manual_action` |
+| `collect_agent_runtime_status` | `agent_runtime` | `not_checked` | `["agent_runtime"]` | `needs_manual_action` |
+| `restart_agent` | `agent_runtime` | `fail` | `["agent_runtime"]` | `needs_manual_action` |
+| `configure_agent` | `agent_mcp`, `mcp_runtime`, or `agent_runtime` | `fail` | `["cli"]` or `["agent_runtime"]` | `needs_manual_action` |
+| `run_repair` | first repairable blocking layer | `fail` | `["cli"]` | `needs_repair` |
+| `open_popup` | `extension_runtime`, `runtime_descriptor`, or `mcp_runtime` | `fail` | `["cli"]` | `needs_browser_popup` |
+
+If a selected `nextAction.kind` cannot be traced to one of these source checks,
+the implementation is missing a normalized check and must add that check instead
+of synthesizing the action in the aggregator.
 
 Each action must include:
 
@@ -918,7 +1083,8 @@ Allowed check status values:
 - `pass`: the check succeeded.
 - `warn`: the check is unsupported or non-blocking.
 - `fail`: the check blocks readiness.
-- `not_checked`: the check was intentionally skipped and the reason is present.
+- `not_checked`: the check was intentionally skipped or cannot complete from the
+  current process without external trusted evidence, and the reason is present.
 
 Every `not_checked` status object must include a non-empty `reason`. Component
 summary fields on `browser` or `browser.profile.candidates[]` with any value
@@ -946,6 +1112,33 @@ Allowed component state values for summary fields such as `profileExists`,
 - `invalid`: the component exists but has invalid shape or contents.
 - `not_checked`: the component was intentionally not checked and the reason is
   present on the containing object.
+
+`agent.runtimeStatus` uses this shape:
+
+```json
+{
+  "status": "pass",
+  "provenance": "agent_runtime_hook",
+  "hook": {
+    "id": "codex-cli-runtime-status",
+    "transport": "agent_connector",
+    "trusted": true
+  },
+  "generatedAt": "2026-05-19T12:34:56.000Z",
+  "targetBound": true,
+  "challengeBound": true
+}
+```
+
+Allowed `agent.runtimeStatus.status` values are `pass`, `fail`, and
+`not_checked`. `pass` is allowed only for trusted hook evidence that can promote
+`readiness.agentRuntime` to `ready`. Stale, unbound, user-supplied, or
+zero-backend payloads must use `fail` or `not_checked` with a non-empty `reason`.
+Allowed `agent.runtimeStatus.hook.transport` values are `agent_connector`,
+`agent_owned_ipc`, and `in_process_adapter`. `agent.runtimeStatus.hook.id` must
+exist in OBU's compiled trusted agent-runtime hook registry for the selected
+`agent.id`. `agent.runtimeStatus.hook.trusted` is an OBU-derived output field;
+payload-provided `trusted` values must be ignored.
 
 Instruction check warnings must use one of these reason values:
 
@@ -977,6 +1170,14 @@ result. Check objects use this shape:
   "blocks": [],
   "reason": "equivalent_config",
   "message": "codex-cli configures open-browser-use",
+  "target": {
+    "agent": "codex-cli"
+  },
+  "evidence": {
+    "scope": "cli",
+    "provenance": "expected_obu_invocation",
+    "source": "agent_config_read"
+  },
   "details": {
     "path": "/Users/alex/.codex/config.toml"
   }
@@ -987,6 +1188,14 @@ result. Check objects use this shape:
 `warn`, `fail`, and `not_checked` checks. Instruction warnings use
 `reason: "not_implemented"` or `reason: "missing_instruction"` on the check
 object, not a synthetic status value.
+
+Every check must include `target` and `evidence` objects. `target` identifies the
+agent, browser, channel, extension id, and profile path that the check applies
+to; fields that do not apply may be omitted. `evidence.scope` must be one of the
+evidence scopes defined above, `evidence.provenance` must be one of the evidence
+provenance values defined above, and `evidence.source` must name the concrete
+probe, hook, file, registry, or command class that produced the signal. Raw
+payloads still belong under `details.raw`.
 
 `blocks` is optional for pass checks and required for blocking checks. It is an
 array containing `cli`, `agent_runtime`, or both. Blocking checks should include
@@ -1012,6 +1221,7 @@ other context fields may be included when they are needed to construct the final
 
 Allowed `checks[].layer` values:
 
+- `target_support`
 - `cli_install`
 - `native_host`
 - `browser_profile`
@@ -1021,6 +1231,13 @@ Allowed `checks[].layer` values:
 - `agent_mcp`
 - `agent_instruction`
 - `mcp_runtime`
+- `agent_runtime`
+
+`target_support` is not a readiness layer. It is used only after command input is
+syntactically valid and OBU can run verification, but the requested platform,
+browser, agent, hook, or feature is outside this build's supported automation
+surface. Invalid command input still exits with code `2` and does not produce a
+normal readiness result.
 
 ```json
 {
@@ -1040,7 +1257,10 @@ Allowed `checks[].layer` values:
       "path": "/Users/alex/.codex/config.toml",
       "serverName": "open-browser-use",
       "command": "/Users/alex/.obu/bin/obu",
-      "args": ["mcp", "stdio"]
+      "args": [
+        "mcp",
+        "stdio"
+      ]
     },
     "instructions": {
       "status": "pass",
@@ -1112,56 +1332,147 @@ Allowed `checks[].layer` values:
       "id": "cli-version",
       "layer": "cli_install",
       "status": "pass",
-      "message": "obu version is parseable"
+      "message": "obu version is parseable",
+      "target": {},
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "cli_version"
+      }
     },
     {
       "id": "native-host-manifest",
       "layer": "native_host",
       "status": "pass",
-      "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/"
+      "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/",
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "native_host_manifest"
+      }
     },
     {
       "id": "browser-profile",
       "layer": "browser_profile",
       "status": "pass",
-      "message": "resolved one matching enabled Chrome profile"
+      "message": "resolved one matching enabled Chrome profile",
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "profile_discovery"
+      }
     },
     {
       "id": "browser-extension-installed",
       "layer": "browser_extension",
       "status": "pass",
-      "message": "extension is installed and enabled in the resolved profile"
+      "message": "extension is installed and enabled in the resolved profile",
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "profile_preferences"
+      }
     },
     {
       "id": "extension-runtime",
       "layer": "extension_runtime",
       "status": "pass",
       "message": "extension runtime inferred active from descriptor probe",
-      "details": { "source": "runtime_descriptor_probe" }
+      "details": {
+        "source": "runtime_descriptor_probe"
+      },
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "browser_extension",
+        "provenance": "runtime_descriptor_probe",
+        "source": "runtime_descriptor_probe"
+      }
     },
     {
       "id": "runtime-descriptor-probe",
       "layer": "runtime_descriptor",
       "status": "pass",
-      "message": "chrome.json responded to getInfo"
+      "message": "chrome.json responded to getInfo",
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "browser_extension",
+        "provenance": "runtime_descriptor_probe",
+        "source": "runtime_descriptor_probe"
+      }
     },
     {
       "id": "mcp-runtime-backend",
       "layer": "mcp_runtime",
       "status": "pass",
-      "message": "direct MCP probe found 1 usable backend"
+      "message": "direct MCP probe found 1 usable backend",
+      "target": {
+        "agent": "codex-cli",
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "direct_mcp_probe"
+      }
     },
     {
       "id": "agent-mcp-server",
       "layer": "agent_mcp",
       "status": "pass",
-      "message": "codex-cli configures open-browser-use"
+      "message": "codex-cli configures open-browser-use",
+      "target": {
+        "agent": "codex-cli"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "agent_config_read"
+      }
     },
     {
       "id": "agent-primary-instruction",
       "layer": "agent_instruction",
       "status": "pass",
-      "message": "primary browser instruction found"
+      "message": "primary browser instruction found",
+      "target": {
+        "agent": "codex-cli"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "agent_instruction_file"
+      }
     }
   ]
 }
@@ -1181,8 +1492,12 @@ Non-ready result:
   },
   "agent": {
     "id": "codex-cli",
-    "mcpConfig": { "status": "pass" },
-    "instructions": { "status": "pass" },
+    "mcpConfig": {
+      "status": "pass"
+    },
+    "instructions": {
+      "status": "pass"
+    },
     "runtimeStatus": {
       "status": "not_checked",
       "provenance": "not_applicable",
@@ -1242,78 +1557,177 @@ Non-ready result:
       "id": "cli-version",
       "layer": "cli_install",
       "status": "pass",
-      "message": "obu version is parseable"
+      "message": "obu version is parseable",
+      "target": {},
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "cli_version"
+      }
     },
     {
       "id": "native-host-manifest",
       "layer": "native_host",
       "status": "pass",
-      "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/"
+      "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/",
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "native_host_manifest"
+      }
     },
     {
       "id": "browser-profile",
       "layer": "browser_profile",
       "status": "pass",
-      "message": "resolved one matching enabled Chrome profile"
+      "message": "resolved one matching enabled Chrome profile",
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "profile_discovery"
+      }
     },
     {
       "id": "browser-extension-installed",
       "layer": "browser_extension",
       "status": "pass",
-      "message": "extension is installed and enabled in the resolved profile"
+      "message": "extension is installed and enabled in the resolved profile",
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "profile_preferences"
+      }
     },
     {
       "id": "extension-runtime",
       "layer": "extension_runtime",
       "status": "fail",
-      "blocks": ["cli"],
+      "blocks": [
+        "cli"
+      ],
       "reason": "runtime_descriptor_not_active",
       "message": "extension runtime is not active from CLI-observable evidence",
-      "details": { "source": "runtime_descriptor_probe" },
+      "details": {
+        "source": "runtime_descriptor_probe"
+      },
       "actionCandidate": {
         "kind": "open_popup",
         "priority": 1,
         "result": "needs_browser_popup"
+      },
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "browser_extension",
+        "provenance": "runtime_descriptor_probe",
+        "source": "runtime_descriptor_probe"
       }
     },
     {
       "id": "runtime-descriptor-probe",
       "layer": "runtime_descriptor",
       "status": "fail",
-      "blocks": ["cli"],
+      "blocks": [
+        "cli"
+      ],
       "reason": "descriptor_missing",
       "message": "no active WebExtension descriptor found",
-      "details": { "resumeRequired": true },
+      "details": {
+        "resumeRequired": true
+      },
       "actionCandidate": {
         "kind": "open_popup",
         "priority": 1,
         "result": "needs_browser_popup"
+      },
+      "target": {
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "browser_extension",
+        "provenance": "runtime_descriptor_probe",
+        "source": "runtime_descriptor_probe"
       }
     },
     {
       "id": "mcp-runtime-backend",
       "layer": "mcp_runtime",
       "status": "fail",
-      "blocks": ["cli"],
+      "blocks": [
+        "cli"
+      ],
       "reason": "zero_backends_after_popup_boundary",
       "message": "direct MCP probe found zero usable browser backends",
       "actionCandidate": {
         "kind": "open_popup",
         "priority": 1,
         "result": "needs_browser_popup"
+      },
+      "target": {
+        "agent": "codex-cli",
+        "browser": "chrome",
+        "channel": "store",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "direct_mcp_probe"
       }
     },
     {
       "id": "agent-mcp-server",
       "layer": "agent_mcp",
       "status": "pass",
-      "message": "codex-cli configures open-browser-use"
+      "message": "codex-cli configures open-browser-use",
+      "target": {
+        "agent": "codex-cli"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "agent_config_read"
+      }
     },
     {
       "id": "agent-primary-instruction",
       "layer": "agent_instruction",
       "status": "pass",
-      "message": "primary browser instruction found"
+      "message": "primary browser instruction found",
+      "target": {
+        "agent": "codex-cli"
+      },
+      "evidence": {
+        "scope": "cli",
+        "provenance": "expected_obu_invocation",
+        "source": "agent_instruction_file"
+      }
     }
   ]
 }
@@ -1490,7 +1904,11 @@ Required fields:
 `source: "agent_runtime"` means the status came from the selected agent process
 after it reloaded MCP tools. Only this source can make
 `readiness.agentRuntime` become `ready`; `probeCommandSource` must be
-`agent_runtime_hook` and `provenance` must be `agent_runtime_hook`.
+`agent_runtime_hook` and `provenance` must be `agent_runtime_hook`. The
+corresponding `agent.runtimeStatus` object must include the trusted hook id,
+transport, freshness, and target-binding result. Since OBU did not directly
+launch the MCP process in this mode, `mcpStarts` may be `null`; `sdkBootstrap`,
+`backendCount`, and `backends` are normalized from the trusted hook payload.
 
 `source: "direct_mcp_probe"` means OBU launched or probed the MCP server itself.
 It can prove CLI-level backend readiness, but it must not be treated as proof
@@ -1503,7 +1921,13 @@ that may contain challenge-bound agent-runtime evidence, but the transport itsel
 is not trusted agent-runtime provenance. It must use
 `provenance: "user_supplied_status_file"` and
 `probeCommandSource: "not_applicable"`, and it must not make
-`readiness.agentRuntime` ready.
+`readiness.agentRuntime` ready. Because this source is diagnostic-only,
+readiness summary fields must not be populated from the file payload:
+`mcpStarts` must be `null`, `sdkBootstrap` must be `not_checked`,
+`backendCount` must be `null`, and `backends` must be an empty array. The raw
+file payload may appear only under `details.raw` or
+`mcpRuntime.diagnostic.raw`; parsed diagnostic summaries, if any, must live under
+`mcpRuntime.diagnostic` and must not affect `readiness`.
 
 When `source: "direct_mcp_probe"` and the MCP process cannot start,
 `mcpStarts` must be `false`, `sdkBootstrap` must be `not_checked`,
@@ -1559,6 +1983,8 @@ The product is complete only when all of the following are true:
   `verificationTarget`, object-shaped `agent.runtimeStatus`, required
   `mcpRuntime.backends`, and non-empty `checks[]` evidence.
 - Human output gives one next action and no ambiguous action chain.
+- Result selection is dependency-gated: CLI-blocking checks determine the result
+  before any agent-runtime blocker can be selected.
 - `ready` is impossible when `mcpRuntime.backendCount` is zero or
   `mcpRuntime.sdkBootstrap` is not `available`.
 - `verificationTarget: "agent_runtime"` cannot return `ready` unless
@@ -1566,8 +1992,13 @@ The product is complete only when all of the following are true:
   challenge binding, target binding, `provenance: "agent_runtime_hook"`, trusted
   hook transport, and verified WebExtension extension identity matching
   `browser.extensionId`.
+- Agent-runtime readiness has a first-class `agent_runtime` check layer and a
+  trusted hook contract; user-supplied status files are never the trust boundary.
+- Trusted hook identity and trust are derived from OBU's hook registry and
+  trusted transport, not accepted from payload fields.
 - User-supplied agent-runtime status files without trusted hook provenance remain
-  diagnostic or pending evidence and cannot make agent-runtime readiness `ready`.
+  diagnostic evidence only and cannot make agent-runtime readiness `ready`. Their
+  payloads do not populate readiness summary fields.
 - WebExtension `backendCount` excludes metadata-less, `"unknown"`, wrong-browser,
   or wrong-extension backends; Store-channel readiness always requires exact
   extension id proof and JSON reports `browser.extensionIdSource`.
@@ -1588,6 +2019,9 @@ The product is complete only when all of the following are true:
   reasons.
 - Same-result-class failures choose `nextAction` from blocking checks'
   `actionCandidate` values by the deterministic priority table in this document.
+- Every allowed `nextAction.kind` is covered by the action derivation source
+  table.
+- Every check includes explicit `target` and `evidence` objects.
 - Agent-runtime challenge issuance has a defined `needs_manual_action` pending
   state with `nextAction.kind: "collect_agent_runtime_status"`.
 - Direct MCP probes never execute divergent or unreadable agent-config commands.

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -27,8 +27,10 @@ obu verify --agent=<agent-id> --browser=<browser> --channel=<channel> --extensio
 
 By default, `obu verify` answers CLI-level readiness for the selected agent's
 durable configuration and the selected browser backend. Agent-runtime readiness
-is a stronger target and must be requested or supplied by an agent-runtime status
-hook. The JSON always states which target was used.
+is a stronger target and must be requested explicitly, for example with
+`--require-agent-runtime`. Trusted agent-runtime hook evidence can satisfy that
+target, but it must not implicitly change the requested target. The JSON always
+states which target was used.
 
 It returns exactly one high-level result:
 
@@ -126,8 +128,11 @@ make `readiness.agentRuntime` ready. A user-supplied status file without trusted
 agent-runtime provenance must not be reported as `source: "agent_runtime"` and
 must not make `verificationTarget: "agent_runtime"` return `ready`.
 
-Every blocking check may emit an `actionCandidate`. The final `nextAction` is
-selected from blocking candidates by result class, action priority, then
+Every blocking check may emit an `actionCandidate`. Result selection is
+dependency-gated before priority is applied: CLI-blocking candidates are eligible
+first, and agent-runtime candidates are considered only after CLI readiness is
+ready and `verificationTarget` is `agent_runtime`. Within the eligible blocker
+set, the final `nextAction` is selected by result class, action priority, then
 verification layer order. This keeps one-next-action behavior derived from the
 same evidence that produced the result.
 
@@ -518,12 +523,20 @@ its MCP tools and its own OBU MCP status reports at least one usable backend.
 
 Required evidence:
 
-```json
-{
-  "sdk_bootstrap": "available",
-  "backends": [{ "...": "..." }]
-}
-```
+- CLI-level readiness is complete.
+- Status came from the selected running agent process through a trusted
+  first-class agent-runtime hook with `provenance: "agent_runtime_hook"`.
+- The hook transport is trusted for the selected agent, such as
+  `agent_connector`, `agent_owned_ipc`, or `in_process_adapter`.
+- The hook identity is registered for the selected canonical `agentId`, and
+  `hook.trusted` is derived by OBU from registry and transport validation rather
+  than accepted from payload fields.
+- The status envelope is fresh, challenge-bound, and target-bound to the selected
+  agent, MCP server name, browser, channel, extension id, and explicit profile
+  value when one was supplied.
+- The selected agent's MCP status reports `sdk_bootstrap: "available"` and at
+  least one usable WebExtension backend with verified extension identity matching
+  `browser.extensionId`.
 
 An MCP server with `backends: []` is not ready for browser automation. It only
 proves that the MCP process can start.
@@ -829,7 +842,12 @@ The default exit codes are:
 
 - `0`: `ready`
 - `1`: `needs_browser_popup`, `needs_repair`, or `needs_manual_action`
-- `2`: invalid command input or unsupported platform
+- `2`: invalid command input, unknown flags, malformed arguments, or platform
+  states that prevent verification from running
+
+Valid requests for targets that OBU can inspect but cannot automate still return
+exit code `1` with `result: "needs_manual_action"` and
+`nextAction.kind: "unsupported"`.
 
 ## Agent Identity Contract
 

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -2,11 +2,14 @@
 
 Date: 2026-05-19
 
-Status: target product contract / implementation plan. This document describes
-the intended `obu verify` behavior. Until `obu verify` is implemented and wired
-into setup output, existing `obu setup`, `obu doctor browser`, and
-`obu agent doctor` commands remain lower-level diagnostics rather than the
-canonical readiness surface described here.
+Status: the agent setup closure branch implements CLI-level `obu verify` as the
+canonical readiness surface. This document also records the stronger
+agent-runtime verification contract. The current build does not register trusted
+agent-runtime hooks, so `--require-agent-runtime` reports
+`agent_runtime_hook_unavailable` once CLI readiness is proved, and user-supplied
+status files remain diagnostic-only. Existing `obu setup`, `obu doctor browser`,
+and `obu agent doctor` commands remain mutating setup or lower-level diagnostics
+rather than the canonical readiness surface described here.
 
 ## Product Contract
 
@@ -19,7 +22,7 @@ user or agent stitching together partial signals from install logs,
 `obu setup`, `obu doctor browser`, `obu agent doctor`, MCP `browser_status`, and
 the extension popup.
 
-Once `obu verify` exists in a runnable OBU CLI, the canonical surface is:
+In a runnable OBU CLI, the canonical surface is:
 
 ```bash
 obu verify --agent=<agent-id> --browser=<browser> --channel=<channel> --extension-id=<id>
@@ -1995,8 +1998,8 @@ Setup requirements:
 - Write primary-browser instructions only when explicitly requested.
 - Include the final verification command in next actions.
 
-Once `obu verify` is implemented, final setup output should tell users to run
-`obu verify`, not ask them to interpret setup completion as browser readiness.
+Final setup output should tell users to run `obu verify`, not ask them to
+interpret setup completion as browser readiness.
 
 ## Doctor Contract
 
@@ -2195,9 +2198,8 @@ The product is complete only when all of the following are true:
 - Popup status distinguishes native-host connection from descriptor readiness.
 - Extension handoff text preserves exact Store extension id and tells agents to
   verify readiness through OBU.
-- When `obu verify` lands, popup handoff text and tests replace doctor retry
-  guidance with verify retry guidance while preserving the current fallback until
-  the command exists.
+- Popup handoff text and tests replace doctor retry guidance with verify retry
+  guidance while preserving doctor as a lower-level diagnostic fallback.
 - Clean-home smoke tests cover Codex, Cursor, Store extension id preservation,
   popup-required descriptor state, and divergent config conflicts.
 - Smoke or unit tests cover direct MCP runtime zero-backend results, SDK

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -508,10 +508,10 @@ Required evidence:
   `profile_runtime_not_bound` warning for explicit profile verification, or
   `single_candidate` for default discovery with exactly one matching profile.
 - `resumeRequired` is `false`.
-- Direct MCP runtime status has `mcpStarts: true`,
+- `mcpRuntime.cli` has `source: "direct_mcp_probe"`, `mcpStarts: true`,
   `sdkBootstrap: "available"`, and `backendCount > 0`.
-- At least one usable WebExtension backend in direct MCP status has normalized
-  extension identity matching the selected `browser.extensionId`.
+- At least one usable WebExtension backend in `mcpRuntime.cli.backends` has
+  normalized extension identity matching the selected `browser.extensionId`.
 - Agent MCP config is equivalent to the expected OBU server.
 - Agent instruction check is either `pass` or a non-blocking `warn` with
   `reason: "not_implemented"` or `reason: "missing_instruction"`.
@@ -534,9 +534,9 @@ Required evidence:
 - The status envelope is fresh, challenge-bound, and target-bound to the selected
   agent, MCP server name, browser, channel, extension id, and explicit profile
   value when one was supplied.
-- The selected agent's MCP status reports `sdk_bootstrap: "available"` and at
-  least one usable WebExtension backend with verified extension identity matching
-  `browser.extensionId`.
+- `mcpRuntime.agentRuntime` has `source: "agent_runtime"`,
+  `sdkBootstrap: "available"`, and at least one usable WebExtension backend with
+  verified extension identity matching `browser.extensionId`.
 
 An MCP server with `backends: []` is not ready for browser automation. It only
 proves that the MCP process can start.
@@ -712,7 +712,7 @@ obu verify --require-agent-runtime \
 
 OBU invokes the registered hook for `codex-cli`, validates the returned envelope,
 derives `agent.runtimeStatus.hook.trusted: true`, and reports
-`mcpRuntime.source: "agent_runtime"` only for trusted hook evidence.
+`mcpRuntime.agentRuntime.source: "agent_runtime"` only for trusted hook evidence.
 
 Some hooks may need a user-mediated in-agent collection step after CLI readiness
 passes. In that case OBU issues a challenge for the trusted hook, not for an
@@ -774,10 +774,11 @@ obu verify --require-agent-runtime \
 `--agent-runtime-status-json` is a file transport, not a trust mechanism. If the
 payload is only a user-supplied status file, verification must report
 `agent.runtimeStatus.provenance: "user_supplied_status_file"` and
-`mcpRuntime.source: "agent_runtime_status_file"`, then treat it as diagnostic
-evidence only. Only a trusted first-class hook can report
+`mcpRuntime.agentRuntime.source: "agent_runtime_status_file"`, then treat it as
+diagnostic evidence only. Only a trusted first-class hook can report
 `agent.runtimeStatus.provenance: "agent_runtime_hook"` and
-`mcpRuntime.source: "agent_runtime"` to make `readiness.agentRuntime` ready.
+`mcpRuntime.agentRuntime.source: "agent_runtime"` to make
+`readiness.agentRuntime` ready.
 
 The challenge-out command is a challenge-issuance verification pass. If CLI-level
 readiness is blocked, it returns the normal blocking result and may omit the
@@ -1131,7 +1132,11 @@ Allowed component state values for summary fields such as `profileExists`,
 - `not_checked`: the component was intentionally not checked and the reason is
   present on the containing object.
 
-`agent.runtimeStatus` uses this shape:
+`agent.runtimeStatus` is a discriminated object. Its shape depends on
+`provenance` and `reason`; diagnostic and pending states must be as stable as the
+trusted success state.
+
+Trusted hook success:
 
 ```json
 {
@@ -1157,6 +1162,56 @@ Allowed `agent.runtimeStatus.hook.transport` values are `agent_connector`,
 exist in OBU's compiled trusted agent-runtime hook registry for the selected
 `agent.id`. `agent.runtimeStatus.hook.trusted` is an OBU-derived output field;
 payload-provided `trusted` values must be ignored.
+
+Trusted hook failure keeps the trusted hook envelope but reports `status: "fail"`
+with a machine-readable `reason`, such as `stale_status`, `target_mismatch`,
+`challenge_mismatch`, `sdk_bootstrap_missing`, or `zero_backends`. It may include
+`targetBound` and `challengeBound` booleans because the transport itself is
+trusted.
+
+User-supplied status files are diagnostic only. They must not include a trusted
+hook object, and parsed challenge or target matches must stay under
+`diagnostic`; top-level `targetBound` and `challengeBound` are reserved for
+trusted hook evidence:
+
+```json
+{
+  "status": "not_checked",
+  "provenance": "user_supplied_status_file",
+  "reason": "diagnostic_status_file_not_trusted",
+  "diagnostic": {
+    "statusFile": "/path/to/status.json",
+    "targetBound": true,
+    "challengeBound": true
+  }
+}
+```
+
+Challenge issuance without a returned trusted hook payload is a pending
+agent-runtime proof state:
+
+```json
+{
+  "status": "not_checked",
+  "provenance": "not_applicable",
+  "reason": "agent_runtime_challenge_issued",
+  "trustedHook": {
+    "id": "codex-cli-runtime-status",
+    "transport": "agent_connector"
+  }
+}
+```
+
+CLI-target verification that did not request agent-runtime proof is explicitly
+not checked:
+
+```json
+{
+  "status": "not_checked",
+  "provenance": "not_applicable",
+  "reason": "verification_target_cli"
+}
+```
 
 Instruction check warnings must use one of these reason values:
 
@@ -1287,7 +1342,7 @@ normal readiness result.
     "runtimeStatus": {
       "status": "not_checked",
       "provenance": "not_applicable",
-      "reason": "target agent runtime is outside this CLI process"
+      "reason": "verification_target_cli"
     }
   },
   "browser": {
@@ -1321,28 +1376,40 @@ normal readiness result.
     }
   },
   "mcpRuntime": {
-    "source": "direct_mcp_probe",
-    "provenance": "expected_obu_invocation",
-    "probeCommandSource": "expected_obu_invocation",
-    "mcpConfigured": true,
-    "mcpStarts": true,
-    "sdkBootstrap": "available",
-    "backendCount": 1,
-    "backends": [
-      {
-        "type": "webextension",
-        "browser": "chrome",
-        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
-        "extensionIdentity": {
-          "source": "descriptor_metadata",
-          "verified": true
-        },
-        "metadata": {
-          "browserKind": "chrome",
-          "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj"
+    "cli": {
+      "source": "direct_mcp_probe",
+      "provenance": "expected_obu_invocation",
+      "probeCommandSource": "expected_obu_invocation",
+      "mcpConfigured": true,
+      "mcpStarts": true,
+      "sdkBootstrap": "available",
+      "backendCount": 1,
+      "backends": [
+        {
+          "type": "webextension",
+          "browser": "chrome",
+          "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+          "extensionIdentity": {
+            "source": "descriptor_metadata",
+            "verified": true
+          },
+          "metadata": {
+            "browserKind": "chrome",
+            "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj"
+          }
         }
-      }
-    ]
+      ]
+    },
+    "agentRuntime": {
+      "source": "not_checked",
+      "provenance": "not_applicable",
+      "probeCommandSource": "not_applicable",
+      "mcpConfigured": true,
+      "mcpStarts": null,
+      "sdkBootstrap": "not_checked",
+      "backendCount": null,
+      "backends": []
+    }
   },
   "nextAction": null,
   "checks": [
@@ -1491,6 +1558,21 @@ normal readiness result.
         "provenance": "expected_obu_invocation",
         "source": "agent_instruction_file"
       }
+    },
+    {
+      "id": "agent-runtime-status",
+      "layer": "agent_runtime",
+      "status": "not_checked",
+      "reason": "verification_target_cli",
+      "message": "agent-runtime status was not requested",
+      "target": {
+        "agent": "codex-cli"
+      },
+      "evidence": {
+        "scope": "agent_runtime",
+        "provenance": "not_applicable",
+        "source": "verification_target_cli"
+      }
     }
   ]
 }
@@ -1519,7 +1601,7 @@ Non-ready result:
     "runtimeStatus": {
       "status": "not_checked",
       "provenance": "not_applicable",
-      "reason": "target agent runtime is outside this CLI process"
+      "reason": "verification_target_cli"
     }
   },
   "browser": {
@@ -1551,14 +1633,26 @@ Non-ready result:
     "resumeRequired": true
   },
   "mcpRuntime": {
-    "source": "direct_mcp_probe",
-    "provenance": "expected_obu_invocation",
-    "probeCommandSource": "expected_obu_invocation",
-    "mcpConfigured": true,
-    "mcpStarts": true,
-    "sdkBootstrap": "available",
-    "backendCount": 0,
-    "backends": []
+    "cli": {
+      "source": "direct_mcp_probe",
+      "provenance": "expected_obu_invocation",
+      "probeCommandSource": "expected_obu_invocation",
+      "mcpConfigured": true,
+      "mcpStarts": true,
+      "sdkBootstrap": "available",
+      "backendCount": 0,
+      "backends": []
+    },
+    "agentRuntime": {
+      "source": "not_checked",
+      "provenance": "not_applicable",
+      "probeCommandSource": "not_applicable",
+      "mcpConfigured": true,
+      "mcpStarts": null,
+      "sdkBootstrap": "not_checked",
+      "backendCount": null,
+      "backends": []
+    }
   },
   "nextAction": {
     "kind": "open_popup",
@@ -1746,6 +1840,21 @@ Non-ready result:
         "provenance": "expected_obu_invocation",
         "source": "agent_instruction_file"
       }
+    },
+    {
+      "id": "agent-runtime-status",
+      "layer": "agent_runtime",
+      "status": "not_checked",
+      "reason": "verification_target_cli",
+      "message": "agent-runtime status was not requested",
+      "target": {
+        "agent": "codex-cli"
+      },
+      "evidence": {
+        "scope": "agent_runtime",
+        "provenance": "not_applicable",
+        "source": "verification_target_cli"
+      }
     }
   ]
 }
@@ -1899,9 +2008,12 @@ those checks into one product result.
 
 ## MCP Runtime Contract
 
-MCP status is split into server availability and browser backend availability.
+MCP runtime JSON is split by trust boundary. `mcpRuntime.cli` records direct
+OBU-owned MCP probing for CLI readiness. `mcpRuntime.agentRuntime` records the
+selected running agent process's MCP status when a trusted hook is available, or
+an explicit diagnostic/not-checked state when it is not.
 
-Required fields:
+Both summaries use the same normalized fields:
 
 - `source`: `agent_runtime | agent_runtime_status_file | direct_mcp_probe |
   not_checked`.
@@ -1919,8 +2031,19 @@ Required fields:
   `extensionIdentity`. A WebExtension backend without verified extension identity
   cannot contribute to `backendCount` for extension-scoped readiness.
 
-`source: "agent_runtime"` means the status came from the selected agent process
-after it reloaded MCP tools. Only this source can make
+`mcpRuntime.cli.source` may be only `direct_mcp_probe` or `not_checked`.
+`mcpRuntime.agentRuntime.source` may be only `agent_runtime`,
+`agent_runtime_status_file`, or `not_checked`.
+
+For `verificationTarget: "cli"`, `mcpRuntime.agentRuntime.source` is normally
+`not_checked`; the agent-runtime layer still appears in `checks[]` as a
+non-blocking `not_checked` check. For `verificationTarget: "agent_runtime"`, a
+ready result requires both `mcpRuntime.cli` and `mcpRuntime.agentRuntime` to have
+`sdkBootstrap: "available"` and `backendCount > 0`, each from its own trust
+boundary.
+
+`mcpRuntime.agentRuntime.source: "agent_runtime"` means the status came from the
+selected agent process after it reloaded MCP tools. Only this source can make
 `readiness.agentRuntime` become `ready`; `probeCommandSource` must be
 `agent_runtime_hook` and `provenance` must be `agent_runtime_hook`. The
 corresponding `agent.runtimeStatus` object must include the trusted hook id,
@@ -1928,26 +2051,27 @@ transport, freshness, and target-binding result. Since OBU did not directly
 launch the MCP process in this mode, `mcpStarts` may be `null`; `sdkBootstrap`,
 `backendCount`, and `backends` are normalized from the trusted hook payload.
 
-`source: "direct_mcp_probe"` means OBU launched or probed the MCP server itself.
-It can prove CLI-level backend readiness, but it must not be treated as proof
-that the selected agent process has reloaded MCP tools. The command must be the
-expected OBU MCP invocation for the current layout, not a command copied from a
-divergent agent config. `provenance` must be `expected_obu_invocation`.
+`mcpRuntime.cli.source: "direct_mcp_probe"` means OBU launched or probed the MCP
+server itself. It can prove CLI-level backend readiness, but it must not be
+treated as proof that the selected agent process has reloaded MCP tools. The
+command must be the expected OBU MCP invocation for the current layout, not a
+command copied from a divergent agent config. `provenance` must be
+`expected_obu_invocation`.
 
-`source: "agent_runtime_status_file"` means OBU read a user-supplied status file
-that may contain challenge-bound agent-runtime evidence, but the transport itself
-is not trusted agent-runtime provenance. It must use
-`provenance: "user_supplied_status_file"` and
+`mcpRuntime.agentRuntime.source: "agent_runtime_status_file"` means OBU read a
+user-supplied status file that may contain challenge-bound agent-runtime
+evidence, but the transport itself is not trusted agent-runtime provenance. It
+must use `provenance: "user_supplied_status_file"` and
 `probeCommandSource: "not_applicable"`, and it must not make
-`readiness.agentRuntime` ready. Because this source is diagnostic-only,
-readiness summary fields must not be populated from the file payload:
-`mcpStarts` must be `null`, `sdkBootstrap` must be `not_checked`,
-`backendCount` must be `null`, and `backends` must be an empty array. The raw
-file payload may appear only under `details.raw` or
-`mcpRuntime.diagnostic.raw`; parsed diagnostic summaries, if any, must live under
-`mcpRuntime.diagnostic` and must not affect `readiness`.
+`readiness.agentRuntime` ready. Because this source is diagnostic-only, readiness
+summary fields must not be populated from the file payload: `mcpStarts` must be
+`null`, `sdkBootstrap` must be `not_checked`, `backendCount` must be `null`, and
+`backends` must be an empty array. The raw file payload may appear only under
+`details.raw` or `mcpRuntime.agentRuntime.diagnostic.raw`; parsed diagnostic
+summaries, if any, must live under `mcpRuntime.agentRuntime.diagnostic` and must
+not affect `readiness`.
 
-When `source: "direct_mcp_probe"` and the MCP process cannot start,
+When `mcpRuntime.cli.source: "direct_mcp_probe"` and the MCP process cannot start,
 `mcpStarts` must be `false`, `sdkBootstrap` must be `not_checked`,
 `backendCount` must be `null`, `backends` must be an empty array, and the
 blocking check must include launch error details. If the MCP process starts but
@@ -1955,10 +2079,10 @@ blocking check must include launch error details. If the MCP process starts but
 be `not_checked`, `backendCount` must be `null`, and `backends` must be an empty
 array.
 
-`source: "not_checked"` means MCP runtime status was not probed. In that case
-`provenance` and `probeCommandSource` must be `not_applicable`, `mcpStarts` must
-be `null`, `sdkBootstrap` must be `not_checked`, `backendCount` must be `null`,
-and `backends` must be an empty array.
+`source: "not_checked"` means that summary's MCP runtime status was not probed.
+In that case `provenance` and `probeCommandSource` must be `not_applicable`,
+`mcpStarts` must be `null`, `sdkBootstrap` must be `not_checked`, `backendCount`
+must be `null`, and `backends` must be an empty array.
 
 `backendCount: 0` means not ready for browser automation even if
 `sdkBootstrap: "available"`.
@@ -1999,12 +2123,15 @@ The product is complete only when all of the following are true:
 - One command, `obu verify`, returns the canonical readiness result.
 - JSON output has the stable schema described above, including
   `verificationTarget`, object-shaped `agent.runtimeStatus`, required
-  `mcpRuntime.backends`, and non-empty `checks[]` evidence.
+  `mcpRuntime.cli.backends`, `mcpRuntime.agentRuntime.backends`, and non-empty
+  `checks[]` evidence.
 - Human output gives one next action and no ambiguous action chain.
 - Result selection is dependency-gated: CLI-blocking checks determine the result
   before any agent-runtime blocker can be selected.
-- `ready` is impossible when `mcpRuntime.backendCount` is zero or
-  `mcpRuntime.sdkBootstrap` is not `available`.
+- `ready` is impossible when a required runtime summary has `backendCount` zero
+  or `sdkBootstrap` not `available`: CLI readiness requires
+  `mcpRuntime.cli`, and agent-runtime readiness requires both `mcpRuntime.cli`
+  and `mcpRuntime.agentRuntime`.
 - `verificationTarget: "agent_runtime"` cannot return `ready` unless
   `readiness.agentRuntime` is `ready`, and agent-runtime evidence has fresh
   challenge binding, target binding, `provenance: "agent_runtime_hook"`, trusted

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -38,8 +38,8 @@ It returns exactly one high-level result:
   descriptor and a direct OBU MCP runtime status with at least one usable
   backend. For `verificationTarget: "agent_runtime"`, the selected agent
   runtime has also proved at least one usable backend through OBU MCP status.
-- `needs_browser_popup`: local setup is correct, but Chrome has not activated
-  the extension/native-host runtime descriptor yet.
+- `needs_browser_popup`: local setup is correct, but the selected Chromium-family
+  browser has not activated the extension/native-host runtime descriptor yet.
 - `needs_repair`: OBU found a deterministic repair it can apply with an
   explicit repair command.
 - `needs_manual_action`: the remaining action is outside safe CLI control.
@@ -69,7 +69,7 @@ Clean-install feedback exposed state mismatches across the setup flow:
   adapter ids such as `codex-cli`, `claude-code`, and `gemini-cli`.
 - `setup --agents=auto` can configure one path while `agent doctor` checks a
   different path.
-- Browser pairing can be repaired on disk while Chrome has not activated the
+- Browser pairing can be repaired on disk while the browser has not activated the
   WebExtension runtime descriptor.
 - MCP server availability and browser backend availability are separate states,
   but agents often treat them as one status.
@@ -79,6 +79,57 @@ Clean-install feedback exposed state mismatches across the setup flow:
 
 State closure means OBU turns these partial facts into one truthful result and
 one precise next action.
+
+## Verification Evidence Model
+
+`obu verify` is a normalization surface before it is a formatter. Each lower
+level signal must be converted into a check that states:
+
+- the target it applies to: agent, browser, channel, extension id, and profile
+  when profile-scoped;
+- the evidence source and provenance;
+- the scope that evidence can prove;
+- whether the check blocks CLI readiness, agent-runtime readiness, or neither;
+- the candidate next action if the check blocks readiness.
+
+The product result must never promote evidence beyond the scope it actually
+proves.
+
+Evidence scopes:
+
+- `cli`: local OBU files, selected agent durable config, selected browser
+  configuration, runtime descriptor probes, and direct OBU MCP probes.
+- `browser_extension`: a live WebExtension backend proves only the selected
+  browser and extension id unless profile identity is also present.
+- `profile`: descriptor metadata or a direct popup/native-host status source
+  identifies the resolved browser profile.
+- `agent_runtime`: the selected running agent process has reloaded the
+  `open-browser-use` MCP server and reports a usable backend through a trusted
+  first-class agent-runtime hook.
+
+Evidence provenance:
+
+- `runtime_descriptor_probe`: OBU probed a local runtime descriptor directly.
+- `expected_obu_invocation`: OBU launched or probed the expected OBU MCP
+  invocation for the current runtime layout.
+- `agent_runtime_hook`: a trusted first-class integration with the selected
+  running agent process supplied the status.
+- `user_supplied_status_file`: a local file was supplied by the user or an
+  agent-mediated workflow. A challenge-bound file can be useful diagnostic
+  evidence, but by itself it does not prove that the selected running agent
+  process produced the payload.
+- `not_applicable`: no runtime evidence was collected for that field.
+
+Only evidence with sufficient scope and provenance can advance the corresponding
+readiness field. A direct MCP probe can make `readiness.cli` ready but cannot
+make `readiness.agentRuntime` ready. A user-supplied status file without trusted
+agent-runtime provenance must not be reported as `source: "agent_runtime"` and
+must not make `verificationTarget: "agent_runtime"` return `ready`.
+
+Every blocking check may emit an `actionCandidate`. The final `nextAction` is
+selected from blocking candidates by result class, action priority, then
+verification layer order. This keeps one-next-action behavior derived from the
+same evidence that produced the result.
 
 ## Verification Layers
 
@@ -113,7 +164,7 @@ and report each layer in JSON.
    - The extension channel and id match the verification target.
 
 5. **Extension runtime state**
-   - Chrome has activated the extension runtime.
+   - The selected Chromium-family browser has activated the extension runtime.
    - The extension has connected to native messaging.
    - The popup can expose this as native-host connection state.
    - The CLI must report the evidence source. Outside the popup, runtime
@@ -156,13 +207,13 @@ and report each layer in JSON.
      invocation for the current runtime layout. For a packaged install this is
      normally:
 
-     ```json
-     {
-       "name": "open-browser-use",
-       "command": "/absolute/path/to/obu",
-       "args": ["mcp", "stdio"]
-     }
-     ```
+   ```json
+   {
+     "name": "open-browser-use",
+     "command": "/absolute/path/to/obu",
+     "args": ["mcp", "stdio"]
+   }
+   ```
 
      Repo or development layouts may be equivalent through `process.execPath`
      plus the CLI entrypoint and `["mcp", "stdio"]`. JSON must report the
@@ -179,10 +230,11 @@ and report each layer in JSON.
 
 Layers 1, 2, 8, and 9 are mostly file/config state. Layer 3 depends on
 browser profile discovery. Layer 4 depends on the resolved browser profile's
-extension preferences. Layers 5 and 6 depend on Chrome extension runtime
-activation. Layer 7 depends on packaged runtime dependencies, SDK bootstrap
-state, and backend discovery. The CLI can repair deterministic file/config
-state, but it cannot force Chrome to keep an MV3 service worker alive.
+extension preferences. Layers 5 and 6 depend on the selected browser's extension
+runtime activation. Layer 7 depends on packaged runtime dependencies, SDK
+bootstrap state, and backend discovery. The CLI can repair deterministic
+file/config state, but it cannot force the browser to keep an MV3 service worker
+alive.
 
 For CLI verification, extension runtime state is considered active when a
 runtime descriptor for the selected browser responds to `getInfo` and
@@ -212,6 +264,8 @@ For profile-scoped verification, runtime proof is explicit:
   `nextAction.kind: "select_profile"`. Supplying an explicit `--profile` is one
   way to resolve the ambiguity, but the resulting runtime proof may still be
   browser/extension-scoped unless a future profile identity source exists.
+  Deterministic sorting may produce a suggested profile, but suggestion is not
+  resolution.
 - `single_candidate` is only acceptable for CLI readiness when default discovery
   found exactly one matching enabled extension profile.
 
@@ -223,21 +277,29 @@ Profile resolution order:
 
 1. If `--profile=<path>` is supplied, verify only that profile.
 2. If the explicit profile path does not exist or cannot be inspected, keep that
-   profile path in JSON and return `needs_manual_action` with
-   `nextAction.kind: "select_profile"`.
+   profile path in JSON, distinguish `missing` from `unreadable`, and return
+   `needs_manual_action` with `nextAction.kind: "select_profile"`.
 3. If no profile is supplied, use the same default profile discovery as
    `obu doctor browser` for the selected browser.
 4. If default discovery cannot find a profile root for the selected browser,
    return `needs_manual_action` with `nextAction.kind: "select_profile"`.
-5. If multiple candidate profiles contain the target extension id, choose the
-   first profile with an enabled matching extension after deterministic sorting,
-   and report all candidates in JSON.
-6. If an explicit profile is supplied but does not contain the target extension
+5. If exactly one candidate profile contains the target extension id, resolve
+   that profile and continue with extension enabled/runtime checks.
+6. If multiple candidate profiles contain the target extension id, sort them
+   deterministically, report all candidates in JSON, and record the first enabled
+   matching profile as `browser.profile.suggestedPath`. Do not treat that
+   suggestion as the resolved profile unless runtime evidence is `profile_verified`
+   for that same profile.
+7. If an explicit profile is supplied but does not contain the target extension
    id, keep that profile path in JSON and return `needs_manual_action` with
    `nextAction.kind: "install_extension"`.
-7. If default discovery finds profiles for the browser but no candidate contains
-   the target extension id, return `needs_manual_action` with
-   `nextAction.kind: "install_extension"`.
+8. If default discovery finds exactly one inspectable profile but it does not
+   contain the target extension id, resolve that profile and return
+   `needs_manual_action` with `nextAction.kind: "install_extension"`.
+9. If default discovery finds multiple inspectable profiles but none contains the
+   target extension id, report all candidates, record the deterministic first
+   inspectable profile as `browser.profile.suggestedPath`, and return
+   `needs_manual_action` with `nextAction.kind: "select_profile"`.
 
 Profile existence and extension installation are separate states. Do not tell a
 user to install the extension into a profile that OBU could not find or inspect;
@@ -255,13 +317,30 @@ extension state, and preservation of profile context in follow-up commands.
 
 The JSON response must include:
 
-- `browser.profile.path`: string path or `null`
+- `browser.profile.path`: selected/resolved profile path or `null`. It is the
+  explicit profile, the only matching default-discovered profile, the only
+  inspectable default-discovered profile when the next action is to install the
+  extension there, or a profile-verified runtime target. It must be `null` when
+  default discovery is ambiguous and runtime evidence is not profile-bound.
+- `browser.profile.suggestedPath`: string path or `null`; deterministic first
+  profile OBU can suggest when default discovery is ambiguous. For multiple
+  matching extensions this is the first enabled matching candidate. For multiple
+  inspectable profiles with no installed target extension this is the first
+  inspectable profile. It is not a resolved profile.
 - `browser.profile.source`: `explicit | default_discovery`
 - `browser.profile.candidates`: array of candidate objects with `path`,
   `profileExists`, `extensionInstalled`, `extensionEnabled`, and optional
-  `reasons` keyed by those field names when any candidate field is `not_checked`
+  `reasons` keyed by those field names when any candidate field is not `pass`
 - `browser.profile.runtimeBinding`: `profile_verified | single_candidate |
   browser_extension_scope | not_available`
+
+Top-level `browser.extensionInstalled` and `browser.extensionEnabled` summarize
+the selected/resolved profile only. If no profile is resolved, or if the selected
+profile cannot be inspected, both fields must be `not_checked` with
+`browser.reasons.extensionInstalled` and `browser.reasons.extensionEnabled`. If a
+resolved profile lacks the extension, `browser.extensionInstalled` must be
+`missing`, `browser.extensionEnabled` must be `not_checked`, and both fields must
+have browser-level reasons.
 
 `browser.profile.runtimeBinding` values mean:
 
@@ -274,41 +353,73 @@ The JSON response must include:
   extension id. Human output must not describe this as profile-bound readiness.
 - `not_available`: no runtime descriptor or status source is available.
 
-If an explicit profile is supplied and the path does not exist or cannot be
-inspected, `browser.profile.path` must keep the explicit path,
-`browser.profile.source` must be `explicit`, `browser.profile.candidates` must
-contain only that path with `profileExists: "missing"`,
-`extensionInstalled: "not_checked"`, and `extensionEnabled: "not_checked"`.
-The candidate must include `reasons.extensionInstalled` and
+If an explicit profile is supplied and the path does not exist,
+`browser.profile.path` must keep the explicit path, `browser.profile.source` must
+be `explicit`, `browser.profile.suggestedPath` must be `null`, and
+`browser.profile.candidates` must contain only that path with
+`profileExists: "missing"`, `extensionInstalled: "not_checked"`, and
+`extensionEnabled: "not_checked"`. The candidate must include
+`reasons.profileExists`, `reasons.extensionInstalled`, and
 `reasons.extensionEnabled` explaining that extension state cannot be inspected
-until the profile exists. `nextAction.kind` must be `select_profile`.
+until the profile exists.
+`nextAction.kind` must be `select_profile`.
+
+If an explicit profile path exists but cannot be inspected,
+`browser.profile.path` must keep the explicit path and the candidate must use
+`profileExists: "unreadable"`, with `extensionInstalled: "not_checked"` and
+`extensionEnabled: "not_checked"` plus per-field reasons for all three fields.
+The blocking `browser_profile` check must include a specific reason such as
+`profile_unreadable` or `profile_preferences_unreadable`. `nextAction.kind` must
+be `select_profile`.
 
 If an explicit profile is supplied and does not contain the target extension id,
 `browser.profile.path` must keep the explicit path,
 `browser.profile.source` must be `explicit`, `browser.profile.candidates` must
 contain only that path with `profileExists: "pass"`,
 `extensionInstalled: "missing"`, and `extensionEnabled: "not_checked"`. The
-candidate must include `reasons.extensionEnabled` explaining that enablement was
-not inspected because the extension is missing. Top-level `extensionInstalled`
-must be `missing`, and `nextAction.kind` must be
-`install_extension`.
+candidate must include `reasons.extensionInstalled` and
+`reasons.extensionEnabled` explaining that enablement was not inspected because
+the extension is missing. Top-level `extensionInstalled` must be `missing`, and
+top-level `extensionEnabled` must be `not_checked`, with browser-level reasons
+for both fields. `nextAction.kind` must be `install_extension`.
 
 If default discovery cannot find or inspect the selected browser profile root,
 `browser.profile.path` must be `null`, `browser.profile.source` must be
-`default_discovery`, `browser.profile.candidates` must be an empty array,
-`extensionInstalled` must be `not_checked`, and the blocking
-`browser_profile` check must include `reason: "profile_root_missing"` or a more
-specific inspection failure reason. `nextAction.kind` must be `select_profile`.
+`default_discovery`, `browser.profile.suggestedPath` must be `null`,
+`browser.profile.candidates` must be an empty array, `extensionInstalled` must be
+`not_checked`, `extensionEnabled` must be `not_checked`, browser-level reasons
+must explain that no profile can be inspected, and the blocking
+`browser_profile` check must include `reason: "profile_root_missing"`,
+`reason: "profile_root_unreadable"`, or a more specific inspection failure
+reason. `nextAction.kind` must be `select_profile`.
 
-If default discovery finds browser profiles but no candidate profile containing
-the target extension id, `browser.profile.path` must be `null`,
-`browser.profile.source` must be `default_discovery`,
-`browser.profile.candidates` must include the inspected profile paths,
-`extensionInstalled` must be `missing`, and `nextAction.kind` must be
-`install_extension`.
+If default discovery finds exactly one inspectable browser profile but it does
+not contain the target extension id, `browser.profile.path` must contain that
+profile path, `browser.profile.source` must be `default_discovery`,
+`browser.profile.suggestedPath` must be `null`, `browser.profile.candidates`
+must include that profile, `extensionInstalled` must be `missing`, and
+`extensionEnabled` must be `not_checked`, with browser-level reasons for both
+fields. `nextAction.kind` must be `install_extension`.
+
+If default discovery finds multiple inspectable browser profiles but no
+candidate profile containing the target extension id, `browser.profile.path` must
+be `null`, `browser.profile.source` must be `default_discovery`,
+`browser.profile.suggestedPath` must contain the deterministic first inspectable
+profile, `browser.profile.candidates` must include all inspected profile paths,
+`extensionInstalled` must be `not_checked`, `extensionEnabled` must be
+`not_checked`, browser-level reasons must explain that profile choice is
+ambiguous, and `nextAction.kind` must be `select_profile`. The human message
+should ask the user to choose the profile before installing the extension.
+
+If default discovery finds multiple matching profiles and no profile-bound
+runtime proof is available, `browser.profile.path` must be `null`,
+`browser.profile.suggestedPath` must contain the deterministic first enabled
+matching profile, all candidates must be reported, and `nextAction.kind` must be
+`select_profile`.
 
 If a matching extension is present but disabled in the resolved profile,
 `extensionInstalled` must be `pass`, `extensionEnabled` must be `disabled`, and
+the candidate or browser summary must include `reasons.extensionEnabled`.
 `nextAction.kind` must be `enable_extension`.
 
 When `--profile=<path>` is supplied, every generated rerun, repair, or follow-up
@@ -400,6 +511,15 @@ obu verify \
   --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
 ```
 
+Store-channel handoff, repair, and generated verification commands must include
+the exact `--channel=store` and `--extension-id=<id>` values from the handoff.
+`obu verify --agent=<agent-id>` may omit browser/channel/extension arguments only
+when OBU can resolve them from trusted local state, and JSON must report the
+resulting `browser.channel`, `browser.extensionId`, and `browser.extensionIdSource`.
+For Store readiness, `extensionIdSource` is part of the readiness evidence, not a
+diagnostic aside. Human handoff output should still prefer the full command even
+when omission would work.
+
 To verify a specific browser profile, add:
 
 ```bash
@@ -437,14 +557,15 @@ MCP status from inside the client.
 
 Agent-runtime proof must come from a first-class agent-runtime status hook, not
 from a direct OBU MCP probe. The hook payload is the selected agent process's raw
-`browser_status` structured content plus enough envelope fields to prove
-freshness, provenance, and target binding:
+`browser_status` structured content plus envelope fields for freshness,
+provenance, and target binding:
 
 ```json
 {
   "schemaVersion": 1,
   "agentId": "codex-cli",
   "mcpServerName": "open-browser-use",
+  "provenance": "agent_runtime_hook",
   "generatedAt": "2026-05-19T12:34:56.000Z",
   "challenge": {
     "nonce": "verify-issued-random-nonce",
@@ -472,12 +593,16 @@ freshness, provenance, and target binding:
 }
 ```
 
-The CLI must reject stale or unbound agent-runtime payloads as proof. A payload
-can make `readiness.agentRuntime` become `ready` only when all of these are true:
+The CLI must reject stale, unbound, or unauthoritative agent-runtime payloads as
+proof. A payload can make `readiness.agentRuntime` become `ready` only when all
+of these are true:
 
 - `generatedAt` is within the freshness window, normally 60 seconds.
 - The challenge nonce matches the challenge JSON supplied to this verification
   command, or an equivalent first-class challenge stored by the CLI.
+- `provenance` is `agent_runtime_hook`, and the CLI can trust the transport or
+  integration that supplied that provenance. A field in a user-edited file is not
+  sufficient by itself.
 - `agentId`, `mcpServerName`, browser, channel, extension id, and explicit
   profile value match the verification target.
 - At least one WebExtension backend in the status payload has normalized
@@ -489,7 +614,7 @@ Raw `browser_status` output or a standalone status JSON without a fresh matching
 challenge is diagnostic evidence only; it must not produce
 `verificationTarget: "agent_runtime"` / `result: "ready"`.
 
-The initial CLI surface for this hook is:
+The initial user-mediated CLI surface for collecting this evidence is:
 
 ```bash
 obu verify --require-agent-runtime \
@@ -500,7 +625,7 @@ obu verify --require-agent-runtime \
   --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
 
 # The selected agent process calls browser_status through its configured OBU MCP
-# server and writes the envelope above with the challenge nonce.
+# server and writes an envelope with the challenge nonce.
 
 obu verify --require-agent-runtime \
   --agent-runtime-challenge-json=/path/to/challenge.json \
@@ -510,6 +635,14 @@ obu verify --require-agent-runtime \
   --channel=store \
   --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
 ```
+
+`--agent-runtime-status-json` is a file transport, not a trust mechanism. If the
+payload is only a user-supplied status file, verification must report
+`agent.runtimeStatus.provenance: "user_supplied_status_file"` and
+`mcpRuntime.source: "agent_runtime_status_file"`, then treat it as diagnostic or
+pending evidence. Only a trusted first-class hook can report
+`agent.runtimeStatus.provenance: "agent_runtime_hook"` and
+`mcpRuntime.source: "agent_runtime"` to make `readiness.agentRuntime` ready.
 
 The first command is a challenge-issuance verification pass. If CLI-level
 readiness is blocked, it returns the normal blocking result and may omit the
@@ -627,8 +760,9 @@ active, `backendCount: 0` is treated as downstream evidence of the same popup
 activation boundary, and the result is `needs_browser_popup` with
 `nextAction.kind: "open_popup"`, not `needs_repair`.
 
-After the top-level result is selected, `obu verify` chooses the single
-`nextAction` deterministically within that result class.
+Each blocking check should emit an `actionCandidate` when OBU knows the next
+action. After the top-level result is selected, `obu verify` chooses the single
+`nextAction` deterministically from those candidates within that result class.
 
 For `needs_manual_action`, action priority is:
 
@@ -642,10 +776,17 @@ For `needs_manual_action`, action priority is:
 8. `restart_agent`
 9. `configure_agent`
 
+`actionCandidate.priority` is a positive integer. It must use the numeric rank
+from the priority list for its result class. Lower numbers win. For example,
+`select_profile` has priority `4` within `needs_manual_action`.
+
 For `needs_repair`, the `run_repair` command should target the first repairable
 blocking layer in verification order. The repair command may repair multiple
 deterministic OBU-owned issues, but the human message must name the first
 blocking issue that determined the action.
+
+For `needs_repair`, `run_repair` uses priority `1`. For
+`needs_browser_popup`, `open_popup` uses priority `1`.
 
 Examples:
 
@@ -692,6 +833,7 @@ Result/action mapping:
 | No runnable OBU CLI exists before handoff reaches the CLI | `needs_manual_action` | `install_cli` |
 | Explicit profile path does not exist, cannot be inspected, or default discovery cannot find a profile root | `needs_manual_action` | `select_profile` |
 | Multiple matching profiles exist but runtime proof is not profile-bound | `needs_manual_action` | `select_profile` |
+| Multiple inspectable profiles exist but none contains the selected extension | `needs_manual_action` | `select_profile` |
 | Selected extension is not installed in the resolved profile | `needs_manual_action` | `install_extension` |
 | Selected extension is installed but disabled in the resolved profile | `needs_manual_action` | `enable_extension` |
 | Native-host manifest, allowed origin, host path, runtime permissions, or stale descriptor can be repaired deterministically | `needs_repair` | `run_repair` |
@@ -715,6 +857,10 @@ Each action must include:
 
 The next action must be directly actionable. It should not say "check docs" if a
 specific repair or configuration command is known.
+
+The selected `nextAction` must be traceable to a blocking check's
+`actionCandidate`. The aggregator should not synthesize a different action that
+cannot be explained by normalized evidence.
 
 When a browser/profile-specific action cannot be represented safely as a shell
 command, `command` must be omitted and the action must include explicit context
@@ -753,6 +899,20 @@ Allowed `verificationTarget` values:
 - `cli`
 - `agent_runtime`
 
+Allowed `browser.channel` values:
+
+- `unpacked-dev`
+- `store`
+
+Allowed `browser.extensionIdSource` values:
+
+- `explicit-argument`
+- `environment`
+- `user-config`
+- `payload-metadata`
+- `repo-release-metadata`
+- `manifest-key`
+
 Allowed check status values:
 
 - `pass`: the check succeeded.
@@ -760,9 +920,11 @@ Allowed check status values:
 - `fail`: the check blocks readiness.
 - `not_checked`: the check was intentionally skipped and the reason is present.
 
-Every `not_checked` status object must include a non-empty `reason`. Scalar
-component fields with value `not_checked` must have a sibling `reason` or
-`reasons.<fieldName>` entry on the containing object.
+Every `not_checked` status object must include a non-empty `reason`. Component
+summary fields on `browser` or `browser.profile.candidates[]` with any value
+other than `pass` must have a sibling `reason` or a
+`reasons.<fieldName>` entry on the containing object. Browser-level component
+reasons belong under `browser.reasons`.
 
 Allowed readiness values:
 
@@ -778,11 +940,12 @@ Allowed component state values for summary fields such as `profileExists`,
 - `warn`: the component has a non-blocking issue.
 - `fail`: the component has a blocking issue.
 - `missing`: the component is absent.
+- `unreadable`: the component exists but cannot be inspected.
 - `disabled`: the component exists but is disabled.
 - `stale`: the component exists but its lifecycle state is stale.
 - `invalid`: the component exists but has invalid shape or contents.
 - `not_checked`: the component was intentionally not checked and the reason is
-  present in details.
+  present on the containing object.
 
 Instruction check warnings must use one of these reason values:
 
@@ -811,6 +974,7 @@ result. Check objects use this shape:
   "id": "agent-mcp-server",
   "layer": "agent_mcp",
   "status": "pass",
+  "blocks": [],
   "reason": "equivalent_config",
   "message": "codex-cli configures open-browser-use",
   "details": {
@@ -823,6 +987,28 @@ result. Check objects use this shape:
 `warn`, `fail`, and `not_checked` checks. Instruction warnings use
 `reason: "not_implemented"` or `reason: "missing_instruction"` on the check
 object, not a synthetic status value.
+
+`blocks` is optional for pass checks and required for blocking checks. It is an
+array containing `cli`, `agent_runtime`, or both. Blocking checks should include
+an `actionCandidate` with `kind`, `priority`, and enough command/context fields
+to construct the final `nextAction`.
+
+`actionCandidate` uses this shape:
+
+```json
+{
+  "result": "needs_browser_popup",
+  "kind": "open_popup",
+  "priority": 1,
+  "message": "Open the open-browser-use extension popup."
+}
+```
+
+`result` must be one of the non-ready result values, `kind` must be one of the
+allowed next action kinds, and `priority` must follow the result-class priority
+rules above. `message`, `command`, `url`, `browser`, `profile`, `rerun`, and
+other context fields may be included when they are needed to construct the final
+`nextAction`.
 
 Allowed `checks[].layer` values:
 
@@ -862,6 +1048,7 @@ Allowed `checks[].layer` values:
     },
     "runtimeStatus": {
       "status": "not_checked",
+      "provenance": "not_applicable",
       "reason": "target agent runtime is outside this CLI process"
     }
   },
@@ -869,8 +1056,10 @@ Allowed `checks[].layer` values:
     "kind": "chrome",
     "channel": "store",
     "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+    "extensionIdSource": "explicit-argument",
     "profile": {
       "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+      "suggestedPath": null,
       "source": "default_discovery",
       "runtimeBinding": "single_candidate",
       "candidates": [
@@ -895,6 +1084,7 @@ Allowed `checks[].layer` values:
   },
   "mcpRuntime": {
     "source": "direct_mcp_probe",
+    "provenance": "expected_obu_invocation",
     "probeCommandSource": "expected_obu_invocation",
     "mcpConfigured": true,
     "mcpStarts": true,
@@ -902,7 +1092,7 @@ Allowed `checks[].layer` values:
     "backendCount": 1,
     "backends": [
       {
-        "kind": "webextension",
+        "type": "webextension",
         "browser": "chrome",
         "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
         "extensionIdentity": {
@@ -995,6 +1185,7 @@ Non-ready result:
     "instructions": { "status": "pass" },
     "runtimeStatus": {
       "status": "not_checked",
+      "provenance": "not_applicable",
       "reason": "target agent runtime is outside this CLI process"
     }
   },
@@ -1002,8 +1193,10 @@ Non-ready result:
     "kind": "chrome",
     "channel": "store",
     "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+    "extensionIdSource": "explicit-argument",
     "profile": {
       "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+      "suggestedPath": null,
       "source": "default_discovery",
       "runtimeBinding": "not_available",
       "candidates": [
@@ -1019,10 +1212,14 @@ Non-ready result:
     "extensionEnabled": "pass",
     "nativeHost": "pass",
     "runtimeDescriptor": "missing",
+    "reasons": {
+      "runtimeDescriptor": "no active WebExtension descriptor found"
+    },
     "resumeRequired": true
   },
   "mcpRuntime": {
     "source": "direct_mcp_probe",
+    "provenance": "expected_obu_invocation",
     "probeCommandSource": "expected_obu_invocation",
     "mcpConfigured": true,
     "mcpStarts": true,
@@ -1069,24 +1266,42 @@ Non-ready result:
       "id": "extension-runtime",
       "layer": "extension_runtime",
       "status": "fail",
+      "blocks": ["cli"],
       "reason": "runtime_descriptor_not_active",
       "message": "extension runtime is not active from CLI-observable evidence",
-      "details": { "source": "runtime_descriptor_probe" }
+      "details": { "source": "runtime_descriptor_probe" },
+      "actionCandidate": {
+        "kind": "open_popup",
+        "priority": 1,
+        "result": "needs_browser_popup"
+      }
     },
     {
       "id": "runtime-descriptor-probe",
       "layer": "runtime_descriptor",
       "status": "fail",
+      "blocks": ["cli"],
       "reason": "descriptor_missing",
       "message": "no active WebExtension descriptor found",
-      "details": { "resumeRequired": true }
+      "details": { "resumeRequired": true },
+      "actionCandidate": {
+        "kind": "open_popup",
+        "priority": 1,
+        "result": "needs_browser_popup"
+      }
     },
     {
       "id": "mcp-runtime-backend",
       "layer": "mcp_runtime",
       "status": "fail",
+      "blocks": ["cli"],
       "reason": "zero_backends_after_popup_boundary",
-      "message": "direct MCP probe found zero usable browser backends"
+      "message": "direct MCP probe found zero usable browser backends",
+      "actionCandidate": {
+        "kind": "open_popup",
+        "priority": 1,
+        "result": "needs_browser_popup"
+      }
     },
     {
       "id": "agent-mcp-server",
@@ -1171,8 +1386,8 @@ false`.
 
 ## Browser Popup Boundary
 
-Opening the popup is sometimes required because Chrome controls MV3 extension
-runtime activation.
+Opening the popup is sometimes required because the selected Chromium-family
+browser controls MV3 extension runtime activation.
 
 `obu verify --repair` can fix:
 
@@ -1182,7 +1397,7 @@ runtime activation.
 - runtime directory permissions;
 - stale or invalid descriptor files.
 
-It cannot force Chrome to:
+It cannot force the browser to:
 
 - wake the MV3 service worker immediately;
 - reconnect the extension to native messaging from outside the browser;
@@ -1256,7 +1471,10 @@ MCP status is split into server availability and browser backend availability.
 
 Required fields:
 
-- `source`: `agent_runtime | direct_mcp_probe | not_checked`.
+- `source`: `agent_runtime | agent_runtime_status_file | direct_mcp_probe |
+  not_checked`.
+- `provenance`: `agent_runtime_hook | expected_obu_invocation |
+  user_supplied_status_file | not_applicable`.
 - `mcpConfigured`: whether the target agent has an equivalent server config.
 - `probeCommandSource`: `expected_obu_invocation | agent_runtime_hook |
   not_applicable`; direct probes must use `expected_obu_invocation`.
@@ -1264,21 +1482,28 @@ Required fields:
   checked directly.
 - `sdkBootstrap`: `available | missing | untrusted | not_checked`.
 - `backendCount`: `number | null`; number of usable browser backends.
-- `backends`: backend summaries when available. WebExtension backend summaries
-  must include normalized `browser`, `extensionId`, and `extensionIdentity`
-  fields. A WebExtension backend without verified extension identity cannot
-  contribute to `backendCount` for extension-scoped readiness.
+- `backends`: normalized backend summaries when available. WebExtension backend
+  summaries must include `type`, `browser`, `extensionId`, and
+  `extensionIdentity`. A WebExtension backend without verified extension identity
+  cannot contribute to `backendCount` for extension-scoped readiness.
 
 `source: "agent_runtime"` means the status came from the selected agent process
 after it reloaded MCP tools. Only this source can make
 `readiness.agentRuntime` become `ready`; `probeCommandSource` must be
-`agent_runtime_hook`.
+`agent_runtime_hook` and `provenance` must be `agent_runtime_hook`.
 
 `source: "direct_mcp_probe"` means OBU launched or probed the MCP server itself.
 It can prove CLI-level backend readiness, but it must not be treated as proof
 that the selected agent process has reloaded MCP tools. The command must be the
 expected OBU MCP invocation for the current layout, not a command copied from a
-divergent agent config.
+divergent agent config. `provenance` must be `expected_obu_invocation`.
+
+`source: "agent_runtime_status_file"` means OBU read a user-supplied status file
+that may contain challenge-bound agent-runtime evidence, but the transport itself
+is not trusted agent-runtime provenance. It must use
+`provenance: "user_supplied_status_file"` and
+`probeCommandSource: "not_applicable"`, and it must not make
+`readiness.agentRuntime` ready.
 
 When `source: "direct_mcp_probe"` and the MCP process cannot start,
 `mcpStarts` must be `false`, `sdkBootstrap` must be `not_checked`,
@@ -1289,12 +1514,37 @@ be `not_checked`, `backendCount` must be `null`, and `backends` must be an empty
 array.
 
 `source: "not_checked"` means MCP runtime status was not probed. In that case
-`probeCommandSource` must be `not_applicable`, `mcpStarts` must be `null`,
-`sdkBootstrap` must be `not_checked`, `backendCount` must be `null`, and
-`backends` must be an empty array.
+`provenance` and `probeCommandSource` must be `not_applicable`, `mcpStarts` must
+be `null`, `sdkBootstrap` must be `not_checked`, `backendCount` must be `null`,
+and `backends` must be an empty array.
 
 `backendCount: 0` means not ready for browser automation even if
 `sdkBootstrap: "available"`.
+
+Normalized backend summary shape:
+
+```json
+{
+  "type": "webextension",
+  "browser": "chrome",
+  "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+  "extensionIdentity": {
+    "source": "descriptor_metadata",
+    "verified": true
+  },
+  "socketPath": "/path/to/socket",
+  "metadata": {
+    "browserKind": "chrome",
+    "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj"
+  }
+}
+```
+
+`socketPath` may be omitted from human output, but if it is present in JSON it
+must be the canonical socket path used for the verified backend. Raw MCP backend
+payloads use fields such as `type`, `name`, `socketPath`, and
+`metadata.browser_kind`; verify may include those raw payloads only under
+`details.raw`.
 
 For setup probes, agents should end turns with `turnEnded()` when the goal is to
 keep the browser connection alive. `finishTurn({ keep: [] })` intentionally
@@ -1313,20 +1563,31 @@ The product is complete only when all of the following are true:
   `mcpRuntime.sdkBootstrap` is not `available`.
 - `verificationTarget: "agent_runtime"` cannot return `ready` unless
   `readiness.agentRuntime` is `ready`, and agent-runtime evidence has fresh
-  challenge binding, target binding, and verified WebExtension extension
-  identity matching `browser.extensionId`.
+  challenge binding, target binding, `provenance: "agent_runtime_hook"`, trusted
+  hook transport, and verified WebExtension extension identity matching
+  `browser.extensionId`.
+- User-supplied agent-runtime status files without trusted hook provenance remain
+  diagnostic or pending evidence and cannot make agent-runtime readiness `ready`.
 - WebExtension `backendCount` excludes metadata-less, `"unknown"`, wrong-browser,
   or wrong-extension backends; Store-channel readiness always requires exact
-  extension id proof.
+  extension id proof and JSON reports `browser.extensionIdSource`.
+- Normalized backend summaries use the documented `type`, `browser`,
+  `extensionId`, and `extensionIdentity` shape; raw backend payloads stay under
+  `details.raw`.
 - Browser profile discovery is deterministic and reports candidate profile state.
+- Multi-profile default discovery reports `suggestedPath` but does not treat it
+  as `browser.profile.path` unless runtime proof is `profile_verified`.
 - Explicit-profile readiness may be browser/extension-scoped only when JSON and
   human output warn with `reason: "profile_runtime_not_bound"`; multi-profile
   default readiness still requires `profile_verified` or `select_profile`.
 - Missing profile roots or nonexistent explicit profiles produce
   `nextAction.kind: "select_profile"`, not `install_extension`.
-- Candidate fields using `not_checked` include per-field reasons.
-- Same-result-class failures choose `nextAction` by the deterministic priority
-  table in this document.
+- Unreadable profile roots or profile files produce unreadable/profile-inspection
+  reasons instead of being collapsed into `missing`.
+- Component summary fields using any value other than `pass` include per-field
+  reasons.
+- Same-result-class failures choose `nextAction` from blocking checks'
+  `actionCandidate` values by the deterministic priority table in this document.
 - Agent-runtime challenge issuance has a defined `needs_manual_action` pending
   state with `nextAction.kind: "collect_agent_runtime_status"`.
 - Direct MCP probes never execute divergent or unreadable agent-config commands.

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -2,6 +2,12 @@
 
 Date: 2026-05-19
 
+Status: target product contract / implementation plan. This document describes
+the intended `obu verify` behavior. Until `obu verify` is implemented and wired
+into setup output, existing `obu setup`, `obu doctor browser`, and
+`obu agent doctor` commands remain lower-level diagnostics rather than the
+canonical readiness surface described here.
+
 ## Product Contract
 
 open-browser-use owns one readiness question end to end:
@@ -13,7 +19,7 @@ user or agent stitching together partial signals from install logs,
 `obu setup`, `obu doctor browser`, `obu agent doctor`, MCP `browser_status`, and
 the extension popup.
 
-Once a runnable OBU CLI exists, the canonical surface is:
+Once `obu verify` exists in a runnable OBU CLI, the canonical surface is:
 
 ```bash
 obu verify --agent=<agent-id> --browser=<browser> --channel=<channel> --extension-id=<id>
@@ -51,7 +57,7 @@ shape at the handoff level:
 - `nextAction.kind: "install_cli"`
 - install command or official install URL
 
-After the CLI exists, all readiness answers flow through `obu verify`.
+After `obu verify` is available, all readiness answers flow through it.
 
 ## Why This Exists
 
@@ -76,7 +82,7 @@ one precise next action.
 
 ## Verification Layers
 
-Readiness spans eight layers. `obu verify` must evaluate them in a stable order
+Readiness spans nine layers. `obu verify` must evaluate them in a stable order
 and report each layer in JSON.
 
 1. **CLI install state**
@@ -93,12 +99,20 @@ and report each layer in JSON.
      `chrome-extension://<extension-id>/`.
    - Store channel verification must preserve the supplied Store extension id.
 
-3. **Browser extension installation state**
+3. **Browser profile resolution state**
+   - The resolved browser profile exists and can be inspected.
+   - Explicit `--profile` input is preserved exactly in JSON and every follow-up
+     command.
+   - Default profile discovery is deterministic and reports all candidates.
+   - Missing profile roots or nonexistent explicit profiles block readiness with
+     a profile-selection action before extension installation can be inferred.
+
+4. **Browser extension installation state**
    - The resolved browser profile contains the matching extension id.
    - The extension is enabled.
    - The extension channel and id match the verification target.
 
-4. **Extension runtime state**
+5. **Extension runtime state**
    - Chrome has activated the extension runtime.
    - The extension has connected to native messaging.
    - The popup can expose this as native-host connection state.
@@ -106,7 +120,7 @@ and report each layer in JSON.
      activation is inferred from runtime descriptor probing; the CLI cannot read
      arbitrary MV3 service-worker state directly.
 
-5. **Runtime descriptor state**
+6. **Runtime descriptor state**
    - The owner-only runtime descriptor directory exists.
    - At least one descriptor is valid JSON.
    - The descriptor points at a socket-like endpoint.
@@ -120,19 +134,24 @@ and report each layer in JSON.
      profile. Without profile identity evidence, the JSON must state that the
      runtime proof is browser/extension-scoped rather than profile-bound.
 
-6. **MCP runtime state**
-   - OBU can launch or probe its MCP server directly using the selected server
-     command and args.
+7. **MCP runtime state**
+   - OBU can launch or probe its MCP server directly using the expected OBU
+     server command and args for the current layout.
+   - Direct MCP probes must not execute a divergent user-managed agent command.
+     If agent config is divergent, verification reports the config conflict
+     instead of probing that command.
    - MCP status reports `sdk_bootstrap: "available"` in raw MCP status,
      normalized to `sdkBootstrap: "available"` in verify JSON.
    - MCP status reports at least one usable browser backend for the selected
      browser/extension runtime.
    - `backends: []` is a blocking state even when the MCP process starts.
 
-7. **Agent MCP state**
+8. **Agent MCP state**
    - The target agent is configured to launch an MCP server named
      `open-browser-use`.
-   - The server command and args are equivalent to:
+   - The server command and args are equivalent to the expected OBU MCP
+     invocation for the current runtime layout. For a packaged install this is
+     normally:
 
      ```json
      {
@@ -142,7 +161,11 @@ and report each layer in JSON.
      }
      ```
 
-8. **Agent instruction state**
+     Repo or development layouts may be equivalent through `process.execPath`
+     plus the CLI entrypoint and `["mcp", "stdio"]`. JSON must report the
+     expected invocation shape that was used for equivalence.
+
+9. **Agent instruction state**
    - Where the target agent supports durable instructions, OBU checks whether
      persistent guidance exists to prefer open-browser-use as the primary
      BrowserUse/browser automation tool.
@@ -151,9 +174,10 @@ and report each layer in JSON.
      `obu setup` writes instruction files only when the user explicitly requests
      that mutation.
 
-Layers 1, 2, 7, and 8 are mostly file/config state. Layer 3 depends on the
-resolved browser profile. Layers 4 and 5 depend on Chrome extension runtime
-activation. Layer 6 depends on packaged runtime dependencies, SDK bootstrap
+Layers 1, 2, 8, and 9 are mostly file/config state. Layer 3 depends on
+browser profile discovery. Layer 4 depends on the resolved browser profile's
+extension preferences. Layers 5 and 6 depend on Chrome extension runtime
+activation. Layer 7 depends on packaged runtime dependencies, SDK bootstrap
 state, and backend discovery. The CLI can repair deterministic file/config
 state, but it cannot force Chrome to keep an MV3 service worker alive.
 
@@ -173,6 +197,16 @@ discovery with a single matching profile, browser/extension-scoped runtime proof
 is acceptable for CLI readiness, but human output must not imply stronger
 profile-specific proof.
 
+For profile-scoped verification, runtime proof is stricter:
+
+- If `--profile=<path>` is supplied, `result: "ready"` requires
+  `browser.profile.runtimeBinding: "profile_verified"`.
+- If default discovery finds multiple matching profiles, `result: "ready"`
+  requires `profile_verified`; otherwise return `needs_manual_action` with
+  `nextAction.kind: "select_profile"`.
+- `single_candidate` is only acceptable for CLI readiness when default discovery
+  found exactly one matching enabled extension profile.
+
 ## Browser Profile Resolution
 
 `obu verify` must make browser profile selection explicit.
@@ -180,17 +214,26 @@ profile-specific proof.
 Profile resolution order:
 
 1. If `--profile=<path>` is supplied, verify only that profile.
-2. If no profile is supplied, use the same default profile discovery as
+2. If the explicit profile path does not exist or cannot be inspected, keep that
+   profile path in JSON and return `needs_manual_action` with
+   `nextAction.kind: "select_profile"`.
+3. If no profile is supplied, use the same default profile discovery as
    `obu doctor browser` for the selected browser.
-3. If multiple candidate profiles contain the target extension id, choose the
+4. If default discovery cannot find a profile root for the selected browser,
+   return `needs_manual_action` with `nextAction.kind: "select_profile"`.
+5. If multiple candidate profiles contain the target extension id, choose the
    first profile with an enabled matching extension after deterministic sorting,
    and report all candidates in JSON.
-4. If an explicit profile is supplied but does not contain the target extension
+6. If an explicit profile is supplied but does not contain the target extension
    id, keep that profile path in JSON and return `needs_manual_action` with
    `nextAction.kind: "install_extension"`.
-5. If default discovery finds no candidate profile containing the target
-   extension id, return `needs_manual_action` with
+7. If default discovery finds profiles for the browser but no candidate contains
+   the target extension id, return `needs_manual_action` with
    `nextAction.kind: "install_extension"`.
+
+Profile existence and extension installation are separate states. Do not tell a
+user to install the extension into a profile that OBU could not find or inspect;
+first ask them to create, launch, or select the intended profile.
 
 Default discovery must sort candidate profile directories deterministically:
 `Default` first, `Profile <number>` in numeric order, then all other profile
@@ -207,7 +250,7 @@ The JSON response must include:
 - `browser.profile.path`: string path or `null`
 - `browser.profile.source`: `explicit | default_discovery`
 - `browser.profile.candidates`: array of candidate objects with `path`,
-  `extensionInstalled`, and `extensionEnabled`
+  `profileExists`, `extensionInstalled`, and `extensionEnabled`
 - `browser.profile.runtimeBinding`: `profile_verified | single_candidate |
   browser_extension_scope | not_available`
 
@@ -222,16 +265,31 @@ The JSON response must include:
   extension id. Human output must not describe this as profile-bound readiness.
 - `not_available`: no runtime descriptor or status source is available.
 
+If an explicit profile is supplied and the path does not exist or cannot be
+inspected, `browser.profile.path` must keep the explicit path,
+`browser.profile.source` must be `explicit`, `browser.profile.candidates` must
+contain only that path with `profileExists: "missing"`,
+`extensionInstalled: "not_checked"`, and `extensionEnabled: "not_checked"`, and
+`nextAction.kind` must be `select_profile`.
+
 If an explicit profile is supplied and does not contain the target extension id,
 `browser.profile.path` must keep the explicit path,
 `browser.profile.source` must be `explicit`, `browser.profile.candidates` must
-contain only that path with `extensionInstalled: "missing"` and
-`extensionEnabled: "not_checked"`, top-level `extensionInstalled` must be
-`missing`, and `nextAction.kind` must be `install_extension`.
+contain only that path with `profileExists: "pass"`,
+`extensionInstalled: "missing"`, and `extensionEnabled: "not_checked"`,
+top-level `extensionInstalled` must be `missing`, and `nextAction.kind` must be
+`install_extension`.
 
-If default discovery finds no candidate profile containing the target extension
-id, `browser.profile.path` must be `null`, `browser.profile.source` must be
+If default discovery cannot find or inspect the selected browser profile root,
+`browser.profile.path` must be `null`, `browser.profile.source` must be
 `default_discovery`, `browser.profile.candidates` must be an empty array,
+`extensionInstalled` must be `not_checked`, and `nextAction.kind` must be
+`select_profile`.
+
+If default discovery finds browser profiles but no candidate profile containing
+the target extension id, `browser.profile.path` must be `null`,
+`browser.profile.source` must be `default_discovery`,
+`browser.profile.candidates` must include the inspected profile paths,
 `extensionInstalled` must be `missing`, and `nextAction.kind` must be
 `install_extension`.
 
@@ -269,6 +327,10 @@ Required evidence:
 - Native-host manifest is valid for the exact extension id.
 - Browser extension is installed and enabled in the resolved profile.
 - Runtime descriptor responds to `getInfo`.
+- `browser.profile.runtimeBinding` is strong enough for the selected profile
+  mode: `profile_verified` for explicit profile or multi-profile verification,
+  and either `profile_verified` or `single_candidate` for default discovery with
+  exactly one matching profile.
 - `resumeRequired` is `false`.
 - Direct MCP runtime status has `mcpStarts: true`,
   `sdkBootstrap: "available"`, and `backendCount > 0`.
@@ -338,6 +400,10 @@ descriptors, and run read-only agent status commands. It must not write config,
 repair native-host manifests, create instruction files, or mutate agent MCP
 config.
 
+Read-only direct MCP probing must execute only OBU-owned expected invocations for
+the selected runtime layout. It must not execute an arbitrary command read from a
+divergent or unreadable agent config.
+
 To require proof from the selected running agent process, use:
 
 ```bash
@@ -355,24 +421,71 @@ MCP status from inside the client.
 
 Agent-runtime proof must come from a first-class agent-runtime status hook, not
 from a direct OBU MCP probe. The hook payload is the selected agent process's raw
-`browser_status` structured content plus enough envelope fields to bind it to the
-target agent and MCP server:
+`browser_status` structured content plus enough envelope fields to prove
+freshness, provenance, and target binding:
 
 ```json
 {
+  "schemaVersion": 1,
   "agentId": "codex-cli",
   "mcpServerName": "open-browser-use",
+  "generatedAt": "2026-05-19T12:34:56.000Z",
+  "challenge": {
+    "nonce": "verify-issued-random-nonce",
+    "issuedAt": "2026-05-19T12:34:30.000Z"
+  },
+  "target": {
+    "browser": "chrome",
+    "channel": "store",
+    "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+    "profile": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+  },
   "status": {
     "sdk_bootstrap": "available",
-    "backends": [{ "...": "..." }]
+    "backends": [
+      {
+        "type": "webextension",
+        "name": "chrome",
+        "metadata": {
+          "browser_kind": "chrome",
+          "extension_id": "fblnfcjnjklpgnmfnngcihbcgojnpadj"
+        }
+      }
+    ]
   }
 }
 ```
+
+The CLI must reject stale or unbound agent-runtime payloads as proof. A payload
+can make `readiness.agentRuntime` become `ready` only when all of these are true:
+
+- `generatedAt` is within the freshness window, normally 60 seconds.
+- The challenge nonce matches the challenge JSON supplied to this verification
+  command, or an equivalent first-class challenge stored by the CLI.
+- `agentId`, `mcpServerName`, browser, channel, extension id, and explicit
+  profile value match the verification target.
+- At least one backend in the status payload matches the selected browser and
+  extension id through backend metadata when metadata is present.
+
+Raw `browser_status` output or a standalone status JSON without a fresh matching
+challenge is diagnostic evidence only; it must not produce
+`verificationTarget: "agent_runtime"` / `result: "ready"`.
 
 The initial CLI surface for this hook is:
 
 ```bash
 obu verify --require-agent-runtime \
+  --agent-runtime-challenge-out=/path/to/challenge.json \
+  --agent=codex-cli \
+  --browser=chrome \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+
+# The selected agent process calls browser_status through its configured OBU MCP
+# server and writes the envelope above with the challenge nonce.
+
+obu verify --require-agent-runtime \
+  --agent-runtime-challenge-json=/path/to/challenge.json \
   --agent-runtime-status-json=/path/to/status.json \
   --agent=codex-cli \
   --browser=chrome \
@@ -479,10 +592,31 @@ active, `backendCount: 0` is treated as downstream evidence of the same popup
 activation boundary, and the result is `needs_browser_popup` with
 `nextAction.kind: "open_popup"`, not `needs_repair`.
 
+After the top-level result is selected, `obu verify` chooses the single
+`nextAction` deterministically within that result class.
+
+For `needs_manual_action`, action priority is:
+
+1. `install_cli`
+2. `unsupported`
+3. `resolve_config_conflict`
+4. `select_profile`
+5. `install_extension`
+6. `enable_extension`
+7. `restart_agent`
+8. `configure_agent`
+
+For `needs_repair`, the `run_repair` command should target the first repairable
+blocking layer in verification order. The repair command may repair multiple
+deterministic OBU-owned issues, but the human message must name the first
+blocking issue that determined the action.
+
 Examples:
 
 - Divergent Codex MCP config plus missing runtime descriptor:
   `needs_manual_action`.
+- Missing or ambiguous profile plus missing extension:
+  `needs_manual_action` with `select_profile`.
 - Native-host manifest missing exact Store id plus no descriptor:
   `needs_repair`.
 - Native host and extension are correct, but descriptor is absent:
@@ -508,6 +642,7 @@ Action kinds:
 - `configure_agent`
 - `resolve_config_conflict`
 - `restart_agent`
+- `select_profile`
 - `install_extension`
 - `enable_extension`
 - `unsupported`
@@ -517,6 +652,8 @@ Result/action mapping:
 | Condition | Result | Next action kind |
 | --- | --- | --- |
 | No runnable OBU CLI exists before handoff reaches the CLI | `needs_manual_action` | `install_cli` |
+| Explicit profile path does not exist, cannot be inspected, or default discovery cannot find a profile root | `needs_manual_action` | `select_profile` |
+| Multiple matching profiles exist but runtime proof is not profile-bound | `needs_manual_action` | `select_profile` |
 | Selected extension is not installed in the resolved profile | `needs_manual_action` | `install_extension` |
 | Selected extension is installed but disabled in the resolved profile | `needs_manual_action` | `enable_extension` |
 | Native-host manifest, allowed origin, host path, runtime permissions, or stale descriptor can be repaired deterministically | `needs_repair` | `run_repair` |
@@ -592,8 +729,9 @@ Allowed readiness values:
 - `blocked`: this readiness level is not ready.
 - `not_checked`: this readiness level was not checked from this process.
 
-Allowed component state values for summary fields such as `extensionInstalled`,
-`extensionEnabled`, `nativeHost`, and `runtimeDescriptor`:
+Allowed component state values for summary fields such as `profileExists`,
+`extensionInstalled`, `extensionEnabled`, `nativeHost`, and
+`runtimeDescriptor`:
 
 - `pass`: the component is present and valid.
 - `warn`: the component has a non-blocking issue.
@@ -625,13 +763,14 @@ They must not introduce separate check statuses named `not_implemented` or
 `missing_instruction`.
 
 `checks[]` contains the normalized lower-level evidence used to compute the
-result:
+result. Check objects use this shape:
 
 ```json
 {
   "id": "agent-mcp-server",
   "layer": "agent_mcp",
   "status": "pass",
+  "reason": "equivalent_config",
   "message": "codex-cli configures open-browser-use",
   "details": {
     "path": "/Users/alex/.codex/config.toml"
@@ -639,10 +778,16 @@ result:
 }
 ```
 
+`reason` is optional for `pass` checks and required for machine-class
+`warn`, `fail`, and `not_checked` checks. Instruction warnings use
+`reason: "not_implemented"` or `reason: "missing_instruction"` on the check
+object, not a synthetic status value.
+
 Allowed `checks[].layer` values:
 
 - `cli_install`
 - `native_host`
+- `browser_profile`
 - `browser_extension`
 - `extension_runtime`
 - `runtime_descriptor`
@@ -690,6 +835,7 @@ Allowed `checks[].layer` values:
       "candidates": [
         {
           "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+          "profileExists": "pass",
           "extensionInstalled": "pass",
           "extensionEnabled": "pass"
         }
@@ -708,6 +854,7 @@ Allowed `checks[].layer` values:
   },
   "mcpRuntime": {
     "source": "direct_mcp_probe",
+    "probeCommandSource": "expected_obu_invocation",
     "mcpConfigured": true,
     "mcpStarts": true,
     "sdkBootstrap": "available",
@@ -732,6 +879,12 @@ Allowed `checks[].layer` values:
       "layer": "native_host",
       "status": "pass",
       "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/"
+    },
+    {
+      "id": "browser-profile",
+      "layer": "browser_profile",
+      "status": "pass",
+      "message": "resolved one matching enabled Chrome profile"
     },
     {
       "id": "browser-extension-installed",
@@ -806,6 +959,7 @@ Non-ready result:
       "candidates": [
         {
           "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+          "profileExists": "pass",
           "extensionInstalled": "pass",
           "extensionEnabled": "pass"
         }
@@ -819,6 +973,7 @@ Non-ready result:
   },
   "mcpRuntime": {
     "source": "direct_mcp_probe",
+    "probeCommandSource": "expected_obu_invocation",
     "mcpConfigured": true,
     "mcpStarts": true,
     "sdkBootstrap": "available",
@@ -843,6 +998,12 @@ Non-ready result:
       "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/"
     },
     {
+      "id": "browser-profile",
+      "layer": "browser_profile",
+      "status": "pass",
+      "message": "resolved one matching enabled Chrome profile"
+    },
+    {
       "id": "browser-extension-installed",
       "layer": "browser_extension",
       "status": "pass",
@@ -852,6 +1013,7 @@ Non-ready result:
       "id": "extension-runtime",
       "layer": "extension_runtime",
       "status": "fail",
+      "reason": "runtime_descriptor_not_active",
       "message": "extension runtime is not active from CLI-observable evidence",
       "details": { "source": "runtime_descriptor_probe" }
     },
@@ -859,6 +1021,7 @@ Non-ready result:
       "id": "runtime-descriptor-probe",
       "layer": "runtime_descriptor",
       "status": "fail",
+      "reason": "descriptor_missing",
       "message": "no active WebExtension descriptor found",
       "details": { "resumeRequired": true }
     },
@@ -866,6 +1029,7 @@ Non-ready result:
       "id": "mcp-runtime-backend",
       "layer": "mcp_runtime",
       "status": "fail",
+      "reason": "zero_backends_after_popup_boundary",
       "message": "direct MCP probe found zero usable browser backends"
     },
     {
@@ -997,8 +1161,8 @@ Setup requirements:
 - Write primary-browser instructions only when explicitly requested.
 - Include the final verification command in next actions.
 
-The final setup output should tell users to run `obu verify`, not ask them to
-interpret setup completion as browser readiness.
+Once `obu verify` is implemented, final setup output should tell users to run
+`obu verify`, not ask them to interpret setup completion as browser readiness.
 
 ## Doctor Contract
 
@@ -1027,6 +1191,8 @@ Required fields:
 
 - `source`: `agent_runtime | direct_mcp_probe | not_checked`.
 - `mcpConfigured`: whether the target agent has an equivalent server config.
+- `probeCommandSource`: `expected_obu_invocation | agent_runtime_hook |
+  not_applicable`; direct probes must use `expected_obu_invocation`.
 - `mcpStarts`: `true | false | null`; whether the MCP process can start when
   checked directly.
 - `sdkBootstrap`: `available | missing | untrusted | not_checked`.
@@ -1035,11 +1201,14 @@ Required fields:
 
 `source: "agent_runtime"` means the status came from the selected agent process
 after it reloaded MCP tools. Only this source can make
-`readiness.agentRuntime` become `ready`.
+`readiness.agentRuntime` become `ready`; `probeCommandSource` must be
+`agent_runtime_hook`.
 
 `source: "direct_mcp_probe"` means OBU launched or probed the MCP server itself.
 It can prove CLI-level backend readiness, but it must not be treated as proof
-that the selected agent process has reloaded MCP tools.
+that the selected agent process has reloaded MCP tools. The command must be the
+expected OBU MCP invocation for the current layout, not a command copied from a
+divergent agent config.
 
 When `source: "direct_mcp_probe"` and the MCP process cannot start,
 `mcpStarts` must be `false`, `sdkBootstrap` must be `not_checked`,
@@ -1050,8 +1219,9 @@ be `not_checked`, `backendCount` must be `null`, and `backends` must be an empty
 array.
 
 `source: "not_checked"` means MCP runtime status was not probed. In that case
-`mcpStarts` must be `null`, `sdkBootstrap` must be `not_checked`,
-`backendCount` must be `null`, and `backends` must be an empty array.
+`probeCommandSource` must be `not_applicable`, `mcpStarts` must be `null`,
+`sdkBootstrap` must be `not_checked`, `backendCount` must be `null`, and
+`backends` must be an empty array.
 
 `backendCount: 0` means not ready for browser automation even if
 `sdkBootstrap: "available"`.
@@ -1072,8 +1242,17 @@ The product is complete only when all of the following are true:
 - `ready` is impossible when `mcpRuntime.backendCount` is zero or
   `mcpRuntime.sdkBootstrap` is not `available`.
 - `verificationTarget: "agent_runtime"` cannot return `ready` unless
-  `readiness.agentRuntime` is `ready`.
+  `readiness.agentRuntime` is `ready`, and agent-runtime evidence has fresh
+  challenge binding, target binding, and matching backend metadata when metadata
+  is present.
 - Browser profile discovery is deterministic and reports candidate profile state.
+- Explicit-profile readiness and multi-profile readiness require
+  `browser.profile.runtimeBinding: "profile_verified"`.
+- Missing profile roots or nonexistent explicit profiles produce
+  `nextAction.kind: "select_profile"`, not `install_extension`.
+- Same-result-class failures choose `nextAction` by the deterministic priority
+  table in this document.
+- Direct MCP probes never execute divergent or unreadable agent-config commands.
 - `needs_browser_popup` is returned when local setup is correct but descriptor
   activation is missing.
 - `open_popup` actions preserve browser/profile context and do not rely on a
@@ -1092,8 +1271,9 @@ The product is complete only when all of the following are true:
   bootstrap missing/untrusted results, disabled extensions, explicit profile
   mismatch, deterministic multi-profile selection, wrong-browser or
   wrong-extension descriptors, explicit `--profile` preservation in rerun/repair
-  commands, read-only verification performing no writes, and `--repair` refusing
-  divergent agent config.
+  commands, read-only verification performing no writes, stale or unbound
+  agent-runtime status JSON, direct probe refusal for divergent agent config, and
+  `--repair` refusing divergent agent config.
 
 ## Product Principle
 

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -29,7 +29,8 @@ It returns exactly one high-level result:
 - `ready`: OBU has verified readiness for the requested target. For
   `verificationTarget: "cli"`, this means CLI-level readiness is complete for
   the selected agent config and browser, including a live browser backend
-  descriptor. For `verificationTarget: "agent_runtime"`, the selected agent
+  descriptor and a direct OBU MCP runtime status with at least one usable
+  backend. For `verificationTarget: "agent_runtime"`, the selected agent
   runtime has also proved at least one usable backend through OBU MCP status.
 - `needs_browser_popup`: local setup is correct, but Chrome has not activated
   the extension/native-host runtime descriptor yet.
@@ -75,7 +76,7 @@ one precise next action.
 
 ## Verification Layers
 
-Readiness spans seven layers. `obu verify` must evaluate them in a stable order
+Readiness spans eight layers. `obu verify` must evaluate them in a stable order
 and report each layer in JSON.
 
 1. **CLI install state**
@@ -111,8 +112,24 @@ and report each layer in JSON.
    - The descriptor points at a socket-like endpoint.
    - The descriptor responds to `getInfo`.
    - The descriptor lifecycle is not stale.
+   - Descriptor metadata matches the selected browser kind and exact extension
+     id when those fields are present. A Store-channel target cannot be
+     certified by a descriptor whose metadata proves a different extension id.
+   - If verification is profile-scoped, descriptor metadata or a future
+     popup/native-host status source must bind the runtime to the resolved
+     profile. Without profile identity evidence, the JSON must state that the
+     runtime proof is browser/extension-scoped rather than profile-bound.
 
-6. **Agent MCP state**
+6. **MCP runtime state**
+   - OBU can launch or probe its MCP server directly using the selected server
+     command and args.
+   - MCP status reports `sdk_bootstrap: "available"` in raw MCP status,
+     normalized to `sdkBootstrap: "available"` in verify JSON.
+   - MCP status reports at least one usable browser backend for the selected
+     browser/extension runtime.
+   - `backends: []` is a blocking state even when the MCP process starts.
+
+7. **Agent MCP state**
    - The target agent is configured to launch an MCP server named
      `open-browser-use`.
    - The server command and args are equivalent to:
@@ -125,15 +142,20 @@ and report each layer in JSON.
      }
      ```
 
-7. **Agent instruction state**
-   - Where the target agent supports durable instructions, the agent has
-     persistent guidance to prefer open-browser-use as the primary
+8. **Agent instruction state**
+   - Where the target agent supports durable instructions, OBU checks whether
+     persistent guidance exists to prefer open-browser-use as the primary
      BrowserUse/browser automation tool.
+   - This is advisory for default CLI readiness. Missing supported instructions
+     are a non-blocking `warn` with `reason: "missing_instruction"` because
+     `obu setup` writes instruction files only when the user explicitly requests
+     that mutation.
 
-Layers 1, 2, 6, and 7 are mostly file/config state. Layer 3 depends on the
+Layers 1, 2, 7, and 8 are mostly file/config state. Layer 3 depends on the
 resolved browser profile. Layers 4 and 5 depend on Chrome extension runtime
-activation. The CLI can repair deterministic file/config state, but it cannot
-force Chrome to keep an MV3 service worker alive.
+activation. Layer 6 depends on packaged runtime dependencies, SDK bootstrap
+state, and backend discovery. The CLI can repair deterministic file/config
+state, but it cannot force Chrome to keep an MV3 service worker alive.
 
 For CLI verification, extension runtime state is considered active when a
 runtime descriptor for the selected browser responds to `getInfo` and any
@@ -142,6 +164,14 @@ inactive when native-host and extension file/config state pass but no fresh
 descriptor can be probed. The corresponding check must include
 `details.source: "runtime_descriptor_probe"` unless a future popup/native-host
 status API supplies a more direct source.
+
+When descriptor metadata cannot prove profile identity, `obu verify` must expose
+that limitation explicitly in `browser.profile.runtimeBinding`. It must not
+claim profile-bound runtime readiness unless descriptor metadata or a direct
+popup/native-host status source identifies the resolved profile. For default
+discovery with a single matching profile, browser/extension-scoped runtime proof
+is acceptable for CLI readiness, but human output must not imply stronger
+profile-specific proof.
 
 ## Browser Profile Resolution
 
@@ -167,12 +197,30 @@ Default discovery must sort candidate profile directories deterministically:
 directories lexicographically by absolute path. `readdir` order is not a product
 contract.
 
+This requires a verify-specific profile resolver. Reusing lower-level browser
+doctor code is acceptable only if the resulting implementation supports explicit
+`--profile`, deterministic candidate ordering, candidate reporting, disabled
+extension state, and preservation of profile context in follow-up commands.
+
 The JSON response must include:
 
 - `browser.profile.path`: string path or `null`
 - `browser.profile.source`: `explicit | default_discovery`
 - `browser.profile.candidates`: array of candidate objects with `path`,
   `extensionInstalled`, and `extensionEnabled`
+- `browser.profile.runtimeBinding`: `profile_verified | single_candidate |
+  browser_extension_scope | not_available`
+
+`browser.profile.runtimeBinding` values mean:
+
+- `profile_verified`: descriptor metadata or direct popup/native-host status
+  identifies the resolved profile.
+- `single_candidate`: default discovery found exactly one matching profile, and
+  the runtime descriptor matches the selected browser and extension id but does
+  not expose profile identity.
+- `browser_extension_scope`: runtime proof matches only the selected browser and
+  extension id. Human output must not describe this as profile-bound readiness.
+- `not_available`: no runtime descriptor or status source is available.
 
 If an explicit profile is supplied and does not contain the target extension id,
 `browser.profile.path` must keep the explicit path,
@@ -187,6 +235,15 @@ id, `browser.profile.path` must be `null`, `browser.profile.source` must be
 `extensionInstalled` must be `missing`, and `nextAction.kind` must be
 `install_extension`.
 
+If a matching extension is present but disabled in the resolved profile,
+`extensionInstalled` must be `pass`, `extensionEnabled` must be `disabled`, and
+`nextAction.kind` must be `enable_extension`.
+
+When `--profile=<path>` is supplied, every generated rerun, repair, or follow-up
+command must preserve that exact `--profile` value. Default-discovery commands
+may omit `--profile` only when profile choice is deterministic and not material
+to the result.
+
 Human output should name the resolved profile only when profile choice affects
 the result or there are multiple candidates.
 
@@ -197,7 +254,8 @@ the result or there are multiple candidates.
 The top-level JSON field `verificationTarget` must be one of:
 
 - `cli`: default target. The command verifies local setup, selected agent
-  durable config, and a live browser backend descriptor.
+  durable config, a live browser backend descriptor, and direct OBU MCP runtime
+  status with at least one usable backend.
 - `agent_runtime`: stronger target. The command verifies CLI readiness and a
   status result from the selected, currently running agent process.
 
@@ -212,9 +270,11 @@ Required evidence:
 - Browser extension is installed and enabled in the resolved profile.
 - Runtime descriptor responds to `getInfo`.
 - `resumeRequired` is `false`.
+- Direct MCP runtime status has `mcpStarts: true`,
+  `sdkBootstrap: "available"`, and `backendCount > 0`.
 - Agent MCP config is equivalent to the expected OBU server.
 - Agent instruction check is either `pass` or a non-blocking `warn` with
-  `reason: "not_implemented"`.
+  `reason: "not_implemented"` or `reason: "missing_instruction"`.
 
 ### Agent-Runtime Readiness
 
@@ -262,6 +322,17 @@ obu verify \
   --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
 ```
 
+To verify a specific browser profile, add:
+
+```bash
+obu verify \
+  --agent=codex-cli \
+  --browser=chrome \
+  --profile="/Users/alex/Library/Application Support/Google/Chrome/Default" \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
 Read-only verification may inspect files, execute OBU binaries, probe runtime
 descriptors, and run read-only agent status commands. It must not write config,
 repair native-host manifests, create instruction files, or mutate agent MCP
@@ -281,6 +352,37 @@ This sets `verificationTarget: "agent_runtime"`. If OBU cannot obtain status
 from that agent process, the command must return a non-ready result with a
 single action such as restarting/reloading the agent or checking the agent's OBU
 MCP status from inside the client.
+
+Agent-runtime proof must come from a first-class agent-runtime status hook, not
+from a direct OBU MCP probe. The hook payload is the selected agent process's raw
+`browser_status` structured content plus enough envelope fields to bind it to the
+target agent and MCP server:
+
+```json
+{
+  "agentId": "codex-cli",
+  "mcpServerName": "open-browser-use",
+  "status": {
+    "sdk_bootstrap": "available",
+    "backends": [{ "...": "..." }]
+  }
+}
+```
+
+The initial CLI surface for this hook is:
+
+```bash
+obu verify --require-agent-runtime \
+  --agent-runtime-status-json=/path/to/status.json \
+  --agent=codex-cli \
+  --browser=chrome \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+If `--require-agent-runtime` is set and no valid hook payload is supplied,
+`agent.runtimeStatus.status` must be `not_checked`,
+`readiness.agentRuntime` must be `blocked`, and the result must not be `ready`.
 
 ### Explicit Repair
 
@@ -371,6 +473,12 @@ Rationale:
 - Agent-runtime-required verification adds the agent runtime as a required layer;
   CLI-level readiness alone is not enough for `ready` in that mode.
 
+MCP zero-backend classification happens after descriptor activation is
+classified. If local file/config state passes but no fresh runtime descriptor is
+active, `backendCount: 0` is treated as downstream evidence of the same popup
+activation boundary, and the result is `needs_browser_popup` with
+`nextAction.kind: "open_popup"`, not `needs_repair`.
+
 Examples:
 
 - Divergent Codex MCP config plus missing runtime descriptor:
@@ -381,6 +489,9 @@ Examples:
   `needs_browser_popup`.
 - Descriptor responds and agent MCP config is equivalent:
   `ready` when `verificationTarget` is `cli`.
+- Descriptor responds and agent MCP config is equivalent, but direct MCP runtime
+  status has `backendCount: 0`: `needs_repair` or `needs_manual_action`,
+  depending on whether the zero-backend cause is safely repairable.
 - Descriptor responds and agent MCP config is equivalent, but
   `--require-agent-runtime` cannot check the running agent:
   `needs_manual_action`.
@@ -398,6 +509,7 @@ Action kinds:
 - `resolve_config_conflict`
 - `restart_agent`
 - `install_extension`
+- `enable_extension`
 - `unsupported`
 
 Result/action mapping:
@@ -406,19 +518,23 @@ Result/action mapping:
 | --- | --- | --- |
 | No runnable OBU CLI exists before handoff reaches the CLI | `needs_manual_action` | `install_cli` |
 | Selected extension is not installed in the resolved profile | `needs_manual_action` | `install_extension` |
+| Selected extension is installed but disabled in the resolved profile | `needs_manual_action` | `enable_extension` |
 | Native-host manifest, allowed origin, host path, runtime permissions, or stale descriptor can be repaired deterministically | `needs_repair` | `run_repair` |
 | Missing first-class auto-writable agent MCP config and no divergent config exists | `needs_repair` | `run_repair` |
+| Direct MCP runtime cannot start, SDK bootstrap is unavailable, or backend count is zero for a reason repair can fix after descriptor activation has been ruled out | `needs_repair` | `run_repair` |
+| Direct MCP runtime cannot start, SDK bootstrap is unavailable, or backend count is zero for a reason outside safe CLI repair after descriptor activation has been ruled out | `needs_manual_action` | `configure_agent` |
 | Agent MCP config is missing but cannot be safely written by OBU | `needs_manual_action` | `configure_agent` |
 | Existing agent MCP config for `open-browser-use` is divergent or unreadable | `needs_manual_action` | `resolve_config_conflict` |
 | CLI-level readiness passes but `verificationTarget: "agent_runtime"` cannot be proved until the client reloads | `needs_manual_action` | `restart_agent` |
 | Local setup is correct but no fresh runtime descriptor is active | `needs_browser_popup` | `open_popup` |
-| Platform, browser, agent, or command input is unsupported | `needs_manual_action` | `unsupported` |
+| A syntactically valid platform, browser, or agent target is unsupported by this OBU build | `needs_manual_action` | `unsupported` |
 
 Each action must include:
 
 - a human message;
 - a command when a command is available;
 - enough context to preserve browser, channel, agent, and extension id;
+- the explicit profile path when verification was profile-scoped;
 - no ambiguous extension id inference.
 
 The next action must be directly actionable. It should not say "check docs" if a
@@ -429,9 +545,25 @@ command, `command` must be omitted and the action must include explicit context
 instead, such as `url`, `browser`, and `profile.path`. A generic operating-system
 `open` command is not enough when it may target the wrong browser or profile.
 
+Every `rerun` or repair command emitted after an explicit `--profile` input must
+include that same `--profile` argument.
+
+Invalid command input, unknown flags, malformed extension ids, and unsupported
+platform states that prevent verification from running are usage errors. They
+exit with code `2` and do not produce a normal readiness result. The
+`unsupported` next action is reserved for valid requests where OBU can run
+verification and determine that the requested target is outside its supported
+automation surface.
+
 ## JSON Contract
 
 The JSON schema is stable for agents:
+
+`obu verify` JSON uses lower camelCase field names. Lower-level doctor and MCP
+payloads may use snake_case, such as `resume_required` or `sdk_bootstrap`, but
+verify must normalize those fields to `resumeRequired` and `sdkBootstrap` in its
+top-level contract. Raw source payloads may appear only under clearly named
+diagnostic fields such as `details.raw`.
 
 Allowed top-level result values:
 
@@ -452,6 +584,8 @@ Allowed check status values:
 - `fail`: the check blocks readiness.
 - `not_checked`: the check was intentionally skipped and the reason is present.
 
+Every `not_checked` status object must include a non-empty `reason`.
+
 Allowed readiness values:
 
 - `ready`: this readiness level is verified.
@@ -471,7 +605,7 @@ Allowed component state values for summary fields such as `extensionInstalled`,
 - `not_checked`: the component was intentionally not checked and the reason is
   present in details.
 
-Unsupported instruction checks must use:
+Instruction check warnings must use one of these reason values:
 
 ```json
 {
@@ -480,7 +614,15 @@ Unsupported instruction checks must use:
 }
 ```
 
-They must not introduce a separate check status named `not_implemented`.
+```json
+{
+  "status": "warn",
+  "reason": "missing_instruction"
+}
+```
+
+They must not introduce separate check statuses named `not_implemented` or
+`missing_instruction`.
 
 `checks[]` contains the normalized lower-level evidence used to compute the
 result:
@@ -544,6 +686,7 @@ Allowed `checks[].layer` values:
     "profile": {
       "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
       "source": "default_discovery",
+      "runtimeBinding": "single_candidate",
       "candidates": [
         {
           "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
@@ -610,6 +753,12 @@ Allowed `checks[].layer` values:
       "message": "chrome.json responded to getInfo"
     },
     {
+      "id": "mcp-runtime-backend",
+      "layer": "mcp_runtime",
+      "status": "pass",
+      "message": "direct MCP probe found 1 usable backend"
+    },
+    {
       "id": "agent-mcp-server",
       "layer": "agent_mcp",
       "status": "pass",
@@ -641,7 +790,10 @@ Non-ready result:
     "id": "codex-cli",
     "mcpConfig": { "status": "pass" },
     "instructions": { "status": "pass" },
-    "runtimeStatus": { "status": "not_checked" }
+    "runtimeStatus": {
+      "status": "not_checked",
+      "reason": "target agent runtime is outside this CLI process"
+    }
   },
   "browser": {
     "kind": "chrome",
@@ -650,6 +802,7 @@ Non-ready result:
     "profile": {
       "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
       "source": "default_discovery",
+      "runtimeBinding": "not_available",
       "candidates": [
         {
           "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
@@ -710,6 +863,12 @@ Non-ready result:
       "details": { "resumeRequired": true }
     },
     {
+      "id": "mcp-runtime-backend",
+      "layer": "mcp_runtime",
+      "status": "fail",
+      "message": "direct MCP probe found zero usable browser backends"
+    },
+    {
       "id": "agent-mcp-server",
       "layer": "agent_mcp",
       "status": "pass",
@@ -728,6 +887,7 @@ open-browser-use is CLI-ready.
 Agent: codex-cli
 Browser: chrome Store extension fblnfcjnjklpgnmfnngcihbcgojnpadj
 Backend: webextension descriptor chrome.json responded to getInfo
+MCP runtime: direct probe found 1 usable backend
 Agent runtime: not checked
 ```
 
@@ -881,6 +1041,14 @@ after it reloaded MCP tools. Only this source can make
 It can prove CLI-level backend readiness, but it must not be treated as proof
 that the selected agent process has reloaded MCP tools.
 
+When `source: "direct_mcp_probe"` and the MCP process cannot start,
+`mcpStarts` must be `false`, `sdkBootstrap` must be `not_checked`,
+`backendCount` must be `null`, `backends` must be an empty array, and the
+blocking check must include launch error details. If the MCP process starts but
+`browser_status` cannot be read, `mcpStarts` must be `true`, `sdkBootstrap` must
+be `not_checked`, `backendCount` must be `null`, and `backends` must be an empty
+array.
+
 `source: "not_checked"` means MCP runtime status was not probed. In that case
 `mcpStarts` must be `null`, `sdkBootstrap` must be `not_checked`,
 `backendCount` must be `null`, and `backends` must be an empty array.
@@ -901,7 +1069,8 @@ The product is complete only when all of the following are true:
   `verificationTarget`, object-shaped `agent.runtimeStatus`, required
   `mcpRuntime.backends`, and non-empty `checks[]` evidence.
 - Human output gives one next action and no ambiguous action chain.
-- `ready` is impossible when browser backend count is zero.
+- `ready` is impossible when `mcpRuntime.backendCount` is zero or
+  `mcpRuntime.sdkBootstrap` is not `available`.
 - `verificationTarget: "agent_runtime"` cannot return `ready` unless
   `readiness.agentRuntime` is `ready`.
 - Browser profile discovery is deterministic and reports candidate profile state.
@@ -919,6 +1088,12 @@ The product is complete only when all of the following are true:
   verify readiness through OBU.
 - Clean-home smoke tests cover Codex, Cursor, Store extension id preservation,
   popup-required descriptor state, and divergent config conflicts.
+- Smoke or unit tests cover direct MCP runtime zero-backend results, SDK
+  bootstrap missing/untrusted results, disabled extensions, explicit profile
+  mismatch, deterministic multi-profile selection, wrong-browser or
+  wrong-extension descriptors, explicit `--profile` preservation in rerun/repair
+  commands, read-only verification performing no writes, and `--repair` refusing
+  divergent agent config.
 
 ## Product Principle
 

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -1023,12 +1023,12 @@ Action derivation sources:
 | Next action kind | Required source check layer | Required status | Required `blocks` | Candidate result |
 | --- | --- | --- | --- | --- |
 | `install_cli` | `cli_install` | `fail` | `["cli"]` | `needs_manual_action` |
-| `unsupported` | `target_support` | `fail` | `["cli"]` or `["agent_runtime"]` | `needs_manual_action` |
+| `unsupported` | `target_support` or `agent_runtime` | `fail` | `["cli"]` or `["agent_runtime"]` | `needs_manual_action` |
 | `resolve_config_conflict` | `agent_mcp` | `fail` | `["cli"]` | `needs_manual_action` |
 | `select_profile` | `browser_profile` | `fail` | `["cli"]` | `needs_manual_action` |
 | `install_extension` | `browser_extension` | `fail` | `["cli"]` | `needs_manual_action` |
 | `enable_extension` | `browser_extension` | `fail` | `["cli"]` | `needs_manual_action` |
-| `collect_agent_runtime_status` | `agent_runtime` | `not_checked` | `["agent_runtime"]` | `needs_manual_action` |
+| `collect_agent_runtime_status` | `agent_runtime` | `fail` | `["agent_runtime"]` | `needs_manual_action` |
 | `restart_agent` | `agent_runtime` | `fail` | `["agent_runtime"]` | `needs_manual_action` |
 | `configure_agent` | `agent_mcp`, `mcp_runtime`, or `agent_runtime` | `fail` | `["cli"]` or `["agent_runtime"]` | `needs_manual_action` |
 | `run_repair` | first repairable blocking layer | `fail` | `["cli"]` | `needs_repair` |
@@ -1652,14 +1652,15 @@ Non-ready result:
   },
   "mcpRuntime": {
     "cli": {
-      "source": "direct_mcp_probe",
-      "provenance": "expected_obu_invocation",
-      "probeCommandSource": "expected_obu_invocation",
+      "source": "not_checked",
+      "provenance": "not_applicable",
+      "probeCommandSource": "not_applicable",
       "mcpConfigured": true,
-      "mcpStarts": true,
-      "sdkBootstrap": "available",
-      "backendCount": 0,
-      "backends": []
+      "mcpStarts": null,
+      "sdkBootstrap": "not_checked",
+      "backendCount": null,
+      "backends": [],
+      "reason": "runtime_descriptor_not_active"
     },
     "agentRuntime": {
       "source": "not_checked",
@@ -1807,17 +1808,9 @@ Non-ready result:
     {
       "id": "mcp-runtime-backend",
       "layer": "mcp_runtime",
-      "status": "fail",
-      "blocks": [
-        "cli"
-      ],
-      "reason": "zero_backends_after_popup_boundary",
-      "message": "direct MCP probe found zero usable browser backends",
-      "actionCandidate": {
-        "kind": "open_popup",
-        "priority": 1,
-        "result": "needs_browser_popup"
-      },
+      "status": "not_checked",
+      "reason": "runtime_descriptor_not_active",
+      "message": "direct MCP probe was not run",
       "target": {
         "agent": "codex-cli",
         "browser": "chrome",
@@ -1978,10 +1971,9 @@ The extension handoff prompt must include:
 - popup guidance that says "click Resume if enabled" rather than assuming Resume
   is always clickable.
 
-Until `obu verify` is implemented, shipped popup handoff text may continue to
-point users at `obu doctor browser`. The verify implementation must update the
-popup handoff copy and tests in the same change that makes `obu verify` the
-canonical readiness command.
+Shipped popup handoff text must point users at `obu verify` as the canonical
+readiness command. It may reference `obu doctor browser` only as a lower-level
+diagnostic after verify has identified a browser-specific boundary.
 
 The Store extension id is security-sensitive native messaging state. Every
 doctor, setup, repair, verify, and generated command must preserve the exact
@@ -1998,7 +1990,8 @@ Setup requirements:
 - Write each first-class agent config to the same surface that doctor verifies.
 - Do not overwrite divergent MCP server settings.
 - Return manual action for unreadable or divergent config.
-- Preserve exact Store extension ids in all suggested doctor/repair commands.
+- Preserve exact Store extension ids in all suggested verify and repair
+  commands.
 - Write primary-browser instructions only when explicitly requested.
 - Include the final verification command in next actions.
 

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -1,0 +1,303 @@
+# Agent Setup State Closure
+
+Date: 2026-05-19
+
+## Product Goal
+
+Productize the setup state loop so a user, an agent, and the extension all get
+the same answer to one question:
+
+> Is open-browser-use ready for this agent to control this browser now?
+
+Today that answer is assembled from several partial surfaces: install output,
+`obu setup`, `obu doctor browser`, `obu agent doctor`, MCP `browser_status`, and
+the extension popup. Each surface is useful, but none owns the whole readiness
+contract. That makes the product feel brittle even when most components are
+working correctly.
+
+The desired product boundary is a single high-level verification path that
+returns one of four outcomes:
+
+- `ready`: the agent can use a browser backend now.
+- `needs_browser_popup`: local setup is correct, but Chrome has not activated
+  the extension/native-host runtime descriptor yet.
+- `needs_repair`: deterministic CLI repair is available and should be run.
+- `needs_manual_action`: the remaining action is outside CLI control, such as
+  installing the Store extension, resolving a divergent MCP config, restarting an
+  agent client, or choosing a config conflict resolution.
+
+## Why This Matters
+
+The recent clean-install feedback exposed a product-level state mismatch rather
+than one isolated bug:
+
+- The extension handoff assumed `~/.obu/bin/obu` might be available, but a clean
+  machine can start with no CLI at all.
+- Agent names used by humans (`codex`, `claude`) did not always match OBU's
+  adapter ids (`codex-cli`, `claude-code`).
+- `setup --agents=auto` could report an agent as configured through one path,
+  while `agent doctor` checked a different path.
+- Browser setup could be repaired on disk while the WebExtension runtime
+  descriptor was still absent because Chrome had not woken the extension.
+- MCP server availability and browser backend availability were treated as a
+  single status by agents, but they are separate layers.
+
+These are exactly the failures a state-closure product surface should prevent.
+
+## Current State Layers
+
+Readiness currently spans seven layers:
+
+1. **CLI install state**: `~/.obu/bin/obu` exists and reports the expected
+   version.
+2. **Native-host registration**: the browser manifest exists, points at an
+   executable host, and includes the exact Store extension id in
+   `allowed_origins`.
+3. **Browser extension installation state**: the selected browser profile has
+   the matching open-browser-use extension installed, enabled, and associated
+   with the extension id being verified.
+4. **Extension runtime state**: Chrome has activated the extension runtime and
+   the extension has connected to the native host.
+5. **Runtime descriptor state**: a valid WebExtension descriptor exists under
+   the owner-only runtime directory and responds to `getInfo`.
+6. **Agent MCP state**: the target agent is configured to launch
+   `open-browser-use` with `obu mcp stdio`.
+7. **Agent instruction state**: the agent has persistent guidance to prefer OBU
+   as the primary browser automation tool.
+
+The critical distinction is that layers 1, 2, 6, and 7 are mostly file/config
+state. Layer 3 depends on the selected browser profile. Layers 4 and 5 depend on
+Chrome extension runtime activation. The CLI can repair files, but it cannot
+force Chrome to keep an MV3 service worker alive.
+
+## Definition of Done
+
+A connection has two verification levels.
+
+CLI-level readiness means OBU can verify local setup and browser backend state
+without relying on a specific agent process:
+
+1. Browser doctor reports a live backend descriptor:
+
+   ```text
+   PASS Runtime descriptor probe: ... responded to getInfo
+   resume required: no
+   ```
+
+2. Agent doctor reports that the target agent has an equivalent
+   `open-browser-use` MCP configuration and, where supported, the primary-browser
+   instruction.
+
+Agent-runtime readiness is stronger. It means the target agent has reloaded its
+MCP tools and its own `browser_status` reports:
+
+   ```json
+   {
+     "sdk_bootstrap": "available",
+     "backends": [{ "...": "..." }]
+   }
+   ```
+
+An MCP server with `backends: []` is not ready for browser automation. It only
+proves that the MCP process can start.
+
+## Why Opening the Popup Is Sometimes Required
+
+Opening the extension popup is not a workaround for bad configuration. It is the
+browser UI boundary where Chrome activates the extension runtime.
+
+`obu doctor browser --repair` can fix:
+
+- native-host manifests;
+- allowed extension origins;
+- host binary paths;
+- runtime directory permissions;
+- stale or invalid descriptor files.
+
+It cannot force Chrome to:
+
+- wake the MV3 service worker immediately;
+- reconnect the extension to native messaging from outside the browser;
+- write a fresh WebExtension descriptor without extension runtime activity.
+
+Opening the popup wakes the extension and gives it a chance to connect to the
+native host. If the popup shows the host connected and the Resume button is
+disabled, that can still be a good state: the popup has already refreshed the
+connection. The correct next step is to rerun doctor and confirm
+`resume required: no`.
+
+## Proposed Product Surface
+
+Add one high-level command:
+
+```bash
+obu verify --agent=codex-cli --browser=chrome --channel=store --extension-id=<id>
+```
+
+The command should compose existing checks instead of replacing them. It should
+be read-only by default:
+
+1. Resolve install/runtime layout.
+2. Verify native-host browser setup and report any repair command.
+3. Verify extension installed/enabled/profile state.
+4. Probe browser descriptor state.
+5. Verify target agent MCP config.
+6. Verify target agent instruction state when implemented.
+7. Optionally run an MCP-level status probe when the target agent supports it or
+   when the current process can safely simulate it.
+8. Return one stable result and one next action.
+
+If mutation is needed, use an explicit flag or a different command path:
+
+```bash
+obu verify --repair --agent=codex-cli --browser=chrome --channel=store --extension-id=<id>
+```
+
+Example human outputs:
+
+```text
+open-browser-use is ready.
+Agent: codex-cli
+Browser: chrome Store extension fblnfcjnjklpgnmfnngcihbcgojnpadj
+Backend: webextension descriptor chrome.json responded to getInfo
+```
+
+```text
+Browser popup required.
+Local setup appears correct, but no active WebExtension descriptor exists yet.
+Open the open-browser-use extension popup. If Resume is enabled, click it.
+If it already shows Connected, wait briefly and rerun:
+  obu verify --agent=codex-cli --browser=chrome --channel=store --extension-id=...
+```
+
+```text
+Agent configuration required.
+Codex MCP config is missing open-browser-use.
+Run:
+  obu setup --yes --agents=codex-cli --write-instructions
+```
+
+## JSON Contract
+
+The verification JSON should be stable enough for agents:
+
+```json
+{
+  "schemaVersion": 1,
+  "command": "verify",
+  "result": "ready",
+  "agent": {
+    "id": "codex-cli",
+    "mcpConfig": "pass",
+    "instructions": "pass",
+    "runtimeStatus": "not_checked"
+  },
+  "browser": {
+    "kind": "chrome",
+    "channel": "store",
+    "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+    "extensionInstalled": "pass",
+    "nativeHost": "pass",
+    "runtimeDescriptor": "pass",
+    "resumeRequired": false
+  },
+  "mcpRuntime": {
+    "sdkBootstrap": "available",
+    "backendCount": 1
+  },
+  "nextAction": null
+}
+```
+
+For non-ready states, `nextAction` should be a single object:
+
+```json
+{
+  "kind": "open_popup",
+  "message": "Open the extension popup; click Resume if enabled, otherwise wait for Connected and rerun verify."
+}
+```
+
+## Systemic Fix Cut Points
+
+### 1. One Source of Truth per Agent
+
+For each first-class agent, setup and doctor must read/write the same config
+surface.
+
+Current direction:
+
+- Codex: `~/.codex/config.toml` for MCP, `~/.codex/AGENTS.md` for global
+  instructions.
+- Cursor: `~/.cursor/mcp.json` for MCP.
+- Claude Code: `claude mcp` for MCP, `~/.claude/CLAUDE.md` for global
+  instructions.
+
+Avoid reporting "configured" when the doctor cannot verify the same state.
+
+### 2. Normalize Human Agent Names
+
+Accept common names as aliases:
+
+- `codex` -> `codex-cli`
+- `claude` -> `claude-code`
+- `gemini` -> `gemini-cli`
+
+Output should still show canonical ids so logs and docs remain precise.
+
+### 3. Separate MCP Availability from Browser Availability
+
+The MCP server can be healthy while browser backends are unavailable. Product
+output should make this explicit:
+
+- MCP configured: yes/no.
+- MCP starts: yes/no.
+- SDK bootstrap: available/missing/untrusted.
+- Browser backend count: `0` means not ready.
+
+### 4. Make Popup State Machine-Readable
+
+The popup should eventually expose or display a direct readiness state:
+
+- `Native host: connected`
+- `Descriptor: active`
+- `Resume required: yes/no`
+- `Last descriptor refresh: timestamp`
+
+This would let users and agents understand whether opening the popup already
+fixed the descriptor activation boundary.
+
+### 5. Keep Prompts as Fallback, Not the State Machine
+
+The agent install prompt should guide unusual environments, but it should not be
+the main state engine. The CLI should produce the canonical machine-readable
+diagnosis and the prompt should tell agents to trust that diagnosis.
+
+### 6. Preserve Exact Store Extension IDs
+
+Store extension id is security-sensitive native messaging state. Every repair,
+doctor, setup, verify, and follow-up command must preserve the exact handoff id
+unless OBU can prove the same id is already configured.
+
+## Short-Term Implementation Plan
+
+1. Keep these first-class setup invariants in place:
+   - agent alias normalization;
+   - Codex config read/write/doctor support;
+   - Cursor setup and doctor using the same `mcp.json`;
+   - longer Claude Code doctor timeout;
+   - clearer popup/doctor Resume wording.
+2. Add `obu verify` as a thin composition layer over existing setup, browser
+   doctor, agent doctor, and MCP status primitives.
+3. Add a release smoke that runs verify in a clean temporary home for Codex and
+   Cursor config paths.
+4. Extend popup status to distinguish host connection from active descriptor
+   readiness.
+5. Update the extension handoff prompt to prefer `obu verify` as the final
+   readiness gate.
+
+## Product Principle
+
+No user or agent should need to infer readiness by stitching together partial
+success messages. The product should own the state closure and return one
+truthful next action.

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -126,9 +126,11 @@ and report each layer in JSON.
    - The descriptor points at a socket-like endpoint.
    - The descriptor responds to `getInfo`.
    - The descriptor lifecycle is not stale.
-   - Descriptor metadata matches the selected browser kind and exact extension
-     id when those fields are present. A Store-channel target cannot be
-     certified by a descriptor whose metadata proves a different extension id.
+   - WebExtension descriptor metadata must include the selected browser kind and
+     exact extension id. `metadata.extension_id` must equal the verification
+     `browser.extensionId`; missing, `"unknown"`, or different extension ids do
+     not certify WebExtension readiness. This is mandatory for Store-channel
+     targets.
    - If verification is profile-scoped, descriptor metadata or a future
      popup/native-host status source must bind the runtime to the resolved
      profile. Without profile identity evidence, the JSON must state that the
@@ -143,7 +145,8 @@ and report each layer in JSON.
    - MCP status reports `sdk_bootstrap: "available"` in raw MCP status,
      normalized to `sdkBootstrap: "available"` in verify JSON.
    - MCP status reports at least one usable browser backend for the selected
-     browser/extension runtime.
+     browser/extension runtime, including verified WebExtension extension
+     identity for WebExtension backends.
    - `backends: []` is a blocking state even when the MCP process starts.
 
 8. **Agent MCP state**
@@ -182,8 +185,8 @@ state, and backend discovery. The CLI can repair deterministic file/config
 state, but it cannot force Chrome to keep an MV3 service worker alive.
 
 For CLI verification, extension runtime state is considered active when a
-runtime descriptor for the selected browser responds to `getInfo` and any
-available descriptor metadata matches the selected extension id. It is considered
+runtime descriptor for the selected browser responds to `getInfo` and
+WebExtension descriptor metadata proves the selected extension id. It is considered
 inactive when native-host and extension file/config state pass but no fresh
 descriptor can be probed. The corresponding check must include
 `details.source: "runtime_descriptor_probe"` unless a future popup/native-host
@@ -192,18 +195,23 @@ status API supplies a more direct source.
 When descriptor metadata cannot prove profile identity, `obu verify` must expose
 that limitation explicitly in `browser.profile.runtimeBinding`. It must not
 claim profile-bound runtime readiness unless descriptor metadata or a direct
-popup/native-host status source identifies the resolved profile. For default
-discovery with a single matching profile, browser/extension-scoped runtime proof
-is acceptable for CLI readiness, but human output must not imply stronger
-profile-specific proof.
+popup/native-host status source identifies the resolved profile. Browser/extension
+scoped runtime proof is acceptable for CLI readiness when the selected profile
+was explicit or default discovery found exactly one matching profile, but human
+output must not imply stronger profile-specific proof.
 
-For profile-scoped verification, runtime proof is stricter:
+For profile-scoped verification, runtime proof is explicit:
 
-- If `--profile=<path>` is supplied, `result: "ready"` requires
-  `browser.profile.runtimeBinding: "profile_verified"`.
+- If `--profile=<path>` is supplied and the runtime cannot be bound to that
+  profile, `result: "ready"` is still allowed only at browser/extension scope.
+  JSON must set `browser.profile.runtimeBinding: "browser_extension_scope"` and
+  include a non-blocking `browser_profile` warning with
+  `reason: "profile_runtime_not_bound"`.
 - If default discovery finds multiple matching profiles, `result: "ready"`
   requires `profile_verified`; otherwise return `needs_manual_action` with
-  `nextAction.kind: "select_profile"`.
+  `nextAction.kind: "select_profile"`. Supplying an explicit `--profile` is one
+  way to resolve the ambiguity, but the resulting runtime proof may still be
+  browser/extension-scoped unless a future profile identity source exists.
 - `single_candidate` is only acceptable for CLI readiness when default discovery
   found exactly one matching enabled extension profile.
 
@@ -250,7 +258,8 @@ The JSON response must include:
 - `browser.profile.path`: string path or `null`
 - `browser.profile.source`: `explicit | default_discovery`
 - `browser.profile.candidates`: array of candidate objects with `path`,
-  `profileExists`, `extensionInstalled`, and `extensionEnabled`
+  `profileExists`, `extensionInstalled`, `extensionEnabled`, and optional
+  `reasons` keyed by those field names when any candidate field is `not_checked`
 - `browser.profile.runtimeBinding`: `profile_verified | single_candidate |
   browser_extension_scope | not_available`
 
@@ -269,22 +278,27 @@ If an explicit profile is supplied and the path does not exist or cannot be
 inspected, `browser.profile.path` must keep the explicit path,
 `browser.profile.source` must be `explicit`, `browser.profile.candidates` must
 contain only that path with `profileExists: "missing"`,
-`extensionInstalled: "not_checked"`, and `extensionEnabled: "not_checked"`, and
-`nextAction.kind` must be `select_profile`.
+`extensionInstalled: "not_checked"`, and `extensionEnabled: "not_checked"`.
+The candidate must include `reasons.extensionInstalled` and
+`reasons.extensionEnabled` explaining that extension state cannot be inspected
+until the profile exists. `nextAction.kind` must be `select_profile`.
 
 If an explicit profile is supplied and does not contain the target extension id,
 `browser.profile.path` must keep the explicit path,
 `browser.profile.source` must be `explicit`, `browser.profile.candidates` must
 contain only that path with `profileExists: "pass"`,
-`extensionInstalled: "missing"`, and `extensionEnabled: "not_checked"`,
-top-level `extensionInstalled` must be `missing`, and `nextAction.kind` must be
+`extensionInstalled: "missing"`, and `extensionEnabled: "not_checked"`. The
+candidate must include `reasons.extensionEnabled` explaining that enablement was
+not inspected because the extension is missing. Top-level `extensionInstalled`
+must be `missing`, and `nextAction.kind` must be
 `install_extension`.
 
 If default discovery cannot find or inspect the selected browser profile root,
 `browser.profile.path` must be `null`, `browser.profile.source` must be
 `default_discovery`, `browser.profile.candidates` must be an empty array,
-`extensionInstalled` must be `not_checked`, and `nextAction.kind` must be
-`select_profile`.
+`extensionInstalled` must be `not_checked`, and the blocking
+`browser_profile` check must include `reason: "profile_root_missing"` or a more
+specific inspection failure reason. `nextAction.kind` must be `select_profile`.
 
 If default discovery finds browser profiles but no candidate profile containing
 the target extension id, `browser.profile.path` must be `null`,
@@ -328,12 +342,14 @@ Required evidence:
 - Browser extension is installed and enabled in the resolved profile.
 - Runtime descriptor responds to `getInfo`.
 - `browser.profile.runtimeBinding` is strong enough for the selected profile
-  mode: `profile_verified` for explicit profile or multi-profile verification,
-  and either `profile_verified` or `single_candidate` for default discovery with
-  exactly one matching profile.
+  mode: `profile_verified`, `browser_extension_scope` with a
+  `profile_runtime_not_bound` warning for explicit profile verification, or
+  `single_candidate` for default discovery with exactly one matching profile.
 - `resumeRequired` is `false`.
 - Direct MCP runtime status has `mcpStarts: true`,
   `sdkBootstrap: "available"`, and `backendCount > 0`.
+- At least one usable WebExtension backend in direct MCP status has normalized
+  extension identity matching the selected `browser.extensionId`.
 - Agent MCP config is equivalent to the expected OBU server.
 - Agent instruction check is either `pass` or a non-blocking `warn` with
   `reason: "not_implemented"` or `reason: "missing_instruction"`.
@@ -464,8 +480,10 @@ can make `readiness.agentRuntime` become `ready` only when all of these are true
   command, or an equivalent first-class challenge stored by the CLI.
 - `agentId`, `mcpServerName`, browser, channel, extension id, and explicit
   profile value match the verification target.
-- At least one backend in the status payload matches the selected browser and
-  extension id through backend metadata when metadata is present.
+- At least one WebExtension backend in the status payload has normalized
+  extension identity proving `extensionId === browser.extensionId`; metadata-less
+  or `"unknown"` WebExtension backends do not count as usable for a selected
+  extension id.
 
 Raw `browser_status` output or a standalone status JSON without a fresh matching
 challenge is diagnostic evidence only; it must not produce
@@ -492,6 +510,23 @@ obu verify --require-agent-runtime \
   --channel=store \
   --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
 ```
+
+The first command is a challenge-issuance verification pass. If CLI-level
+readiness is blocked, it returns the normal blocking result and may omit the
+challenge file. If CLI-level readiness is complete and the challenge file is
+written, but no valid agent-runtime status payload has been supplied yet, the
+command returns:
+
+- exit code `1`;
+- `result: "needs_manual_action"`;
+- `readiness.cli: "ready"`;
+- `readiness.agentRuntime: "blocked"`;
+- `agent.runtimeStatus.status: "not_checked"`;
+- `agent.runtimeStatus.reason: "agent_runtime_challenge_issued"`;
+- `nextAction.kind: "collect_agent_runtime_status"`;
+- `nextAction.challenge.path`: the challenge JSON path.
+
+This is a pending agent-runtime proof state, not a failed local setup state.
 
 If `--require-agent-runtime` is set and no valid hook payload is supplied,
 `agent.runtimeStatus.status` must be `not_checked`,
@@ -603,8 +638,9 @@ For `needs_manual_action`, action priority is:
 4. `select_profile`
 5. `install_extension`
 6. `enable_extension`
-7. `restart_agent`
-8. `configure_agent`
+7. `collect_agent_runtime_status`
+8. `restart_agent`
+9. `configure_agent`
 
 For `needs_repair`, the `run_repair` command should target the first repairable
 blocking layer in verification order. The repair command may repair multiple
@@ -621,7 +657,8 @@ Examples:
   `needs_repair`.
 - Native host and extension are correct, but descriptor is absent:
   `needs_browser_popup`.
-- Descriptor responds and agent MCP config is equivalent:
+- Descriptor responds, direct MCP runtime proves `sdkBootstrap: "available"` with
+  at least one identity-matched backend, and agent MCP config is equivalent:
   `ready` when `verificationTarget` is `cli`.
 - Descriptor responds and agent MCP config is equivalent, but direct MCP runtime
   status has `backendCount: 0`: `needs_repair` or `needs_manual_action`,
@@ -642,6 +679,7 @@ Action kinds:
 - `configure_agent`
 - `resolve_config_conflict`
 - `restart_agent`
+- `collect_agent_runtime_status`
 - `select_profile`
 - `install_extension`
 - `enable_extension`
@@ -662,6 +700,7 @@ Result/action mapping:
 | Direct MCP runtime cannot start, SDK bootstrap is unavailable, or backend count is zero for a reason outside safe CLI repair after descriptor activation has been ruled out | `needs_manual_action` | `configure_agent` |
 | Agent MCP config is missing but cannot be safely written by OBU | `needs_manual_action` | `configure_agent` |
 | Existing agent MCP config for `open-browser-use` is divergent or unreadable | `needs_manual_action` | `resolve_config_conflict` |
+| CLI-level readiness passes and an agent-runtime challenge has been issued but no valid status payload is available yet | `needs_manual_action` | `collect_agent_runtime_status` |
 | CLI-level readiness passes but `verificationTarget: "agent_runtime"` cannot be proved until the client reloads | `needs_manual_action` | `restart_agent` |
 | Local setup is correct but no fresh runtime descriptor is active | `needs_browser_popup` | `open_popup` |
 | A syntactically valid platform, browser, or agent target is unsupported by this OBU build | `needs_manual_action` | `unsupported` |
@@ -721,7 +760,9 @@ Allowed check status values:
 - `fail`: the check blocks readiness.
 - `not_checked`: the check was intentionally skipped and the reason is present.
 
-Every `not_checked` status object must include a non-empty `reason`.
+Every `not_checked` status object must include a non-empty `reason`. Scalar
+component fields with value `not_checked` must have a sibling `reason` or
+`reasons.<fieldName>` entry on the containing object.
 
 Allowed readiness values:
 
@@ -862,7 +903,16 @@ Allowed `checks[].layer` values:
     "backends": [
       {
         "kind": "webextension",
-        "browser": "chrome"
+        "browser": "chrome",
+        "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+        "extensionIdentity": {
+          "source": "descriptor_metadata",
+          "verified": true
+        },
+        "metadata": {
+          "browserKind": "chrome",
+          "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj"
+        }
       }
     ]
   },
@@ -992,6 +1042,12 @@ Non-ready result:
   },
   "checks": [
     {
+      "id": "cli-version",
+      "layer": "cli_install",
+      "status": "pass",
+      "message": "obu version is parseable"
+    },
+    {
       "id": "native-host-manifest",
       "layer": "native_host",
       "status": "pass",
@@ -1037,6 +1093,12 @@ Non-ready result:
       "layer": "agent_mcp",
       "status": "pass",
       "message": "codex-cli configures open-browser-use"
+    },
+    {
+      "id": "agent-primary-instruction",
+      "layer": "agent_instruction",
+      "status": "pass",
+      "message": "primary browser instruction found"
     }
   ]
 }
@@ -1142,6 +1204,11 @@ The extension handoff prompt must include:
 - popup guidance that says "click Resume if enabled" rather than assuming Resume
   is always clickable.
 
+Until `obu verify` is implemented, shipped popup handoff text may continue to
+point users at `obu doctor browser`. The verify implementation must update the
+popup handoff copy and tests in the same change that makes `obu verify` the
+canonical readiness command.
+
 The Store extension id is security-sensitive native messaging state. Every
 doctor, setup, repair, verify, and generated command must preserve the exact
 handoff id unless OBU can prove the same id is already configured.
@@ -1197,7 +1264,10 @@ Required fields:
   checked directly.
 - `sdkBootstrap`: `available | missing | untrusted | not_checked`.
 - `backendCount`: `number | null`; number of usable browser backends.
-- `backends`: backend summaries when available.
+- `backends`: backend summaries when available. WebExtension backend summaries
+  must include normalized `browser`, `extensionId`, and `extensionIdentity`
+  fields. A WebExtension backend without verified extension identity cannot
+  contribute to `backendCount` for extension-scoped readiness.
 
 `source: "agent_runtime"` means the status came from the selected agent process
 after it reloaded MCP tools. Only this source can make
@@ -1243,15 +1313,22 @@ The product is complete only when all of the following are true:
   `mcpRuntime.sdkBootstrap` is not `available`.
 - `verificationTarget: "agent_runtime"` cannot return `ready` unless
   `readiness.agentRuntime` is `ready`, and agent-runtime evidence has fresh
-  challenge binding, target binding, and matching backend metadata when metadata
-  is present.
+  challenge binding, target binding, and verified WebExtension extension
+  identity matching `browser.extensionId`.
+- WebExtension `backendCount` excludes metadata-less, `"unknown"`, wrong-browser,
+  or wrong-extension backends; Store-channel readiness always requires exact
+  extension id proof.
 - Browser profile discovery is deterministic and reports candidate profile state.
-- Explicit-profile readiness and multi-profile readiness require
-  `browser.profile.runtimeBinding: "profile_verified"`.
+- Explicit-profile readiness may be browser/extension-scoped only when JSON and
+  human output warn with `reason: "profile_runtime_not_bound"`; multi-profile
+  default readiness still requires `profile_verified` or `select_profile`.
 - Missing profile roots or nonexistent explicit profiles produce
   `nextAction.kind: "select_profile"`, not `install_extension`.
+- Candidate fields using `not_checked` include per-field reasons.
 - Same-result-class failures choose `nextAction` by the deterministic priority
   table in this document.
+- Agent-runtime challenge issuance has a defined `needs_manual_action` pending
+  state with `nextAction.kind: "collect_agent_runtime_status"`.
 - Direct MCP probes never execute divergent or unreadable agent-config commands.
 - `needs_browser_popup` is returned when local setup is correct but descriptor
   activation is missing.
@@ -1265,6 +1342,9 @@ The product is complete only when all of the following are true:
 - Popup status distinguishes native-host connection from descriptor readiness.
 - Extension handoff text preserves exact Store extension id and tells agents to
   verify readiness through OBU.
+- When `obu verify` lands, popup handoff text and tests replace doctor retry
+  guidance with verify retry guidance while preserving the current fallback until
+  the command exists.
 - Clean-home smoke tests cover Codex, Cursor, Store extension id preservation,
   popup-required descriptor state, and divergent config conflicts.
 - Smoke or unit tests cover direct MCP runtime zero-backend results, SDK
@@ -1272,8 +1352,8 @@ The product is complete only when all of the following are true:
   mismatch, deterministic multi-profile selection, wrong-browser or
   wrong-extension descriptors, explicit `--profile` preservation in rerun/repair
   commands, read-only verification performing no writes, stale or unbound
-  agent-runtime status JSON, direct probe refusal for divergent agent config, and
-  `--repair` refusing divergent agent config.
+  agent-runtime status JSON, challenge issuance mode, direct probe refusal for
+  divergent agent config, and `--repair` refusing divergent agent config.
 
 ## Product Principle
 

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -700,7 +700,8 @@ Raw `browser_status` output or a standalone status JSON without a fresh matching
 challenge is diagnostic evidence only; it must not produce
 `verificationTarget: "agent_runtime"` / `result: "ready"`.
 
-When a trusted hook is available, the normal command is still:
+When a trusted hook implementation and transport are registered for the selected
+agent, the normal command is still:
 
 ```bash
 obu verify --require-agent-runtime \
@@ -710,9 +711,12 @@ obu verify --require-agent-runtime \
   --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
 ```
 
-OBU invokes the registered hook for `codex-cli`, validates the returned envelope,
-derives `agent.runtimeStatus.hook.trusted: true`, and reports
+OBU invokes the registered hook, validates the returned envelope, derives
+`agent.runtimeStatus.hook.trusted: true`, and reports
 `mcpRuntime.agentRuntime.source: "agent_runtime"` only for trusted hook evidence.
+If this OBU build has no registered trusted hook for the selected agent, the
+command must return `agent_runtime_hook_unavailable`; it must not emit a
+`trustedHook` object or write a challenge file for an unimplemented transport.
 
 Some hooks may need a user-mediated in-agent collection step after CLI readiness
 passes. In that case OBU issues a challenge for the trusted hook, not for an
@@ -780,11 +784,13 @@ diagnostic evidence only. Only a trusted first-class hook can report
 `mcpRuntime.agentRuntime.source: "agent_runtime"` to make
 `readiness.agentRuntime` ready.
 
-The challenge-out command is a challenge-issuance verification pass. If CLI-level
-readiness is blocked, it returns the normal blocking result and may omit the
-challenge file. If CLI-level readiness is complete and the challenge file is
-written, but no valid trusted hook payload has been supplied yet, the command
-returns:
+The challenge-out command is a challenge-issuance verification pass only when a
+trusted hook is registered. If CLI-level readiness is blocked, it returns the
+normal blocking result and may omit the challenge file. If no trusted hook is
+registered for the selected agent, it returns `agent_runtime_hook_unavailable`
+and must not write a challenge file. If CLI-level readiness is complete, a
+trusted hook is registered, and the challenge file is written, but no valid
+trusted hook payload has been supplied yet, the command returns:
 
 - exit code `1`;
 - `result: "needs_manual_action"`;
@@ -803,8 +809,8 @@ If `--require-agent-runtime` is set and no valid hook payload is supplied,
 `readiness.agentRuntime` must be `blocked`, and the result must not be `ready`.
 The blocking check must use `checks[].layer: "agent_runtime"`,
 `blocks: ["agent_runtime"]`, and an `actionCandidate` for
-`collect_agent_runtime_status`, `restart_agent`, or `configure_agent` as
-appropriate.
+`unsupported`, `collect_agent_runtime_status`, `restart_agent`, or
+`configure_agent` as appropriate.
 
 ### Explicit Repair
 
@@ -1006,7 +1012,8 @@ Result/action mapping:
 | Direct MCP runtime cannot start, SDK bootstrap is unavailable, or backend count is zero for a reason outside safe CLI repair after descriptor activation has been ruled out | `needs_manual_action` | `configure_agent` |
 | Agent MCP config is missing but cannot be safely written by OBU | `needs_manual_action` | `configure_agent` |
 | Existing agent MCP config for `open-browser-use` is divergent or unreadable | `needs_manual_action` | `resolve_config_conflict` |
-| CLI-level readiness passes and an agent-runtime challenge has been issued but no valid trusted hook payload is available yet | `needs_manual_action` | `collect_agent_runtime_status` |
+| CLI-level readiness passes but no trusted agent-runtime hook is registered for the selected agent in this build | `needs_manual_action` | `unsupported` |
+| CLI-level readiness passes, a trusted agent-runtime hook is registered, and an agent-runtime challenge has been issued but no valid trusted hook payload is available yet | `needs_manual_action` | `collect_agent_runtime_status` |
 | CLI-level readiness passes but `verificationTarget: "agent_runtime"` cannot be proved until the client reloads | `needs_manual_action` | `restart_agent` |
 | Local setup is correct but no fresh runtime descriptor is active | `needs_browser_popup` | `open_popup` |
 | A syntactically valid platform, browser, or agent target is unsupported by this OBU build | `needs_manual_action` | `unsupported` |
@@ -1187,8 +1194,19 @@ trusted hook evidence:
 }
 ```
 
-Challenge issuance without a returned trusted hook payload is a pending
-agent-runtime proof state:
+When no trusted hook is registered for the selected agent, agent-runtime proof is
+unavailable in this build:
+
+```json
+{
+  "status": "not_checked",
+  "provenance": "not_applicable",
+  "reason": "agent_runtime_hook_unavailable"
+}
+```
+
+Challenge issuance through a registered trusted hook without a returned trusted
+hook payload is a pending agent-runtime proof state:
 
 ```json
 {
@@ -2167,8 +2185,10 @@ The product is complete only when all of the following are true:
 - Every allowed `nextAction.kind` is covered by the action derivation source
   table.
 - Every check includes explicit `target` and `evidence` objects.
-- Agent-runtime challenge issuance has a defined `needs_manual_action` pending
-  state with `nextAction.kind: "collect_agent_runtime_status"`.
+- Agent-runtime hook unavailability has a defined `needs_manual_action` state
+  with `nextAction.kind: "unsupported"`, and registered-hook challenge issuance
+  has a defined pending state with
+  `nextAction.kind: "collect_agent_runtime_status"`.
 - Direct MCP probes never execute divergent or unreadable agent-config commands.
 - `needs_browser_popup` is returned when local setup is correct but descriptor
   activation is missing.

--- a/docs/agent-setup-state-closure.md
+++ b/docs/agent-setup-state-closure.md
@@ -2,111 +2,793 @@
 
 Date: 2026-05-19
 
-## Product Goal
+## Product Contract
 
-Productize the setup state loop so a user, an agent, and the extension all get
-the same answer to one question:
+open-browser-use owns one readiness question end to end:
 
-> Is open-browser-use ready for this agent to control this browser now?
+> Is the selected agent/browser pair ready at the requested verification level?
 
-Today that answer is assembled from several partial surfaces: install output,
+The product answer must come from one canonical verification surface, not from a
+user or agent stitching together partial signals from install logs,
 `obu setup`, `obu doctor browser`, `obu agent doctor`, MCP `browser_status`, and
-the extension popup. Each surface is useful, but none owns the whole readiness
-contract. That makes the product feel brittle even when most components are
-working correctly.
+the extension popup.
 
-The desired product boundary is a single high-level verification path that
-returns one of four outcomes:
+Once a runnable OBU CLI exists, the canonical surface is:
 
-- `ready`: the agent can use a browser backend now.
+```bash
+obu verify --agent=<agent-id> --browser=<browser> --channel=<channel> --extension-id=<id>
+```
+
+By default, `obu verify` answers CLI-level readiness for the selected agent's
+durable configuration and the selected browser backend. Agent-runtime readiness
+is a stronger target and must be requested or supplied by an agent-runtime status
+hook. The JSON always states which target was used.
+
+It returns exactly one high-level result:
+
+- `ready`: OBU has verified readiness for the requested target. For
+  `verificationTarget: "cli"`, this means CLI-level readiness is complete for
+  the selected agent config and browser, including a live browser backend
+  descriptor. For `verificationTarget: "agent_runtime"`, the selected agent
+  runtime has also proved at least one usable backend through OBU MCP status.
 - `needs_browser_popup`: local setup is correct, but Chrome has not activated
   the extension/native-host runtime descriptor yet.
-- `needs_repair`: deterministic CLI repair is available and should be run.
-- `needs_manual_action`: the remaining action is outside CLI control, such as
-  installing the Store extension, resolving a divergent MCP config, restarting an
-  agent client, or choosing a config conflict resolution.
+- `needs_repair`: OBU found a deterministic repair it can apply with an
+  explicit repair command.
+- `needs_manual_action`: the remaining action is outside safe CLI control.
 
-## Why This Matters
+The command returns exactly one next action for every non-ready result. The user
+or agent should never have to infer what to do next from multiple successful but
+incomplete checks.
 
-The recent clean-install feedback exposed a product-level state mismatch rather
-than one isolated bug:
+There is one pre-CLI exception: if no runnable OBU CLI exists, `obu verify`
+cannot be invoked. In that state, the extension handoff, installer, or agent
+install prompt owns the preflight result and must return the same product result
+shape at the handoff level:
 
-- The extension handoff assumed `~/.obu/bin/obu` might be available, but a clean
-  machine can start with no CLI at all.
-- Agent names used by humans (`codex`, `claude`) did not always match OBU's
-  adapter ids (`codex-cli`, `claude-code`).
-- `setup --agents=auto` could report an agent as configured through one path,
-  while `agent doctor` checked a different path.
-- Browser setup could be repaired on disk while the WebExtension runtime
-  descriptor was still absent because Chrome had not woken the extension.
-- MCP server availability and browser backend availability were treated as a
-  single status by agents, but they are separate layers.
+- `result: "needs_manual_action"`
+- `nextAction.kind: "install_cli"`
+- install command or official install URL
 
-These are exactly the failures a state-closure product surface should prevent.
+After the CLI exists, all readiness answers flow through `obu verify`.
 
-## Current State Layers
+## Why This Exists
 
-Readiness currently spans seven layers:
+Clean-install feedback exposed state mismatches across the setup flow:
 
-1. **CLI install state**: `~/.obu/bin/obu` exists and reports the expected
-   version.
-2. **Native-host registration**: the browser manifest exists, points at an
-   executable host, and includes the exact Store extension id in
-   `allowed_origins`.
-3. **Browser extension installation state**: the selected browser profile has
-   the matching open-browser-use extension installed, enabled, and associated
-   with the extension id being verified.
-4. **Extension runtime state**: Chrome has activated the extension runtime and
-   the extension has connected to the native host.
-5. **Runtime descriptor state**: a valid WebExtension descriptor exists under
-   the owner-only runtime directory and responds to `getInfo`.
-6. **Agent MCP state**: the target agent is configured to launch
-   `open-browser-use` with `obu mcp stdio`.
-7. **Agent instruction state**: the agent has persistent guidance to prefer OBU
-   as the primary browser automation tool.
+- The extension handoff can tell agents to use `~/.obu/bin/obu`, but a fresh
+  machine may not have the CLI installed yet.
+- Human agent names such as `codex`, `claude`, and `gemini` can differ from OBU
+  adapter ids such as `codex-cli`, `claude-code`, and `gemini-cli`.
+- `setup --agents=auto` can configure one path while `agent doctor` checks a
+  different path.
+- Browser pairing can be repaired on disk while Chrome has not activated the
+  WebExtension runtime descriptor.
+- MCP server availability and browser backend availability are separate states,
+  but agents often treat them as one status.
+- Opening the extension popup can be required to wake the MV3 extension runtime,
+  but the current wording can make that look like a workaround instead of a
+  browser lifecycle boundary.
 
-The critical distinction is that layers 1, 2, 6, and 7 are mostly file/config
-state. Layer 3 depends on the selected browser profile. Layers 4 and 5 depend on
-Chrome extension runtime activation. The CLI can repair files, but it cannot
+State closure means OBU turns these partial facts into one truthful result and
+one precise next action.
+
+## Verification Layers
+
+Readiness spans seven layers. `obu verify` must evaluate them in a stable order
+and report each layer in JSON.
+
+1. **CLI install state**
+   - The executing CLI is valid, and the release CLI exists at the expected path
+     when verification is running from a packaged install, normally
+     `~/.obu/bin/obu`.
+   - The binary is executable.
+   - `obu --version` returns a parseable version.
+
+2. **Native-host registration**
+   - The selected browser has a native messaging manifest.
+   - The manifest points at an executable OBU native host.
+   - The manifest includes the exact verified extension origin:
+     `chrome-extension://<extension-id>/`.
+   - Store channel verification must preserve the supplied Store extension id.
+
+3. **Browser extension installation state**
+   - The resolved browser profile contains the matching extension id.
+   - The extension is enabled.
+   - The extension channel and id match the verification target.
+
+4. **Extension runtime state**
+   - Chrome has activated the extension runtime.
+   - The extension has connected to native messaging.
+   - The popup can expose this as native-host connection state.
+   - The CLI must report the evidence source. Outside the popup, runtime
+     activation is inferred from runtime descriptor probing; the CLI cannot read
+     arbitrary MV3 service-worker state directly.
+
+5. **Runtime descriptor state**
+   - The owner-only runtime descriptor directory exists.
+   - At least one descriptor is valid JSON.
+   - The descriptor points at a socket-like endpoint.
+   - The descriptor responds to `getInfo`.
+   - The descriptor lifecycle is not stale.
+
+6. **Agent MCP state**
+   - The target agent is configured to launch an MCP server named
+     `open-browser-use`.
+   - The server command and args are equivalent to:
+
+     ```json
+     {
+       "name": "open-browser-use",
+       "command": "/absolute/path/to/obu",
+       "args": ["mcp", "stdio"]
+     }
+     ```
+
+7. **Agent instruction state**
+   - Where the target agent supports durable instructions, the agent has
+     persistent guidance to prefer open-browser-use as the primary
+     BrowserUse/browser automation tool.
+
+Layers 1, 2, 6, and 7 are mostly file/config state. Layer 3 depends on the
+resolved browser profile. Layers 4 and 5 depend on Chrome extension runtime
+activation. The CLI can repair deterministic file/config state, but it cannot
 force Chrome to keep an MV3 service worker alive.
 
-## Definition of Done
+For CLI verification, extension runtime state is considered active when a
+runtime descriptor for the selected browser responds to `getInfo` and any
+available descriptor metadata matches the selected extension id. It is considered
+inactive when native-host and extension file/config state pass but no fresh
+descriptor can be probed. The corresponding check must include
+`details.source: "runtime_descriptor_probe"` unless a future popup/native-host
+status API supplies a more direct source.
 
-A connection has two verification levels.
+## Browser Profile Resolution
 
-CLI-level readiness means OBU can verify local setup and browser backend state
-without relying on a specific agent process:
+`obu verify` must make browser profile selection explicit.
 
-1. Browser doctor reports a live backend descriptor:
+Profile resolution order:
 
-   ```text
-   PASS Runtime descriptor probe: ... responded to getInfo
-   resume required: no
-   ```
+1. If `--profile=<path>` is supplied, verify only that profile.
+2. If no profile is supplied, use the same default profile discovery as
+   `obu doctor browser` for the selected browser.
+3. If multiple candidate profiles contain the target extension id, choose the
+   first profile with an enabled matching extension after deterministic sorting,
+   and report all candidates in JSON.
+4. If an explicit profile is supplied but does not contain the target extension
+   id, keep that profile path in JSON and return `needs_manual_action` with
+   `nextAction.kind: "install_extension"`.
+5. If default discovery finds no candidate profile containing the target
+   extension id, return `needs_manual_action` with
+   `nextAction.kind: "install_extension"`.
 
-2. Agent doctor reports that the target agent has an equivalent
-   `open-browser-use` MCP configuration and, where supported, the primary-browser
-   instruction.
+Default discovery must sort candidate profile directories deterministically:
+`Default` first, `Profile <number>` in numeric order, then all other profile
+directories lexicographically by absolute path. `readdir` order is not a product
+contract.
 
-Agent-runtime readiness is stronger. It means the target agent has reloaded its
-MCP tools and its own `browser_status` reports:
+The JSON response must include:
 
-   ```json
-   {
-     "sdk_bootstrap": "available",
-     "backends": [{ "...": "..." }]
-   }
-   ```
+- `browser.profile.path`: string path or `null`
+- `browser.profile.source`: `explicit | default_discovery`
+- `browser.profile.candidates`: array of candidate objects with `path`,
+  `extensionInstalled`, and `extensionEnabled`
+
+If an explicit profile is supplied and does not contain the target extension id,
+`browser.profile.path` must keep the explicit path,
+`browser.profile.source` must be `explicit`, `browser.profile.candidates` must
+contain only that path with `extensionInstalled: "missing"` and
+`extensionEnabled: "not_checked"`, top-level `extensionInstalled` must be
+`missing`, and `nextAction.kind` must be `install_extension`.
+
+If default discovery finds no candidate profile containing the target extension
+id, `browser.profile.path` must be `null`, `browser.profile.source` must be
+`default_discovery`, `browser.profile.candidates` must be an empty array,
+`extensionInstalled` must be `missing`, and `nextAction.kind` must be
+`install_extension`.
+
+Human output should name the resolved profile only when profile choice affects
+the result or there are multiple candidates.
+
+## Readiness Levels
+
+`obu verify` reports two levels of readiness.
+
+The top-level JSON field `verificationTarget` must be one of:
+
+- `cli`: default target. The command verifies local setup, selected agent
+  durable config, and a live browser backend descriptor.
+- `agent_runtime`: stronger target. The command verifies CLI readiness and a
+  status result from the selected, currently running agent process.
+
+### CLI-Level Readiness
+
+CLI-level readiness means OBU can verify local setup and a live browser backend
+without relying on a specific agent process.
+
+Required evidence:
+
+- Native-host manifest is valid for the exact extension id.
+- Browser extension is installed and enabled in the resolved profile.
+- Runtime descriptor responds to `getInfo`.
+- `resumeRequired` is `false`.
+- Agent MCP config is equivalent to the expected OBU server.
+- Agent instruction check is either `pass` or a non-blocking `warn` with
+  `reason: "not_implemented"`.
+
+### Agent-Runtime Readiness
+
+Agent-runtime readiness is stronger. It means the selected agent has reloaded
+its MCP tools and its own OBU MCP status reports at least one usable backend.
+
+Required evidence:
+
+```json
+{
+  "sdk_bootstrap": "available",
+  "backends": [{ "...": "..." }]
+}
+```
 
 An MCP server with `backends: []` is not ready for browser automation. It only
 proves that the MCP process can start.
 
-## Why Opening the Popup Is Sometimes Required
+When agent-runtime status cannot be checked from the CLI, `obu verify` must set
+`agent.runtimeStatus.status: "not_checked"` and still provide CLI-level
+readiness. It must not silently imply agent-runtime readiness.
 
-Opening the extension popup is not a workaround for bad configuration. It is the
-browser UI boundary where Chrome activates the extension runtime.
+With `verificationTarget: "cli"`, `result: "ready"` is allowed when CLI-level
+readiness is complete and agent-runtime readiness is `not_checked`. Human output
+must call this CLI-level readiness, and JSON must keep
+`readiness.agentRuntime: "not_checked"` so agents can distinguish "CLI verified"
+from "the current agent process has reloaded and proved a backend through MCP."
 
-`obu doctor browser --repair` can fix:
+With `verificationTarget: "agent_runtime"`, `result: "ready"` is allowed only
+when `readiness.agentRuntime` is `ready`. If agent-runtime status is unavailable,
+not checked, or checked with zero usable backends, the result must not be
+`ready`.
+
+## Command Surface
+
+### Read-Only Verification
+
+Default verification is read-only:
+
+```bash
+obu verify \
+  --agent=codex-cli \
+  --browser=chrome \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+Read-only verification may inspect files, execute OBU binaries, probe runtime
+descriptors, and run read-only agent status commands. It must not write config,
+repair native-host manifests, create instruction files, or mutate agent MCP
+config.
+
+To require proof from the selected running agent process, use:
+
+```bash
+obu verify --require-agent-runtime \
+  --agent=codex-cli \
+  --browser=chrome \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+This sets `verificationTarget: "agent_runtime"`. If OBU cannot obtain status
+from that agent process, the command must return a non-ready result with a
+single action such as restarting/reloading the agent or checking the agent's OBU
+MCP status from inside the client.
+
+### Explicit Repair
+
+Repair requires an explicit flag:
+
+```bash
+obu verify --repair \
+  --agent=codex-cli \
+  --browser=chrome \
+  --channel=store \
+  --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+`--repair` may apply deterministic OBU-owned repairs:
+
+- create or repair native-host manifests;
+- fix allowed extension origins;
+- fix native-host binary paths;
+- create owner-only runtime directories;
+- remove stale or invalid runtime descriptors;
+- create or repair first-class auto-writable agent MCP config when no divergent
+  user config exists.
+
+`--repair` must not overwrite divergent user-managed agent config. Divergence is
+`needs_manual_action`.
+
+### Output Modes
+
+Human output is concise by default. JSON output is stable:
+
+```bash
+obu verify --agent=codex-cli --json
+```
+
+The default exit codes are:
+
+- `0`: `ready`
+- `1`: `needs_browser_popup`, `needs_repair`, or `needs_manual_action`
+- `2`: invalid command input or unsupported platform
+
+## Agent Identity Contract
+
+OBU accepts common human names but emits canonical ids.
+
+| Input | Canonical id |
+| --- | --- |
+| `codex` | `codex-cli` |
+| `claude`, `claude-cli` | `claude-code` |
+| `gemini` | `gemini-cli` |
+
+Canonical ids appear in logs, JSON, and remediation commands.
+
+First-class agent config surfaces:
+
+| Agent | MCP surface | Instruction surface |
+| --- | --- | --- |
+| `codex-cli` | `~/.codex/config.toml` | project `AGENTS.md`/`AGENT.md`, then `~/.codex/AGENTS.md` |
+| `cursor` | `~/.cursor/mcp.json` | not implemented |
+| `claude-code` | `claude mcp` | project `CLAUDE.md`, then `~/.claude/CLAUDE.md` |
+| `gemini-cli` | `gemini mcp` | not implemented |
+| `vscode` | VS Code MCP add command | not implemented |
+| `cline` | Cline JSON MCP config | not implemented |
+| `windsurf` | Windsurf JSON MCP config | not implemented |
+| `claude-desktop` | Claude Desktop JSON MCP config | not implemented |
+| `zed` | Zed `context_servers` config | not implemented |
+| `continue` | reference/manual config only | not implemented |
+
+Setup and doctor must read and write the same MCP surface for each first-class
+agent. OBU must never report an agent as configured through one path while
+doctor verifies a different path.
+
+## Result Precedence
+
+When multiple layers are non-ready, `obu verify` chooses the highest-priority
+result using this order:
+
+1. `needs_manual_action`
+2. `needs_repair`
+3. `needs_browser_popup`
+4. `ready`
+
+Rationale:
+
+- Manual action blocks safe automation and cannot be solved by OBU alone.
+- Deterministic repair should be surfaced before popup activation.
+- Popup activation only makes sense when local setup is otherwise correct.
+- Ready requires all required layers to pass.
+- Agent-runtime-required verification adds the agent runtime as a required layer;
+  CLI-level readiness alone is not enough for `ready` in that mode.
+
+Examples:
+
+- Divergent Codex MCP config plus missing runtime descriptor:
+  `needs_manual_action`.
+- Native-host manifest missing exact Store id plus no descriptor:
+  `needs_repair`.
+- Native host and extension are correct, but descriptor is absent:
+  `needs_browser_popup`.
+- Descriptor responds and agent MCP config is equivalent:
+  `ready` when `verificationTarget` is `cli`.
+- Descriptor responds and agent MCP config is equivalent, but
+  `--require-agent-runtime` cannot check the running agent:
+  `needs_manual_action`.
+
+## Next Action Contract
+
+Every non-ready result has exactly one `nextAction`.
+
+Action kinds:
+
+- `install_cli`
+- `run_repair`
+- `open_popup`
+- `configure_agent`
+- `resolve_config_conflict`
+- `restart_agent`
+- `install_extension`
+- `unsupported`
+
+Result/action mapping:
+
+| Condition | Result | Next action kind |
+| --- | --- | --- |
+| No runnable OBU CLI exists before handoff reaches the CLI | `needs_manual_action` | `install_cli` |
+| Selected extension is not installed in the resolved profile | `needs_manual_action` | `install_extension` |
+| Native-host manifest, allowed origin, host path, runtime permissions, or stale descriptor can be repaired deterministically | `needs_repair` | `run_repair` |
+| Missing first-class auto-writable agent MCP config and no divergent config exists | `needs_repair` | `run_repair` |
+| Agent MCP config is missing but cannot be safely written by OBU | `needs_manual_action` | `configure_agent` |
+| Existing agent MCP config for `open-browser-use` is divergent or unreadable | `needs_manual_action` | `resolve_config_conflict` |
+| CLI-level readiness passes but `verificationTarget: "agent_runtime"` cannot be proved until the client reloads | `needs_manual_action` | `restart_agent` |
+| Local setup is correct but no fresh runtime descriptor is active | `needs_browser_popup` | `open_popup` |
+| Platform, browser, agent, or command input is unsupported | `needs_manual_action` | `unsupported` |
+
+Each action must include:
+
+- a human message;
+- a command when a command is available;
+- enough context to preserve browser, channel, agent, and extension id;
+- no ambiguous extension id inference.
+
+The next action must be directly actionable. It should not say "check docs" if a
+specific repair or configuration command is known.
+
+When a browser/profile-specific action cannot be represented safely as a shell
+command, `command` must be omitted and the action must include explicit context
+instead, such as `url`, `browser`, and `profile.path`. A generic operating-system
+`open` command is not enough when it may target the wrong browser or profile.
+
+## JSON Contract
+
+The JSON schema is stable for agents:
+
+Allowed top-level result values:
+
+- `ready`
+- `needs_browser_popup`
+- `needs_repair`
+- `needs_manual_action`
+
+Allowed `verificationTarget` values:
+
+- `cli`
+- `agent_runtime`
+
+Allowed check status values:
+
+- `pass`: the check succeeded.
+- `warn`: the check is unsupported or non-blocking.
+- `fail`: the check blocks readiness.
+- `not_checked`: the check was intentionally skipped and the reason is present.
+
+Allowed readiness values:
+
+- `ready`: this readiness level is verified.
+- `blocked`: this readiness level is not ready.
+- `not_checked`: this readiness level was not checked from this process.
+
+Allowed component state values for summary fields such as `extensionInstalled`,
+`extensionEnabled`, `nativeHost`, and `runtimeDescriptor`:
+
+- `pass`: the component is present and valid.
+- `warn`: the component has a non-blocking issue.
+- `fail`: the component has a blocking issue.
+- `missing`: the component is absent.
+- `disabled`: the component exists but is disabled.
+- `stale`: the component exists but its lifecycle state is stale.
+- `invalid`: the component exists but has invalid shape or contents.
+- `not_checked`: the component was intentionally not checked and the reason is
+  present in details.
+
+Unsupported instruction checks must use:
+
+```json
+{
+  "status": "warn",
+  "reason": "not_implemented"
+}
+```
+
+They must not introduce a separate check status named `not_implemented`.
+
+`checks[]` contains the normalized lower-level evidence used to compute the
+result:
+
+```json
+{
+  "id": "agent-mcp-server",
+  "layer": "agent_mcp",
+  "status": "pass",
+  "message": "codex-cli configures open-browser-use",
+  "details": {
+    "path": "/Users/alex/.codex/config.toml"
+  }
+}
+```
+
+Allowed `checks[].layer` values:
+
+- `cli_install`
+- `native_host`
+- `browser_extension`
+- `extension_runtime`
+- `runtime_descriptor`
+- `agent_mcp`
+- `agent_instruction`
+- `mcp_runtime`
+
+```json
+{
+  "schemaVersion": 1,
+  "command": "verify",
+  "verificationTarget": "cli",
+  "result": "ready",
+  "readiness": {
+    "cli": "ready",
+    "agentRuntime": "not_checked"
+  },
+  "agent": {
+    "id": "codex-cli",
+    "input": "codex",
+    "mcpConfig": {
+      "status": "pass",
+      "path": "/Users/alex/.codex/config.toml",
+      "serverName": "open-browser-use",
+      "command": "/Users/alex/.obu/bin/obu",
+      "args": ["mcp", "stdio"]
+    },
+    "instructions": {
+      "status": "pass",
+      "path": "/Users/alex/.codex/AGENTS.md"
+    },
+    "runtimeStatus": {
+      "status": "not_checked",
+      "reason": "target agent runtime is outside this CLI process"
+    }
+  },
+  "browser": {
+    "kind": "chrome",
+    "channel": "store",
+    "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+    "profile": {
+      "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+      "source": "default_discovery",
+      "candidates": [
+        {
+          "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+          "extensionInstalled": "pass",
+          "extensionEnabled": "pass"
+        }
+      ]
+    },
+    "extensionInstalled": "pass",
+    "extensionEnabled": "pass",
+    "nativeHost": "pass",
+    "runtimeDescriptor": "pass",
+    "resumeRequired": false,
+    "descriptor": {
+      "file": "chrome.json",
+      "probe": "getInfo",
+      "lifecycle": "fresh"
+    }
+  },
+  "mcpRuntime": {
+    "source": "direct_mcp_probe",
+    "mcpConfigured": true,
+    "mcpStarts": true,
+    "sdkBootstrap": "available",
+    "backendCount": 1,
+    "backends": [
+      {
+        "kind": "webextension",
+        "browser": "chrome"
+      }
+    ]
+  },
+  "nextAction": null,
+  "checks": [
+    {
+      "id": "cli-version",
+      "layer": "cli_install",
+      "status": "pass",
+      "message": "obu version is parseable"
+    },
+    {
+      "id": "native-host-manifest",
+      "layer": "native_host",
+      "status": "pass",
+      "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/"
+    },
+    {
+      "id": "browser-extension-installed",
+      "layer": "browser_extension",
+      "status": "pass",
+      "message": "extension is installed and enabled in the resolved profile"
+    },
+    {
+      "id": "extension-runtime",
+      "layer": "extension_runtime",
+      "status": "pass",
+      "message": "extension runtime inferred active from descriptor probe",
+      "details": { "source": "runtime_descriptor_probe" }
+    },
+    {
+      "id": "runtime-descriptor-probe",
+      "layer": "runtime_descriptor",
+      "status": "pass",
+      "message": "chrome.json responded to getInfo"
+    },
+    {
+      "id": "agent-mcp-server",
+      "layer": "agent_mcp",
+      "status": "pass",
+      "message": "codex-cli configures open-browser-use"
+    },
+    {
+      "id": "agent-primary-instruction",
+      "layer": "agent_instruction",
+      "status": "pass",
+      "message": "primary browser instruction found"
+    }
+  ]
+}
+```
+
+Non-ready result:
+
+```json
+{
+  "schemaVersion": 1,
+  "command": "verify",
+  "verificationTarget": "cli",
+  "result": "needs_browser_popup",
+  "readiness": {
+    "cli": "blocked",
+    "agentRuntime": "not_checked"
+  },
+  "agent": {
+    "id": "codex-cli",
+    "mcpConfig": { "status": "pass" },
+    "instructions": { "status": "pass" },
+    "runtimeStatus": { "status": "not_checked" }
+  },
+  "browser": {
+    "kind": "chrome",
+    "channel": "store",
+    "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
+    "profile": {
+      "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+      "source": "default_discovery",
+      "candidates": [
+        {
+          "path": "/Users/alex/Library/Application Support/Google/Chrome/Default",
+          "extensionInstalled": "pass",
+          "extensionEnabled": "pass"
+        }
+      ]
+    },
+    "extensionInstalled": "pass",
+    "extensionEnabled": "pass",
+    "nativeHost": "pass",
+    "runtimeDescriptor": "missing",
+    "resumeRequired": true
+  },
+  "mcpRuntime": {
+    "source": "direct_mcp_probe",
+    "mcpConfigured": true,
+    "mcpStarts": true,
+    "sdkBootstrap": "available",
+    "backendCount": 0,
+    "backends": []
+  },
+  "nextAction": {
+    "kind": "open_popup",
+    "message": "Open the open-browser-use extension popup. Click Resume if enabled; otherwise wait for Connected and rerun verify.",
+    "url": "chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/popup.html",
+    "browser": "chrome",
+    "profile": {
+      "path": "/Users/alex/Library/Application Support/Google/Chrome/Default"
+    },
+    "rerun": "obu verify --agent=codex-cli --browser=chrome --channel=store --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj"
+  },
+  "checks": [
+    {
+      "id": "native-host-manifest",
+      "layer": "native_host",
+      "status": "pass",
+      "message": "native host allows chrome-extension://fblnfcjnjklpgnmfnngcihbcgojnpadj/"
+    },
+    {
+      "id": "browser-extension-installed",
+      "layer": "browser_extension",
+      "status": "pass",
+      "message": "extension is installed and enabled in the resolved profile"
+    },
+    {
+      "id": "extension-runtime",
+      "layer": "extension_runtime",
+      "status": "fail",
+      "message": "extension runtime is not active from CLI-observable evidence",
+      "details": { "source": "runtime_descriptor_probe" }
+    },
+    {
+      "id": "runtime-descriptor-probe",
+      "layer": "runtime_descriptor",
+      "status": "fail",
+      "message": "no active WebExtension descriptor found",
+      "details": { "resumeRequired": true }
+    },
+    {
+      "id": "agent-mcp-server",
+      "layer": "agent_mcp",
+      "status": "pass",
+      "message": "codex-cli configures open-browser-use"
+    }
+  ]
+}
+```
+
+## Human Output Contract
+
+Ready:
+
+```text
+open-browser-use is CLI-ready.
+Agent: codex-cli
+Browser: chrome Store extension fblnfcjnjklpgnmfnngcihbcgojnpadj
+Backend: webextension descriptor chrome.json responded to getInfo
+Agent runtime: not checked
+```
+
+Browser popup required:
+
+```text
+Browser popup required.
+Local setup is correct, but no active WebExtension descriptor exists yet.
+Open the open-browser-use extension popup. Click Resume if enabled.
+If it already shows Connected, wait briefly and rerun:
+  obu verify --agent=codex-cli --browser=chrome --channel=store --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+Repair required:
+
+```text
+Repair required.
+Chrome native host manifest does not allow extension fblnfcjnjklpgnmfnngcihbcgojnpadj.
+Run:
+  obu verify --repair --agent=codex-cli --browser=chrome --channel=store --extension-id=fblnfcjnjklpgnmfnngcihbcgojnpadj
+```
+
+Manual action required:
+
+```text
+Agent configuration conflict.
+Codex already has an open-browser-use MCP server with different settings.
+Review /Users/alex/.codex/config.toml and keep the intended command.
+Expected:
+  /Users/alex/.obu/bin/obu mcp stdio
+```
+
+## Popup Contract
+
+The popup must distinguish host connection from descriptor readiness.
+
+Required state fields:
+
+- `Native host: connected | disconnected`
+- `Host version: <version> | unknown`
+- `Descriptor: active | missing | stale | invalid`
+- `Resume required: yes | no`
+- `Last descriptor refresh: <timestamp> | never`
+
+The Resume button state must match the state model:
+
+- Enabled when the extension knows a resume action can refresh or reconnect the
+  descriptor.
+- Disabled when the extension is already connected or no resume action is
+  meaningful.
+
+If Resume is disabled while the host is connected, the UI must not imply failure.
+The correct guidance is to rerun `obu verify` and confirm `resumeRequired:
+false`.
+
+## Browser Popup Boundary
+
+Opening the popup is sometimes required because Chrome controls MV3 extension
+runtime activation.
+
+`obu verify --repair` can fix:
 
 - native-host manifests;
 - allowed extension origins;
@@ -120,184 +802,126 @@ It cannot force Chrome to:
 - reconnect the extension to native messaging from outside the browser;
 - write a fresh WebExtension descriptor without extension runtime activity.
 
-Opening the popup wakes the extension and gives it a chance to connect to the
-native host. If the popup shows the host connected and the Resume button is
-disabled, that can still be a good state: the popup has already refreshed the
-connection. The correct next step is to rerun doctor and confirm
-`resume required: no`.
+When all file/config state is correct but no descriptor is active, the product
+must return `needs_browser_popup`, not `ready` and not `needs_repair`.
 
-## Proposed Product Surface
+## Extension Handoff Contract
 
-Add one high-level command:
+The extension handoff prompt must include:
 
-```bash
-obu verify --agent=codex-cli --browser=chrome --channel=store --extension-id=<id>
-```
+- extension channel;
+- exact extension id;
+- reminder not to infer a different Store id;
+- instruction to ensure `~/.obu/bin/obu` exists before writing MCP config;
+- canonical agent ids for known agents;
+- instruction to verify with `obu verify`;
+- popup guidance that says "click Resume if enabled" rather than assuming Resume
+  is always clickable.
 
-The command should compose existing checks instead of replacing them. It should
-be read-only by default:
+The Store extension id is security-sensitive native messaging state. Every
+doctor, setup, repair, verify, and generated command must preserve the exact
+handoff id unless OBU can prove the same id is already configured.
 
-1. Resolve install/runtime layout.
-2. Verify native-host browser setup and report any repair command.
-3. Verify extension installed/enabled/profile state.
-4. Probe browser descriptor state.
-5. Verify target agent MCP config.
-6. Verify target agent instruction state when implemented.
-7. Optionally run an MCP-level status probe when the target agent supports it or
-   when the current process can safely simulate it.
-8. Return one stable result and one next action.
+## Setup Contract
 
-If mutation is needed, use an explicit flag or a different command path:
+`obu setup` remains the mutating setup command. It must not be the canonical
+readiness answer.
 
-```bash
-obu verify --repair --agent=codex-cli --browser=chrome --channel=store --extension-id=<id>
-```
+Setup requirements:
 
-Example human outputs:
+- Accept human agent aliases and normalize to canonical ids.
+- Write each first-class agent config to the same surface that doctor verifies.
+- Do not overwrite divergent MCP server settings.
+- Return manual action for unreadable or divergent config.
+- Preserve exact Store extension ids in all suggested doctor/repair commands.
+- Write primary-browser instructions only when explicitly requested.
+- Include the final verification command in next actions.
 
-```text
-open-browser-use is ready.
-Agent: codex-cli
-Browser: chrome Store extension fblnfcjnjklpgnmfnngcihbcgojnpadj
-Backend: webextension descriptor chrome.json responded to getInfo
-```
+The final setup output should tell users to run `obu verify`, not ask them to
+interpret setup completion as browser readiness.
 
-```text
-Browser popup required.
-Local setup appears correct, but no active WebExtension descriptor exists yet.
-Open the open-browser-use extension popup. If Resume is enabled, click it.
-If it already shows Connected, wait briefly and rerun:
-  obu verify --agent=codex-cli --browser=chrome --channel=store --extension-id=...
-```
+## Doctor Contract
 
-```text
-Agent configuration required.
-Codex MCP config is missing open-browser-use.
-Run:
-  obu setup --yes --agents=codex-cli --write-instructions
-```
+`obu doctor browser` and `obu agent doctor` remain lower-level diagnostic
+commands.
 
-## JSON Contract
+Doctor requirements:
 
-The verification JSON should be stable enough for agents:
+- Browser doctor must expose `resume_required` in details.
+- Browser doctor must preserve exact channel and extension id in repair hints.
+- Browser doctor must distinguish warnings from live backend readiness.
+- Agent doctor must fail divergent config instead of falling back to another
+  probe that masks the conflict.
+- Agent doctor must report unsupported instruction checks as `warn`, not fail.
+- Agent doctor must use timeouts that avoid false failures for normal client
+  startup latency.
 
-```json
-{
-  "schemaVersion": 1,
-  "command": "verify",
-  "result": "ready",
-  "agent": {
-    "id": "codex-cli",
-    "mcpConfig": "pass",
-    "instructions": "pass",
-    "runtimeStatus": "not_checked"
-  },
-  "browser": {
-    "kind": "chrome",
-    "channel": "store",
-    "extensionId": "fblnfcjnjklpgnmfnngcihbcgojnpadj",
-    "extensionInstalled": "pass",
-    "nativeHost": "pass",
-    "runtimeDescriptor": "pass",
-    "resumeRequired": false
-  },
-  "mcpRuntime": {
-    "sdkBootstrap": "available",
-    "backendCount": 1
-  },
-  "nextAction": null
-}
-```
+Doctor commands can produce many checks. `obu verify` is responsible for turning
+those checks into one product result.
 
-For non-ready states, `nextAction` should be a single object:
+## MCP Runtime Contract
 
-```json
-{
-  "kind": "open_popup",
-  "message": "Open the extension popup; click Resume if enabled, otherwise wait for Connected and rerun verify."
-}
-```
+MCP status is split into server availability and browser backend availability.
 
-## Systemic Fix Cut Points
+Required fields:
 
-### 1. One Source of Truth per Agent
+- `source`: `agent_runtime | direct_mcp_probe | not_checked`.
+- `mcpConfigured`: whether the target agent has an equivalent server config.
+- `mcpStarts`: `true | false | null`; whether the MCP process can start when
+  checked directly.
+- `sdkBootstrap`: `available | missing | untrusted | not_checked`.
+- `backendCount`: `number | null`; number of usable browser backends.
+- `backends`: backend summaries when available.
 
-For each first-class agent, setup and doctor must read/write the same config
-surface.
+`source: "agent_runtime"` means the status came from the selected agent process
+after it reloaded MCP tools. Only this source can make
+`readiness.agentRuntime` become `ready`.
 
-Current direction:
+`source: "direct_mcp_probe"` means OBU launched or probed the MCP server itself.
+It can prove CLI-level backend readiness, but it must not be treated as proof
+that the selected agent process has reloaded MCP tools.
 
-- Codex: `~/.codex/config.toml` for MCP, `~/.codex/AGENTS.md` for global
-  instructions.
-- Cursor: `~/.cursor/mcp.json` for MCP.
-- Claude Code: `claude mcp` for MCP, `~/.claude/CLAUDE.md` for global
-  instructions.
+`source: "not_checked"` means MCP runtime status was not probed. In that case
+`mcpStarts` must be `null`, `sdkBootstrap` must be `not_checked`,
+`backendCount` must be `null`, and `backends` must be an empty array.
 
-Avoid reporting "configured" when the doctor cannot verify the same state.
+`backendCount: 0` means not ready for browser automation even if
+`sdkBootstrap: "available"`.
 
-### 2. Normalize Human Agent Names
+For setup probes, agents should end turns with `turnEnded()` when the goal is to
+keep the browser connection alive. `finishTurn({ keep: [] })` intentionally
+releases state and can remove runtime descriptors.
 
-Accept common names as aliases:
+## Acceptance Criteria
 
-- `codex` -> `codex-cli`
-- `claude` -> `claude-code`
-- `gemini` -> `gemini-cli`
+The product is complete only when all of the following are true:
 
-Output should still show canonical ids so logs and docs remain precise.
-
-### 3. Separate MCP Availability from Browser Availability
-
-The MCP server can be healthy while browser backends are unavailable. Product
-output should make this explicit:
-
-- MCP configured: yes/no.
-- MCP starts: yes/no.
-- SDK bootstrap: available/missing/untrusted.
-- Browser backend count: `0` means not ready.
-
-### 4. Make Popup State Machine-Readable
-
-The popup should eventually expose or display a direct readiness state:
-
-- `Native host: connected`
-- `Descriptor: active`
-- `Resume required: yes/no`
-- `Last descriptor refresh: timestamp`
-
-This would let users and agents understand whether opening the popup already
-fixed the descriptor activation boundary.
-
-### 5. Keep Prompts as Fallback, Not the State Machine
-
-The agent install prompt should guide unusual environments, but it should not be
-the main state engine. The CLI should produce the canonical machine-readable
-diagnosis and the prompt should tell agents to trust that diagnosis.
-
-### 6. Preserve Exact Store Extension IDs
-
-Store extension id is security-sensitive native messaging state. Every repair,
-doctor, setup, verify, and follow-up command must preserve the exact handoff id
-unless OBU can prove the same id is already configured.
-
-## Short-Term Implementation Plan
-
-1. Keep these first-class setup invariants in place:
-   - agent alias normalization;
-   - Codex config read/write/doctor support;
-   - Cursor setup and doctor using the same `mcp.json`;
-   - longer Claude Code doctor timeout;
-   - clearer popup/doctor Resume wording.
-2. Add `obu verify` as a thin composition layer over existing setup, browser
-   doctor, agent doctor, and MCP status primitives.
-3. Add a release smoke that runs verify in a clean temporary home for Codex and
-   Cursor config paths.
-4. Extend popup status to distinguish host connection from active descriptor
-   readiness.
-5. Update the extension handoff prompt to prefer `obu verify` as the final
-   readiness gate.
+- One command, `obu verify`, returns the canonical readiness result.
+- JSON output has the stable schema described above, including
+  `verificationTarget`, object-shaped `agent.runtimeStatus`, required
+  `mcpRuntime.backends`, and non-empty `checks[]` evidence.
+- Human output gives one next action and no ambiguous action chain.
+- `ready` is impossible when browser backend count is zero.
+- `verificationTarget: "agent_runtime"` cannot return `ready` unless
+  `readiness.agentRuntime` is `ready`.
+- Browser profile discovery is deterministic and reports candidate profile state.
+- `needs_browser_popup` is returned when local setup is correct but descriptor
+  activation is missing.
+- `open_popup` actions preserve browser/profile context and do not rely on a
+  generic OS `open` command when that could target the wrong profile.
+- `needs_repair` includes a repair command with exact browser/channel/extension
+  id.
+- `needs_manual_action` is returned for divergent agent config.
+- Setup and doctor use the same source of truth for Codex and Cursor.
+- Agent aliases are accepted but canonical ids are emitted.
+- Popup status distinguishes native-host connection from descriptor readiness.
+- Extension handoff text preserves exact Store extension id and tells agents to
+  verify readiness through OBU.
+- Clean-home smoke tests cover Codex, Cursor, Store extension id preservation,
+  popup-required descriptor state, and divergent config conflicts.
 
 ## Product Principle
 
 No user or agent should need to infer readiness by stitching together partial
-success messages. The product should own the state closure and return one
-truthful next action.
+success messages. OBU owns the state closure and returns one truthful next
+action.

--- a/docs/install.md
+++ b/docs/install.md
@@ -87,7 +87,7 @@ The future update path should make that decision explicitly: compare the local
 `obu --version` / payload metadata with the latest release version, download and
 install only when the release is newer, and otherwise keep the existing local
 install and reconnect or repair it with `obu bootstrap`, `obu setup`, or
-`obu doctor`.
+`obu verify --repair`.
 
 For a Chrome Web Store-installed extension, use the Store channel so native-host
 manifests allow the Store extension id instead of the unpacked-dev id:
@@ -106,18 +106,24 @@ requires the manifest `allowed_origins` entry to match the installed extension:
 `chrome-extension://<store-extension-id>/`.
 
 If the CLI and MCP server are installed but browser automation is still
-unavailable, check both layers:
+unavailable, verify the selected agent/browser pair. Replace `<agent-id>` with
+the canonical OBU adapter id for the agent whose MCP config should be checked,
+such as `codex-cli` for Codex, `claude-code` for Claude Code, `gemini-cli`,
+`cursor`, or `vscode`; the full supported list is in
+[Agent Configuration](#agent-configuration). If this came from the popup **Copy
+for agent** handoff, use the current agent by default unless the user asks to
+configure another client.
 
 ```bash
-~/.obu/bin/obu doctor browser --channel=store --extension-id=<store-extension-id>
-~/.obu/bin/obu doctor browser --repair --channel=store --extension-id=<store-extension-id>
+~/.obu/bin/obu verify --agent=<agent-id> --browser=chrome --channel=store --extension-id=<store-extension-id>
+~/.obu/bin/obu verify --repair --agent=<agent-id> --browser=chrome --channel=store --extension-id=<store-extension-id>
 ```
 
 After repair, open the open-browser-use extension popup and click **Resume** if
 the browser is not connected yet. Repair can update native-host manifests and
 runtime descriptor permissions, but Chrome publishes the active WebExtension
 runtime descriptor only after the extension connects to the native host. Rerun
-doctor with the same channel/id after opening the popup.
+verify with the same agent/browser/channel/id after opening the popup.
 
 Manual GitHub Release installs can still pin a specific asset and checksum:
 
@@ -164,7 +170,7 @@ After installing an `obu` shim:
 eval "$("$HOME/.obu/bin/obu" shellenv zsh)"
 obu bootstrap --yes --all --agents=auto
 obu setup --yes --agents=codex-cli,claude-code --write-instructions
-obu doctor
+obu verify --agent=codex-cli --browser=chrome
 ```
 
 `--write-instructions` is opt-in. It appends the primary-browser instruction to
@@ -187,22 +193,24 @@ returns `manual_action_required`, load or reload:
 from `chrome://extensions`, then rerun:
 
 ```bash
-obu doctor
+obu verify --agent=<agent-id> --browser=chrome
 ```
 
 For Chrome Web Store installs, do not run `obu update-extension`; Chrome Web
-Store owns extension updates. Use:
+Store owns extension updates. Verify and repair the selected Store target with:
 
 ```bash
-obu doctor browser --channel=store --extension-id=<store-extension-id>
-obu doctor browser --repair --channel=store --extension-id=<store-extension-id>
+obu verify --agent=<agent-id> --browser=chrome --channel=store --extension-id=<store-extension-id>
+obu verify --repair --agent=<agent-id> --browser=chrome --channel=store --extension-id=<store-extension-id>
 ```
 
 If `browser_status` in an MCP client reports that the SDK is available but
 `backends` is empty, MCP is configured but the browser backend is not connected.
-Run the Store-channel doctor command with the exact extension id, repair if
-needed, then open the extension popup and click **Resume** so Chrome reconnects
-the native host.
+Run `obu verify` for that same MCP client with the exact Store extension id,
+repair if needed, then open the extension popup and click **Resume** so Chrome
+reconnects the native host. Keep the same `--agent`, `--browser`, `--channel`,
+and `--extension-id` values between repair and the final verify rerun. Use
+`obu doctor browser` only when you need lower-level browser diagnostics.
 
 ## Agent Configuration
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -152,8 +152,8 @@ Verify installer support for:
 - stable `bin/obu` shim pointing at `payloads/current`;
 - packaged `obu shellenv` output and installer Next steps without writing
   arbitrary current-`PATH` shims.
-- packaged `obu doctor --json` payload integrity checks and `obu mcp stdio`
-  initialize/list-tools through the installed shim.
+- packaged `obu doctor --json` payload integrity checks, `obu verify` readiness
+  checks, and `obu mcp stdio` initialize/list-tools through the installed shim.
 - installed-payload `obu setup --yes --skip-agents`,
   `obu setup --yes --agents=codex-cli --write-instructions` using a fake Codex
   CLI, and `obu agent doctor --agent=codex-cli`.
@@ -212,7 +212,7 @@ Required draft checks:
 
    ```bash
    obu bootstrap --yes --all --channel=store --extension-id <STORE_EXTENSION_ID> --agents=auto
-   obu doctor browser --channel=store --extension-id <STORE_EXTENSION_ID> --json
+   obu verify --agent=codex-cli --browser=chrome --channel=store --extension-id <STORE_EXTENSION_ID> --json
    ```
 
 Verify:
@@ -221,9 +221,15 @@ Verify:
   `storeExtensionId`.
 - native-host manifests include
   `chrome-extension://<STORE_EXTENSION_ID>/`.
+- `verify --agent=codex-cli --browser=chrome --channel=store --extension-id
+  <STORE_EXTENSION_ID> --json` reports the Store target and returns exactly one
+  readiness result plus one next action when not ready.
+- In a clean profile before popup activation, Store verify may return
+  `needs_browser_popup` with `nextAction.kind: "open_popup"`; after the popup is
+  connected, the same command should return `ready`.
 - `doctor browser --channel=store --extension-id <STORE_EXTENSION_ID> --json`
-  reports channel, extension id, id source, and `resume_required` on the runtime
-  descriptor probe.
+  remains available as a lower-level diagnostic and reports `resume_required` on
+  the runtime descriptor probe.
 - the popup agent handoff preserves `Extension channel: store`, the exact Store
   extension id, and does not expose a Terminal command.
 - the popup agent handoff links to the version-tagged
@@ -245,6 +251,7 @@ Run from a fresh temp home with Chrome or Chrome for Testing:
 
 ```bash
 obu bootstrap --yes --all --agents=auto
+obu verify --agent=codex-cli --browser=chrome --json
 obu doctor --json
 obu doctor --strict --json
 ```
@@ -285,8 +292,8 @@ MCP/browser-use compatibility gates:
 - `tools/list` shows `js`, `browser_status`, `js_reset`, and
   `js_add_module_dir`, and `initialize` advertises both tools and resources.
 - `browser_status` returns SDK bootstrap state, discovered backends,
-  diagnostics, runtime dir, and a doctor hint without leaking descriptor auth
-  tokens or capability tokens.
+  diagnostics, runtime dir, a verify hint, and the legacy doctor hint alias
+  without leaking descriptor auth tokens or capability tokens.
 - A `display({ __obuImage: true, mime_type, data })` call returns a resource
   link, and `resources/read` fetches the artifact bytes.
 - A huge `console.log` or huge final result stays bounded and sets the matching

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,15 +1,21 @@
 # open-browser-use Troubleshooting
 
-Start with:
+For readiness issues, start with the selected agent/browser pair. Replace
+`<agent-id>` with the current agent's canonical OBU adapter id, such as
+`codex-cli` for Codex, `claude-code` for Claude Code, `gemini-cli`, `cursor`, or
+`vscode`. If you are working from a popup **Copy for agent** handoff, use the
+agent receiving that handoff unless the user asked to configure another client.
+
+```bash
+obu verify --agent=<agent-id> --browser=chrome
+obu verify --agent=<agent-id> --browser=chrome --json
+```
+
+Use doctor for lower-level diagnostics and CI drift checks:
 
 ```bash
 obu doctor
 obu doctor --json
-```
-
-Use strict mode in CI:
-
-```bash
 obu doctor --strict --json
 ```
 
@@ -32,7 +38,7 @@ The directory must be owner-only and must not be a symlink. Repairable
 permission issues can be fixed by rerunning setup or:
 
 ```bash
-obu doctor browser --repair
+obu verify --repair --agent=<agent-id> --browser=chrome
 ```
 
 ## MCP Stdio Exits Before Starting
@@ -44,8 +50,8 @@ writes a short error to stderr.
 Run:
 
 ```bash
-obu setup --yes
-obu doctor
+obu setup --yes --agents=<agent-id>
+obu verify --agent=<agent-id> --browser=chrome
 ```
 
 Then retry the MCP client.
@@ -57,11 +63,12 @@ MCP availability and browser availability are separate. An agent can have the
 an available SDK with `backends: []`. That means the MCP server can start, but
 no live browser backend descriptor is available yet.
 
-For a Store-channel extension, repair with the exact extension id copied from
-the extension popup:
+For a Store-channel extension, repair the same agent/browser/channel/id tuple
+that produced the stale status. Use the exact extension id copied from the
+extension popup:
 
 ```bash
-obu doctor browser --repair --channel=store --extension-id=<STORE_EXTENSION_ID>
+obu verify --repair --agent=<agent-id> --browser=chrome --channel=store --extension-id=<STORE_EXTENSION_ID>
 ```
 
 Do not infer this id from the unpacked extension manifest or another Chrome
@@ -79,12 +86,13 @@ descriptor is written only after the extension reconnects to the native host.
 Rerun:
 
 ```bash
-obu doctor browser --channel=store --extension-id=<STORE_EXTENSION_ID>
+obu verify --agent=<agent-id> --browser=chrome --channel=store --extension-id=<STORE_EXTENSION_ID>
 ```
 
-Then retry `browser_status`. Current `doctor browser` output includes
-`resume required: yes/no` on the runtime descriptor probe so agents do not need
-to infer popup state from deliverable counts or low-level descriptor details.
+Then retry `browser_status`. If verify asks for deeper browser diagnostics,
+`doctor browser` includes `resume required: yes/no` on the runtime descriptor
+probe so agents do not need to infer popup state from deliverable counts or
+low-level descriptor details.
 
 ## Agent JavaScript Pitfalls
 
@@ -172,7 +180,7 @@ For a Chrome Web Store-installed extension, repair with the Store channel:
 
 ```bash
 obu install-host --channel=store --browser chrome --extension-id <STORE_EXTENSION_ID>
-obu doctor browser --repair --channel=store --extension-id <STORE_EXTENSION_ID>
+obu verify --repair --agent=<agent-id> --browser=chrome --channel=store --extension-id <STORE_EXTENSION_ID>
 ```
 
 If the Store channel reports that the Store extension id is not configured,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "open-browser-use user-facing command line tools.",
   "license": "MIT",

--- a/packages/cli/src/agents/codex-config.ts
+++ b/packages/cli/src/agents/codex-config.ts
@@ -18,6 +18,7 @@ export type CodexMcpServerState =
 export type CodexMcpWriteResult =
   | { status: "applied"; path: string; backupPath?: string }
   | { status: "skipped"; path: string; reason: "unchanged" }
+  | { status: "parse_error"; path: string; message: string; code: "PARSE_ERROR" }
   | { status: "io_error"; path: string; message: string; code?: string };
 
 export function codexConfigPath(options: CodexConfigOptions = {}): string {
@@ -38,6 +39,8 @@ export async function readCodexMcpServer(
   const raw = await readOptionalFile(configPath).catch((error): CodexMcpServerState => ioState(configPath, error));
   if (raw === undefined) return { status: "missing", path: configPath };
   if (typeof raw !== "string") return raw;
+  const parseIssue = validateCodexToml(raw);
+  if (parseIssue) return codexParseState(configPath, parseIssue);
   const table = findMcpServerTable(raw, serverName);
   if (!table) return { status: "missing", path: configPath };
   return { status: "found", path: configPath, server: parseServerTable(table.body) };
@@ -56,6 +59,10 @@ export async function writeCodexMcpServer(
   }
 
   const raw = existing ?? "";
+  if (existing !== undefined) {
+    const parseIssue = validateCodexToml(raw);
+    if (parseIssue) return codexParseError(configPath, parseIssue);
+  }
   const table = renderMcpServerTable(server);
   const current = findMcpServerTable(raw, server.name);
   const next = current
@@ -102,6 +109,124 @@ async function readOptionalFile(file: string): Promise<string | undefined> {
 
 async function exists(file: string): Promise<boolean> {
   return access(file, constants.F_OK).then(() => true).catch(() => false);
+}
+
+const TOML_KEY_PATTERN = String.raw`(?:"(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.\s*(?:"(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+))*`;
+const TOML_TABLE_HEADER_PATTERN = new RegExp(String.raw`^\s*\[\s*${TOML_KEY_PATTERN}\s*\]\s*$`);
+const TOML_ARRAY_TABLE_HEADER_PATTERN = new RegExp(String.raw`^\s*\[\[\s*${TOML_KEY_PATTERN}\s*\]\]\s*$`);
+
+type TomlStringState = {
+  quote: `"` | "'";
+  multiline: boolean;
+  escaped: boolean;
+  startedAtLine: number;
+  startedAtColumn: number;
+};
+
+function validateCodexToml(raw: string): string | undefined {
+  let stringState: TomlStringState | undefined;
+  let inComment = false;
+  let bracketDepth = 0;
+  const lines = raw.match(/^.*(?:\r?\n|$)/gm) ?? [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex]!;
+    const lineNumber = lineIndex + 1;
+    if (!stringState && bracketDepth === 0 && line.trimStart().startsWith("[")) {
+      const header = stripTomlLineComment(line).trim();
+      if (!TOML_TABLE_HEADER_PATTERN.test(header) && !TOML_ARRAY_TABLE_HEADER_PATTERN.test(header)) {
+        return `malformed table header at line ${lineNumber}`;
+      }
+    }
+
+    for (let column = 0; column < line.length; column += 1) {
+      const char = line[column]!;
+      const columnNumber = column + 1;
+      if (char === "\r" || char === "\n") {
+        if (stringState && !stringState.multiline) {
+          return `unterminated string starting at line ${stringState.startedAtLine}, column ${stringState.startedAtColumn}`;
+        }
+        inComment = false;
+        continue;
+      }
+      if (inComment) continue;
+      if (stringState) {
+        if (stringState.quote === `"` && stringState.escaped) {
+          stringState.escaped = false;
+          continue;
+        }
+        if (stringState.quote === `"` && char === "\\") {
+          stringState.escaped = true;
+          continue;
+        }
+        if (char === stringState.quote) {
+          if (stringState.multiline) {
+            if (line[column + 1] === char && line[column + 2] === char) {
+              stringState = undefined;
+              column += 2;
+            }
+          } else {
+            stringState = undefined;
+          }
+        }
+        continue;
+      }
+      if (char === "#") {
+        inComment = true;
+        continue;
+      }
+      if (char === `"` || char === "'") {
+        const multiline = line[column + 1] === char && line[column + 2] === char;
+        stringState = {
+          quote: char,
+          multiline,
+          escaped: false,
+          startedAtLine: lineNumber,
+          startedAtColumn: columnNumber,
+        };
+        if (multiline) column += 2;
+        continue;
+      }
+      if (char === "[") {
+        bracketDepth += 1;
+        continue;
+      }
+      if (char === "]") {
+        bracketDepth -= 1;
+        if (bracketDepth < 0) return `unexpected closing bracket at line ${lineNumber}, column ${columnNumber}`;
+      }
+    }
+  }
+
+  if (stringState) {
+    return `unterminated string starting at line ${stringState.startedAtLine}, column ${stringState.startedAtColumn}`;
+  }
+  if (bracketDepth > 0) return "unterminated bracketed expression";
+  return undefined;
+}
+
+function stripTomlLineComment(line: string): string {
+  let inString: `"` | "'" | undefined;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]!;
+    if (inString) {
+      if (inString === `"` && escaped) {
+        escaped = false;
+      } else if (inString === `"` && char === "\\") {
+        escaped = true;
+      } else if (char === inString) {
+        inString = undefined;
+      }
+      continue;
+    }
+    if (char === `"` || char === "'") {
+      inString = char;
+      continue;
+    }
+    if (char === "#") return line.slice(0, index);
+  }
+  return line;
 }
 
 function findMcpServerTable(raw: string, serverName: string): { start: number; end: number; body: string } | undefined {
@@ -282,6 +407,24 @@ function ioState(file: string, error: unknown): CodexMcpServerState {
     path: file,
     message: nodeError.message ?? String(error),
     ...(nodeError.code ? { code: nodeError.code } : {}),
+  };
+}
+
+function codexParseState(file: string, issue: string): CodexMcpServerState {
+  return {
+    status: "error",
+    path: file,
+    message: `codex-cli MCP config could not be parsed: ${issue}`,
+    code: "PARSE_ERROR",
+  };
+}
+
+function codexParseError(file: string, issue: string): CodexMcpWriteResult {
+  return {
+    status: "parse_error",
+    path: file,
+    message: `codex-cli MCP config could not be parsed: ${issue}`,
+    code: "PARSE_ERROR",
   };
 }
 

--- a/packages/cli/src/agents/codex-config.ts
+++ b/packages/cli/src/agents/codex-config.ts
@@ -1,0 +1,300 @@
+import { constants } from "node:fs";
+import { access, copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { McpServerInvocation } from "./registry.js";
+
+export type CodexConfigOptions = {
+  homeDir?: string;
+  now?: Date;
+};
+
+export type CodexMcpServerState =
+  | { status: "missing"; path: string }
+  | { status: "found"; path: string; server: { command?: string; args?: string[] } }
+  | { status: "error"; path: string; message: string; code?: string };
+
+export type CodexMcpWriteResult =
+  | { status: "applied"; path: string; backupPath?: string }
+  | { status: "skipped"; path: string; reason: "unchanged" }
+  | { status: "io_error"; path: string; message: string; code?: string };
+
+export function codexConfigPath(options: CodexConfigOptions = {}): string {
+  return path.join(options.homeDir ?? os.homedir(), ".codex", "config.toml");
+}
+
+export async function canAutoConfigureCodex(options: CodexConfigOptions = {}): Promise<boolean> {
+  const configPath = codexConfigPath(options);
+  if (await exists(configPath)) return true;
+  return exists(path.dirname(configPath));
+}
+
+export async function readCodexMcpServer(
+  serverName: string,
+  options: CodexConfigOptions = {},
+): Promise<CodexMcpServerState> {
+  const configPath = codexConfigPath(options);
+  const raw = await readOptionalFile(configPath).catch((error): CodexMcpServerState => ioState(configPath, error));
+  if (raw === undefined) return { status: "missing", path: configPath };
+  if (typeof raw !== "string") return raw;
+  const table = findMcpServerTable(raw, serverName);
+  if (!table) return { status: "missing", path: configPath };
+  return { status: "found", path: configPath, server: parseServerTable(table.body) };
+}
+
+export async function writeCodexMcpServer(
+  server: McpServerInvocation,
+  options: CodexConfigOptions = {},
+): Promise<CodexMcpWriteResult> {
+  const configPath = codexConfigPath(options);
+  let existing: string | undefined;
+  try {
+    existing = await readOptionalFile(configPath);
+  } catch (error) {
+    return ioError(configPath, error);
+  }
+
+  const raw = existing ?? "";
+  const table = renderMcpServerTable(server);
+  const current = findMcpServerTable(raw, server.name);
+  const next = current
+    ? `${raw.slice(0, current.start)}${table}${raw.slice(current.end).replace(/^\n+/, "\n")}`
+    : appendTable(raw, table);
+
+  if (next === raw) return { status: "skipped", path: configPath, reason: "unchanged" };
+
+  try {
+    await mkdir(path.dirname(configPath), { recursive: true, mode: 0o700 });
+    let backupPath: string | undefined;
+    if (existing !== undefined) {
+      backupPath = `${configPath}.bak-${utcBackupTimestamp(options.now ?? new Date())}`;
+      await copyFile(configPath, backupPath);
+    }
+    await writeFile(configPath, next, { encoding: "utf8", mode: 0o600 });
+    return { status: "applied", path: configPath, ...(backupPath ? { backupPath } : {}) };
+  } catch (error) {
+    return ioError(configPath, error);
+  }
+}
+
+export function equivalentCodexServer(
+  actual: { command?: string; args?: string[] },
+  expected: McpServerInvocation,
+): boolean {
+  return (
+    actual.command === expected.command &&
+    Array.isArray(actual.args) &&
+    actual.args.length === expected.args.length &&
+    actual.args.every((arg, index) => arg === expected.args[index])
+  );
+}
+
+async function readOptionalFile(file: string): Promise<string | undefined> {
+  try {
+    return await readFile(file, "utf8");
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function exists(file: string): Promise<boolean> {
+  return access(file, constants.F_OK).then(() => true).catch(() => false);
+}
+
+function findMcpServerTable(raw: string, serverName: string): { start: number; end: number; body: string } | undefined {
+  const tablePattern = new RegExp(
+    `^\\s*\\[\\s*mcp_servers\\.${tomlKeyPattern(serverName)}\\s*\\]\\s*(?:#.*)?$`,
+  );
+  const lines = raw.match(/^.*(?:\r?\n|$)/gm) ?? [];
+  let offset = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    const content = line.replace(/\r?\n$/, "");
+    if (!tablePattern.test(content)) {
+      offset += line.length;
+      continue;
+    }
+    const start = offset;
+    let end = offset + line.length;
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const next = lines[cursor]!;
+      if (/^\s*\[/.test(next)) break;
+      end += next.length;
+    }
+    return { start, end, body: raw.slice(start, end) };
+  }
+  return undefined;
+}
+
+function parseServerTable(body: string): { command?: string; args?: string[] } {
+  const command = parseTomlStringAssignment(body, "command");
+  const args = parseTomlStringArrayAssignment(body, "args");
+  return { ...(command !== undefined ? { command } : {}), ...(args !== undefined ? { args } : {}) };
+}
+
+function parseTomlStringAssignment(body: string, key: string): string | undefined {
+  const stringPattern = `"(?:(?:\\\\.)|[^"\\\\])*"|'[^']*'`;
+  const match = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*(${stringPattern})`, "m").exec(body);
+  if (!match) return undefined;
+  return parseTomlString(match[1]!.trim());
+}
+
+function parseTomlStringArrayAssignment(body: string, key: string): string[] | undefined {
+  const raw = extractTomlArrayAssignment(body, key);
+  if (!raw) return undefined;
+  return parseTomlStringArray(raw);
+}
+
+function parseTomlString(raw: string): string | undefined {
+  if (raw.startsWith('"') && raw.endsWith('"')) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return undefined;
+    }
+  }
+  if (raw.startsWith("'") && raw.endsWith("'")) return raw.slice(1, -1);
+  return undefined;
+}
+
+function extractTomlArrayAssignment(body: string, key: string): string | undefined {
+  const match = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*\\[`, "m").exec(body);
+  if (!match) return undefined;
+  const start = body.indexOf("[", match.index);
+  if (start < 0) return undefined;
+  let inString: `"` | "'" | undefined;
+  let escaped = false;
+  let inComment = false;
+  let depth = 0;
+  for (let index = start; index < body.length; index += 1) {
+    const char = body[index]!;
+    if (inComment) {
+      if (char === "\n" || char === "\r") inComment = false;
+      continue;
+    }
+    if (inString) {
+      if (inString === `"` && escaped) {
+        escaped = false;
+      } else if (inString === `"` && char === "\\") {
+        escaped = true;
+      } else if (char === inString) {
+        inString = undefined;
+      }
+      continue;
+    }
+    if (char === "#") {
+      inComment = true;
+      continue;
+    }
+    if (char === `"` || char === "'") {
+      inString = char;
+      continue;
+    }
+    if (char === "[") depth += 1;
+    if (char === "]") {
+      depth -= 1;
+      if (depth === 0) return body.slice(start, index + 1);
+    }
+  }
+  return undefined;
+}
+
+function parseTomlStringArray(raw: string): string[] | undefined {
+  const values: string[] = [];
+  for (let index = 1; index < raw.length - 1; index += 1) {
+    const char = raw[index]!;
+    if (/\s|,/.test(char)) continue;
+    if (char === "#") {
+      while (index < raw.length - 1 && raw[index] !== "\n" && raw[index] !== "\r") index += 1;
+      continue;
+    }
+    if (char === `"`) {
+      const start = index;
+      let escaped = false;
+      for (index += 1; index < raw.length - 1; index += 1) {
+        const inner = raw[index]!;
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (inner === "\\") {
+          escaped = true;
+          continue;
+        }
+        if (inner === `"`) break;
+      }
+      if (raw[index] !== `"`) return undefined;
+      const value = parseTomlString(raw.slice(start, index + 1));
+      if (value === undefined) return undefined;
+      values.push(value);
+      continue;
+    }
+    if (char === "'") {
+      const start = index;
+      index += 1;
+      while (index < raw.length - 1 && raw[index] !== "'") index += 1;
+      if (raw[index] !== "'") return undefined;
+      const value = parseTomlString(raw.slice(start, index + 1));
+      if (value === undefined) return undefined;
+      values.push(value);
+      continue;
+    }
+    return undefined;
+  }
+  return values;
+}
+
+function renderMcpServerTable(server: McpServerInvocation): string {
+  return [
+    `[mcp_servers.${tomlBareOrQuotedKey(server.name)}]`,
+    `command = ${JSON.stringify(server.command)}`,
+    `args = [${server.args.map((arg) => JSON.stringify(arg)).join(", ")}]`,
+    "",
+  ].join("\n");
+}
+
+function appendTable(raw: string, table: string): string {
+  if (raw.trim().length === 0) return table;
+  const normalized = raw.endsWith("\n") ? raw : `${raw}\n`;
+  return `${normalized}\n${table}`;
+}
+
+function tomlBareOrQuotedKey(key: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : JSON.stringify(key);
+}
+
+function tomlKeyPattern(key: string): string {
+  const escaped = escapeRegExp(key);
+  return `(?:${escaped}|"${escaped}"|'${escaped}')`;
+}
+
+function utcBackupTimestamp(now: Date): string {
+  return now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+function ioState(file: string, error: unknown): CodexMcpServerState {
+  const nodeError = error as NodeJS.ErrnoException;
+  return {
+    status: "error",
+    path: file,
+    message: nodeError.message ?? String(error),
+    ...(nodeError.code ? { code: nodeError.code } : {}),
+  };
+}
+
+function ioError(file: string, error: unknown): CodexMcpWriteResult {
+  const nodeError = error as NodeJS.ErrnoException;
+  return {
+    status: "io_error",
+    path: file,
+    message: nodeError.message ?? String(error),
+    ...(nodeError.code ? { code: nodeError.code } : {}),
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/cli/src/agents/configure.test.ts
+++ b/packages/cli/src/agents/configure.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { configureAgents } from "./configure.js";
+import { configureAgents, detectInstalledAgents } from "./configure.js";
 import type { McpServerInvocation } from "./registry.js";
 
 test("configureAgents runs shell adapters found on PATH", async (t) => {
@@ -13,18 +13,18 @@ test("configureAgents runs shell adapters found on PATH", async (t) => {
   const bin = path.join(root, "bin");
   await mkdir(bin, { recursive: true });
   const log = path.join(root, "args.txt");
-  const codex = path.join(bin, "codex");
-  await writeFile(codex, `#!/bin/sh\necho "$@" > ${shellQuote(log)}\n`, "utf8");
-  await chmod(codex, 0o755);
+  const claude = path.join(bin, "claude");
+  await writeFile(claude, `#!/bin/sh\necho "$@" > ${shellQuote(log)}\n`, "utf8");
+  await chmod(claude, 0o755);
 
   const steps = await configureAgents({
-    agents: ["codex-cli"],
+    agents: ["claude-code"],
     server: server(root),
     env: { PATH: bin },
   });
 
   assert.equal(steps[0]?.status, "applied");
-  assert.match(await readFile(log, "utf8"), /mcp add open-browser-use -- .* mcp stdio/);
+  assert.match(await readFile(log, "utf8"), /mcp add -s user open-browser-use -- .* mcp stdio/);
 });
 
 test("configureAgents skips shell adapters when an equivalent server already exists", async (t) => {
@@ -33,18 +33,18 @@ test("configureAgents skips shell adapters when an equivalent server already exi
   const bin = path.join(root, "bin");
   await mkdir(bin, { recursive: true });
   const log = path.join(root, "add.txt");
-  const codex = path.join(bin, "codex");
-  await writeFile(codex, `#!/bin/sh
+  const claude = path.join(bin, "claude");
+  await writeFile(claude, `#!/bin/sh
 if [ "$1 $2" = "mcp list" ]; then
   echo "open-browser-use ${shellEscapeForDoubleQuotes(path.join(root, "obu"))} mcp stdio"
   exit 0
 fi
 echo "$@" > ${shellQuote(log)}
 `, "utf8");
-  await chmod(codex, 0o755);
+  await chmod(claude, 0o755);
 
   const steps = await configureAgents({
-    agents: ["codex-cli"],
+    agents: ["claude-code"],
     server: server(root),
     env: { PATH: bin },
   });
@@ -76,12 +76,12 @@ test("configureAgents times out hung shell adapters with a manual action", async
   t.after(() => rm(root, { recursive: true, force: true }));
   const bin = path.join(root, "bin");
   await mkdir(bin, { recursive: true });
-  const codex = path.join(bin, "codex");
-  await writeFile(codex, "#!/bin/sh\nsleep 5\n", "utf8");
-  await chmod(codex, 0o755);
+  const claude = path.join(bin, "claude");
+  await writeFile(claude, "#!/bin/sh\nsleep 5\n", "utf8");
+  await chmod(claude, 0o755);
 
   const steps = await configureAgents({
-    agents: ["codex-cli"],
+    agents: ["claude-code"],
     server: server(root),
     env: { PATH: bin },
     adapterTimeoutMs: 25,
@@ -90,7 +90,7 @@ test("configureAgents times out hung shell adapters with a manual action", async
   assert.equal(steps[0]?.status, "manual_action_required");
   assert.match(steps[0]?.message ?? "", /timed out/);
   assert.equal(steps[0]?.details?.timeout_ms, 25);
-  assert.match(steps[0]?.nextActions?.[0]?.value ?? "", /mcp-config --agent=codex-cli --print/);
+  assert.match(steps[0]?.nextActions?.[0]?.value ?? "", /mcp-config --agent=claude-code --print/);
 });
 
 test("configureAgents dry-run reports planned shell and direct-edit work", async (t) => {
@@ -107,9 +107,63 @@ test("configureAgents dry-run reports planned shell and direct-edit work", async
   });
 
   assert.equal(steps.find((step) => step.id === "agent-codex-cli")?.status, "would_apply");
-  assert.match(steps.find((step) => step.id === "agent-codex-cli")?.message ?? "", /would run codex adapter/);
+  assert.match(steps.find((step) => step.id === "agent-codex-cli")?.message ?? "", /would update codex-cli MCP config/);
   assert.equal(steps.find((step) => step.id === "agent-zed")?.status, "would_apply");
   assert.match(steps.find((step) => step.id === "agent-zed")?.message ?? "", /would update zed MCP config/);
+});
+
+test("configureAgents writes Codex global MCP config without requiring codex on PATH", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const first = await configureAgents({
+    agents: ["codex-cli"],
+    server: server(root),
+    env: { PATH: "" },
+    homeDir: root,
+  });
+
+  assert.equal(first[0]?.status, "applied");
+  const configPath = path.join(root, ".codex", "config.toml");
+  const config = await readFile(configPath, "utf8");
+  assert.match(config, /\[mcp_servers\.open-browser-use\]/);
+  assert.match(config, new RegExp(`command = "${escapeRegExp(path.join(root, "obu"))}"`));
+  assert.match(config, /args = \["mcp", "stdio"\]/);
+
+  const second = await configureAgents({
+    agents: ["codex-cli"],
+    server: server(root),
+    env: { PATH: "" },
+    homeDir: root,
+  });
+  assert.equal(second[0]?.status, "skipped");
+});
+
+test("configureAgents does not overwrite divergent Codex MCP config", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const configPath = path.join(root, ".codex", "config.toml");
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, [
+    "[mcp_servers.open-browser-use]",
+    'command = "/custom/obu"',
+    'args = ["mcp", "stdio"]',
+    "",
+  ].join("\n"), "utf8");
+
+  const steps = await configureAgents({
+    agents: ["codex-cli"],
+    server: server(root),
+    env: { PATH: "" },
+    homeDir: root,
+  });
+
+  assert.equal(steps[0]?.status, "manual_action_required");
+  assert.match(steps[0]?.message ?? "", /different settings/);
+  assert.match(steps[0]?.nextActions?.[0]?.value ?? "", /mcp-config --agent=codex-cli --print/);
+  const config = await readFile(configPath, "utf8");
+  assert.match(config, /command = "\/custom\/obu"/);
+  assert.doesNotMatch(config, new RegExp(escapeRegExp(path.join(root, "obu"))));
 });
 
 test("configureAgents writes JSONC direct-edit adapters and skips unchanged reruns", async (t) => {
@@ -223,7 +277,7 @@ test("configureAgents writes primary-browser instructions only when requested", 
     writeInstructions: true,
   });
 
-  assert.equal(steps.find((step) => step.id === "agent-codex-cli")?.status, "manual_action_required");
+  assert.equal(steps.find((step) => step.id === "agent-codex-cli")?.status, "applied");
   const instructionStep = steps.find((step) => step.id === "agent-codex-cli-instructions");
   assert.equal(instructionStep?.status, "applied");
   assert.match(await readFile(path.join(root, ".codex", "AGENTS.md"), "utf8"), /primary BrowserUse\/browser automation tool/);
@@ -261,7 +315,7 @@ test("configureAgents prefers an existing project instruction file over the glob
   await assert.rejects(() => readFile(path.join(root, ".codex", "AGENTS.md"), "utf8"), { code: "ENOENT" });
 });
 
-test("configureAgents uses Cursor shell adapter only when --add-mcp is available", async (t) => {
+test("configureAgents writes Cursor config where agent doctor checks it", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
   t.after(() => rm(root, { recursive: true, force: true }));
   const bin = path.join(root, "bin");
@@ -285,8 +339,31 @@ echo "$@" > ${shellQuote(log)}
   });
 
   assert.equal(steps[0]?.status, "applied");
-  assert.match(await readFile(log, "utf8"), /--add-mcp/);
-  await assert.rejects(() => readFile(path.join(root, ".cursor", "mcp.json"), "utf8"), { code: "ENOENT" });
+  await assert.rejects(() => readFile(log, "utf8"), { code: "ENOENT" });
+  const config = JSON.parse(await readFile(path.join(root, ".cursor", "mcp.json"), "utf8"));
+  assert.equal(config.mcpServers["open-browser-use"].command, path.join(root, "obu"));
+  assert.deepEqual(config.mcpServers["open-browser-use"].args, ["mcp", "stdio"]);
+  assert.equal("name" in config.mcpServers["open-browser-use"], false);
+});
+
+test("detectInstalledAgents includes Codex config directories and Cursor executables", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const bin = path.join(root, "bin");
+  await mkdir(path.join(root, ".codex"), { recursive: true });
+  await mkdir(bin, { recursive: true });
+  const cursor = path.join(bin, "cursor");
+  await writeFile(cursor, "#!/bin/sh\n", "utf8");
+  await chmod(cursor, 0o755);
+
+  const agents = await detectInstalledAgents({
+    env: { PATH: bin },
+    homeDir: root,
+    platform: "linux",
+  });
+
+  assert.equal(agents.includes("codex-cli"), true);
+  assert.equal(agents.includes("cursor"), true);
 });
 
 function server(root: string): McpServerInvocation {
@@ -303,4 +380,8 @@ function shellQuote(value: string): string {
 
 function shellEscapeForDoubleQuotes(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("$", "\\$").replaceAll("`", "\\`");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/cli/src/agents/configure.test.ts
+++ b/packages/cli/src/agents/configure.test.ts
@@ -166,6 +166,28 @@ test("configureAgents does not overwrite divergent Codex MCP config", async (t) 
   assert.doesNotMatch(config, new RegExp(escapeRegExp(path.join(root, "obu"))));
 });
 
+test("configureAgents does not append to malformed Codex config", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const configPath = path.join(root, ".codex", "config.toml");
+  const malformed = "[broken\n";
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, malformed, "utf8");
+
+  const steps = await configureAgents({
+    agents: ["codex-cli"],
+    server: server(root),
+    env: { PATH: "" },
+    homeDir: root,
+  });
+
+  assert.equal(steps[0]?.status, "manual_action_required");
+  assert.match(steps[0]?.message ?? "", /could not be parsed/);
+  assert.equal(steps[0]?.details?.code, "PARSE_ERROR");
+  assert.match(steps[0]?.nextActions?.[0]?.value ?? "", /mcp-config --agent=codex-cli --print/);
+  assert.equal(await readFile(configPath, "utf8"), malformed);
+});
+
 test("configureAgents writes JSONC direct-edit adapters and skips unchanged reruns", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "obu-agent-config-"));
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/packages/cli/src/agents/configure.ts
+++ b/packages/cli/src/agents/configure.ts
@@ -182,10 +182,13 @@ async function configureCodex(
     };
   }
   if (current.status === "error") {
+    const parsed = current.code === "PARSE_ERROR";
     return {
       id: "agent-codex-cli",
       status: "manual_action_required",
-      message: "codex-cli MCP config could not be read; configure it manually",
+      message: parsed
+        ? "codex-cli MCP config could not be parsed; configure it manually"
+        : "codex-cli MCP config could not be read; configure it manually",
       details: { path: current.path, message: current.message, ...(current.code ? { code: current.code } : {}) },
       nextActions: [manualAction],
     };
@@ -205,6 +208,15 @@ async function configureCodex(
       status: "manual_action_required",
       message: "codex-cli MCP config could not be written; configure it manually",
       details: { path: result.path, message: result.message, ...(result.code ? { code: result.code } : {}) },
+      nextActions: [manualAction],
+    };
+  }
+  if (result.status === "parse_error") {
+    return {
+      id: "agent-codex-cli",
+      status: "manual_action_required",
+      message: "codex-cli MCP config could not be parsed; configure it manually",
+      details: { path: result.path, message: result.message, code: result.code },
       nextActions: [manualAction],
     };
   }

--- a/packages/cli/src/agents/configure.ts
+++ b/packages/cli/src/agents/configure.ts
@@ -6,6 +6,12 @@ import { spawn } from "node:child_process";
 import { renderAgentMcpConfig, type AgentId, type McpServerInvocation } from "./registry.js";
 import { appendShellArgs } from "../command-line.js";
 import {
+  canAutoConfigureCodex,
+  equivalentCodexServer,
+  readCodexMcpServer,
+  writeCodexMcpServer,
+} from "./codex-config.js";
+import {
   canAutoConfigureDirectEditAgent,
   isDirectEditAgentId,
   writeDirectEditAgentConfig,
@@ -80,16 +86,8 @@ export async function configureAgents(options: ConfigureAgentsOptions): Promise<
       value: appendShellArgs(options.commandPrefix ?? "obu", ["mcp-config", `--agent=${agent}`, "--print"]),
     };
     let step: AgentConfigureStep;
-    if (agent === "cursor") {
-      step = await configureCursor(
-        config,
-        options.server,
-        env,
-        options.dryRun === true,
-        directEditOptions,
-        manualAction,
-        options.adapterTimeoutMs ?? DEFAULT_ADAPTER_TIMEOUT_MS,
-      );
+    if (agent === "codex-cli") {
+      step = await configureCodex(options.server, options.dryRun === true, directEditOptions, manualAction);
       steps.push(step);
       steps.push(...await maybeConfigureInstructions(options, agent));
       continue;
@@ -141,31 +139,81 @@ async function maybeConfigureInstructions(options: ConfigureAgentsOptions, agent
 
 async function isAgentInstalled(agent: AgentId, env: NodeJS.ProcessEnv, directEditOptions: DirectEditOptions): Promise<boolean> {
   const config = renderAgentMcpConfig(agent, { name: "open-browser-use", command: "obu", args: ["mcp", "stdio"] });
+  if (agent === "codex-cli") {
+    return await findExecutable(config.mode === "shell" ? config.executable : "codex", env) !== undefined ||
+      await canAutoConfigureCodex(directEditOptions);
+  }
+  if (agent === "cursor" && await findExecutable("cursor", env)) return true;
   if (config.mode === "shell" && await findExecutable(config.executable, env)) return true;
   if (isDirectEditAgentId(agent)) return canAutoConfigureDirectEditAgent(agent, directEditOptions);
   return false;
 }
 
-async function configureCursor(
-  config: ReturnType<typeof renderAgentMcpConfig>,
+async function configureCodex(
   server: McpServerInvocation,
-  env: NodeJS.ProcessEnv,
   dryRun: boolean,
-  directEditOptions: DirectEditOptions,
+  options: DirectEditOptions,
   manualAction: AgentNextAction,
-  adapterTimeoutMs: number,
 ): Promise<AgentConfigureStep> {
-  if (config.mode !== "shell") {
-    return configureDirectEdit("cursor", server, dryRun, directEditOptions, manualAction);
+  if (dryRun) {
+    return {
+      id: "agent-codex-cli",
+      status: "would_apply",
+      message: "would update codex-cli MCP config",
+      details: { dryRun: true },
+    };
   }
-  const executable = await findExecutable(config.executable, env);
-  if (executable) {
-    const help = await runAdapter(executable, ["--help"], env, adapterTimeoutMs);
-    if (help.code === 0 && /--add-mcp\b/.test(`${help.stdout}\n${help.stderr}`)) {
-      return configureShell("cursor", config, env, dryRun, manualAction, executable, adapterTimeoutMs);
-    }
+  const current = await readCodexMcpServer(server.name, options);
+  if (current.status === "found" && equivalentCodexServer(current.server, server)) {
+    return {
+      id: "agent-codex-cli",
+      status: "skipped",
+      message: "codex-cli already has an equivalent open-browser-use MCP server",
+      details: { path: current.path },
+    };
   }
-  return configureDirectEdit("cursor", server, dryRun, directEditOptions, manualAction);
+  if (current.status === "found") {
+    return {
+      id: "agent-codex-cli",
+      status: "manual_action_required",
+      message: "codex-cli already has an open-browser-use MCP server with different settings",
+      details: { path: current.path, expected: server, actual: current.server },
+      nextActions: [manualAction],
+    };
+  }
+  if (current.status === "error") {
+    return {
+      id: "agent-codex-cli",
+      status: "manual_action_required",
+      message: "codex-cli MCP config could not be read; configure it manually",
+      details: { path: current.path, message: current.message, ...(current.code ? { code: current.code } : {}) },
+      nextActions: [manualAction],
+    };
+  }
+  const result = await writeCodexMcpServer(server, options);
+  if (result.status === "skipped") {
+    return {
+      id: "agent-codex-cli",
+      status: "skipped",
+      message: "codex-cli MCP config is unchanged",
+      details: { path: result.path },
+    };
+  }
+  if (result.status === "io_error") {
+    return {
+      id: "agent-codex-cli",
+      status: "manual_action_required",
+      message: "codex-cli MCP config could not be written; configure it manually",
+      details: { path: result.path, message: result.message, ...(result.code ? { code: result.code } : {}) },
+      nextActions: [manualAction],
+    };
+  }
+  return {
+    id: "agent-codex-cli",
+    status: "applied",
+    message: "updated codex-cli MCP config",
+    details: { path: result.path, ...(result.backupPath ? { backupPath: result.backupPath } : {}) },
+  };
 }
 
 async function configureShell(

--- a/packages/cli/src/agents/direct-edit.ts
+++ b/packages/cli/src/agents/direct-edit.ts
@@ -216,7 +216,7 @@ function directEditPatch(agent: DirectEditAgentId, server: McpServerInvocation):
   }
   return {
     path: ["mcpServers", server.name],
-    value: server,
+    value: { command: server.command, args: server.args },
   };
 }
 

--- a/packages/cli/src/agents/doctor.ts
+++ b/packages/cli/src/agents/doctor.ts
@@ -11,6 +11,7 @@ import {
   PRIMARY_BROWSER_INSTRUCTION,
   primaryInstructionTargets,
 } from "./instructions.js";
+import { equivalentCodexServer, readCodexMcpServer } from "./codex-config.js";
 import { renderAgentMcpConfig, type AgentId, type McpServerInvocation } from "./registry.js";
 
 export type AgentDoctorStatus = "pass" | "warn" | "fail";
@@ -37,7 +38,7 @@ export type AgentDoctorOptions = {
   adapterTimeoutMs?: number;
 };
 
-const DEFAULT_ADAPTER_TIMEOUT_MS = 5_000;
+const DEFAULT_ADAPTER_TIMEOUT_MS = 15_000;
 const MCP_LIST_AGENT_IDS = new Set<AgentId>(["codex-cli", "claude-code", "gemini-cli"]);
 
 export async function doctorAgent(options: AgentDoctorOptions): Promise<AgentDoctorReport> {
@@ -68,6 +69,10 @@ export function hasAgentDoctorFailures(report: AgentDoctorReport): boolean {
 
 async function checkMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorCheck> {
   const config = renderAgentMcpConfig(options.agent, options.server);
+  if (options.agent === "codex-cli") {
+    const configCheck = await checkCodexConfigMcpServer(options);
+    if (configCheck) return configCheck;
+  }
   if (isDirectEditAgentId(options.agent)) {
     return checkDirectEditMcpConfig(options);
   }
@@ -116,6 +121,32 @@ async function checkMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorC
   }
   return pass("agent-mcp-server", "MCP server", `${options.agent} lists ${options.server.name}`, {
     executable,
+  });
+}
+
+async function checkCodexConfigMcpServer(options: AgentDoctorOptions): Promise<AgentDoctorCheck | undefined> {
+  const state = await readCodexMcpServer(options.server.name, {
+    ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+  });
+  if (state.status === "error") {
+    return fail("agent-mcp-server", "MCP server", "codex-cli MCP config could not be read", {
+      path: state.path,
+      message: state.message,
+      ...(state.code ? { code: state.code } : {}),
+    });
+  }
+  if (state.status === "missing") {
+    return undefined;
+  }
+  if (!equivalentCodexServer(state.server, options.server)) {
+    return fail("agent-mcp-server", "MCP server", `Codex config lists ${options.server.name} with different settings`, {
+      path: state.path,
+      expected: options.server,
+      actual: state.server,
+    });
+  }
+  return pass("agent-mcp-server", "MCP server", `codex-cli configures ${options.server.name}`, {
+    path: state.path,
   });
 }
 

--- a/packages/cli/src/agents/doctor.ts
+++ b/packages/cli/src/agents/doctor.ts
@@ -129,7 +129,8 @@ async function checkCodexConfigMcpServer(options: AgentDoctorOptions): Promise<A
     ...(options.homeDir ? { homeDir: options.homeDir } : {}),
   });
   if (state.status === "error") {
-    return fail("agent-mcp-server", "MCP server", "codex-cli MCP config could not be read", {
+    const parsed = state.code === "PARSE_ERROR";
+    return fail("agent-mcp-server", "MCP server", parsed ? "codex-cli MCP config could not be parsed" : "codex-cli MCP config could not be read", {
       path: state.path,
       message: state.message,
       ...(state.code ? { code: state.code } : {}),

--- a/packages/cli/src/agents/instructions.ts
+++ b/packages/cli/src/agents/instructions.ts
@@ -29,7 +29,7 @@ export const PRIMARY_BROWSER_INSTRUCTION = [
   PRIMARY_INSTRUCTION_NEEDLE,
   "Prefer the `open-browser-use` MCP server for browser tasks. Check `browser_status`",
   "before the first browser action, use the `js` tool for browser automation, and",
-  "run `~/.obu/bin/obu doctor browser` if setup appears stale.",
+  "run `~/.obu/bin/obu verify --agent=<agent-id> --browser=<browser> --channel=<channel> --extension-id=<extension-id>` if setup appears stale.",
 ].join("\n");
 
 export async function configureAgentInstructions(options: AgentInstructionOptions): Promise<AgentInstructionStep> {

--- a/packages/cli/src/agents/registry.ts
+++ b/packages/cli/src/agents/registry.ts
@@ -52,12 +52,29 @@ const AGENT_IDS: AgentId[] = [
   "continue",
 ];
 
+const AGENT_ALIASES: Record<string, AgentId> = {
+  codex: "codex-cli",
+  claude: "claude-code",
+  "claude-cli": "claude-code",
+  gemini: "gemini-cli",
+};
+
 export function isAgentId(value: string): value is AgentId {
   return (AGENT_IDS as string[]).includes(value);
 }
 
+export function normalizeAgentId(value: string): AgentId | undefined {
+  const normalized = value.toLowerCase();
+  if (isAgentId(normalized)) return normalized;
+  return AGENT_ALIASES[normalized];
+}
+
 export function supportedAgentIds(): AgentId[] {
   return [...AGENT_IDS];
+}
+
+export function supportedAgentAliasHelp(): string {
+  return "Aliases: codex=codex-cli, claude=claude-code, gemini=gemini-cli.";
 }
 
 export function renderAgentMcpConfig(agent: AgentId, server: McpServerInvocation): AgentMcpConfig {
@@ -71,13 +88,13 @@ export function renderAgentMcpConfig(agent: AgentId, server: McpServerInvocation
     case "vscode":
       return shellConfig(agent, server, "code", ["--add-mcp", JSON.stringify(server)]);
     case "cursor":
-      return shellConfig(agent, server, "cursor", ["--add-mcp", JSON.stringify(server)]);
+      return jsonConfig(agent, server, { mcpServers: { [server.name]: jsonServerConfig(server) } });
     case "cline":
-      return jsonConfig(agent, server, { mcpServers: { [server.name]: server } });
+      return jsonConfig(agent, server, { mcpServers: { [server.name]: jsonServerConfig(server) } });
     case "windsurf":
-      return jsonConfig(agent, server, { mcpServers: { [server.name]: server } });
+      return jsonConfig(agent, server, { mcpServers: { [server.name]: jsonServerConfig(server) } });
     case "claude-desktop":
-      return jsonConfig(agent, server, { mcpServers: { [server.name]: server } });
+      return jsonConfig(agent, server, { mcpServers: { [server.name]: jsonServerConfig(server) } });
     case "zed":
       return jsonConfig(agent, server, { context_servers: { [server.name]: { command: server.command, args: server.args } } });
     case "continue":
@@ -109,6 +126,10 @@ function jsonConfig(agent: AgentId, server: McpServerInvocation, config: Record<
     server,
     config,
   };
+}
+
+function jsonServerConfig(server: McpServerInvocation): { command: string; args: string[] } {
+  return { command: server.command, args: server.args };
 }
 
 function shellQuote(value: string): string {

--- a/packages/cli/src/doctor-browser.test.ts
+++ b/packages/cli/src/doctor-browser.test.ts
@@ -14,6 +14,7 @@ import {
   type DoctorBrowserOptions,
   type DoctorReport,
 } from "./doctor-browser.js";
+import { nativeHostWrapperContent, nativeHostWrapperPath } from "./native-host.js";
 
 const HOST_NAME = "dev.obu.host";
 const EXTENSION_KEY = Buffer.from("open-browser-use test extension key").toString("base64");
@@ -903,21 +904,31 @@ async function createDoctorFixture(t: TestContext): Promise<DoctorFixture> {
   await writeFile(hostBinary, "#!/bin/sh\necho obu-host 0.1.0\n", "utf8");
   await chmod(hostBinary, 0o700);
 
+  const runtimeDir = path.join(root, "runtime");
+  const runtimeDescriptorDir = path.join(runtimeDir, "webextension");
+  await mkdir(runtimeDescriptorDir, { recursive: true, mode: 0o700 });
+  await chmod(runtimeDir, 0o700);
+  await chmod(runtimeDescriptorDir, 0o700);
+
+  const nativeHostInstallRoot = path.join(homeDir, ".obu", "native-host");
+  const wrapperPath = nativeHostWrapperPath({ nativeHostInstallRoot, browser });
+  await mkdir(path.dirname(wrapperPath), { recursive: true });
+  await writeFile(wrapperPath, nativeHostWrapperContent({
+    hostBin: hostBinary,
+    browser,
+    runtimeDir,
+  }), "utf8");
+  await chmod(wrapperPath, 0o755);
+
   const nativeManifestDir = path.join(root, "NativeMessagingHosts");
   await mkdir(nativeManifestDir, { recursive: true });
   const nativeHostManifestPath = path.join(nativeManifestDir, `${HOST_NAME}.json`);
   await writeJson(nativeHostManifestPath, {
     name: HOST_NAME,
     type: "stdio",
-    path: hostBinary,
+    path: wrapperPath,
     allowed_origins: [`chrome-extension://${extensionId}/`],
   });
-
-  const runtimeDir = path.join(root, "runtime");
-  const runtimeDescriptorDir = path.join(runtimeDir, "webextension");
-  await mkdir(runtimeDescriptorDir, { recursive: true, mode: 0o700 });
-  await chmod(runtimeDir, 0o700);
-  await chmod(runtimeDescriptorDir, 0o700);
 
   return {
     root,

--- a/packages/cli/src/doctor-browser.ts
+++ b/packages/cli/src/doctor-browser.ts
@@ -816,7 +816,7 @@ async function checkRuntimeDescriptors(descriptorDir: string): Promise<DoctorChe
 function resumeRequiredDetails(): Record<string, unknown> {
   return {
     resume_required: true,
-    resume_action: "open the open-browser-use extension popup and click Resume",
+    resume_action: "open the open-browser-use extension popup; click Resume if it is enabled, otherwise wait for Connected and rerun doctor",
   };
 }
 
@@ -1127,9 +1127,9 @@ function repairHint(id: string, status: DoctorStatus, details: Record<string, un
     case "runtime-dir":
       return "Repair the runtime directory to an owner-only real directory, then rerun doctor.";
     case "runtime-descriptor-dir":
-      return "Repair the runtime descriptor directory to owner-only, then open the extension popup and click Resume.";
+      return "Repair the runtime descriptor directory to owner-only, then open the extension popup; click Resume if it is enabled.";
     case "runtime-descriptor-probe":
-      return "Run --repair if offered, then open the extension popup and click Resume to retry the native-host connection; rerun doctor after it reconnects.";
+      return "Run --repair if offered, then open the extension popup; click Resume if enabled, otherwise wait for Connected and rerun doctor.";
     default:
       return undefined;
   }

--- a/packages/cli/src/doctor-browser.ts
+++ b/packages/cli/src/doctor-browser.ts
@@ -9,6 +9,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { browserInstallPath, browserProfileRoot, nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
 import { type ExtensionChannel, type ExtensionIdSource } from "./extension-channel.js";
+import { nativeHostWrapperContent, nativeHostWrapperPath } from "./native-host.js";
 import { resolveRuntimeLayout, validateRuntimeDir, type RuntimeLayout } from "./runtime-layout.js";
 
 const execFileAsync = promisify(execFile);
@@ -277,8 +278,18 @@ async function repairNativeHostManifest(input: NativeHostRepairInput): Promise<D
       },
     ];
   }
+  const wrapperPath = nativeHostWrapperPath({
+    nativeHostInstallRoot: input.nativeHostInstallRoot,
+    browser: input.browser,
+  });
+  const wrapper = nativeHostWrapperContent({
+    hostBin: input.hostBinary,
+    browser: input.browser,
+    runtimeDir: input.runtimeDir,
+  });
   const current = await checkNativeHostManifest(input.nativeManifestPath, input.extensionId);
-  if (current.status === "pass") {
+  const executable = await access(input.hostBinary, constants.X_OK).then(() => true).catch(() => false);
+  if (current.status === "pass" && executable && await nativeHostManifestUsesCurrentWrapper(input.nativeManifestPath, wrapperPath, wrapper)) {
     return [
       {
         id: "native-host-manifest",
@@ -288,7 +299,6 @@ async function repairNativeHostManifest(input: NativeHostRepairInput): Promise<D
       },
     ];
   }
-  const executable = await access(input.hostBinary, constants.X_OK).then(() => true).catch(() => false);
   if (!executable) {
     return [
       {
@@ -300,33 +310,9 @@ async function repairNativeHostManifest(input: NativeHostRepairInput): Promise<D
     ];
   }
 
-  const browserKind = input.browser === "chrome-for-testing" ? "chrome" : input.browser;
-  const wrapperDir = path.join(input.nativeHostInstallRoot, HOST_NAME, input.browser);
-  const wrapperPath = path.join(wrapperDir, "obu-host-wrapper");
+  const wrapperDir = path.dirname(wrapperPath);
   await mkdir(wrapperDir, { recursive: true });
-  await writeFile(
-    wrapperPath,
-    [
-      "#!/bin/sh",
-      "set -eu",
-      `export OBU_BROWSER_KIND=${shellQuote(browserKind)}`,
-      `export OBU_RUNTIME_DIR=${shellQuote(input.runtimeDir)}`,
-      "if [ -L \"$OBU_RUNTIME_DIR\" ]; then",
-      "  echo \"open-browser-use runtime directory is a symlink: $OBU_RUNTIME_DIR\" >&2",
-      "  exit 1",
-      "fi",
-      "if [ -e \"$OBU_RUNTIME_DIR\" ] && [ ! -d \"$OBU_RUNTIME_DIR\" ]; then",
-      "  echo \"open-browser-use runtime path is not a directory: $OBU_RUNTIME_DIR\" >&2",
-      "  exit 1",
-      "fi",
-      "if [ ! -e \"$OBU_RUNTIME_DIR\" ]; then",
-      "  mkdir -m 700 -p \"$OBU_RUNTIME_DIR\"",
-      "fi",
-      `exec ${shellQuote(input.hostBinary)} --native-messaging`,
-      "",
-    ].join("\n"),
-    "utf8",
-  );
+  await writeFile(wrapperPath, wrapper, "utf8");
   await chmod(wrapperPath, 0o755);
   await mkdir(path.dirname(input.nativeManifestPath), { recursive: true });
   await writeFile(
@@ -349,6 +335,28 @@ async function repairNativeHostManifest(input: NativeHostRepairInput): Promise<D
       details: { path: input.nativeManifestPath, wrapperPath, extensionId: input.extensionId },
     },
   ];
+}
+
+async function nativeHostManifestUsesCurrentWrapper(
+  manifestPath: string,
+  wrapperPath: string,
+  expectedWrapper: string,
+): Promise<boolean> {
+  const manifest = await readJson(manifestPath).catch(() => undefined);
+  if (!isRecord(manifest) || typeof manifest.path !== "string") return false;
+  if (!sameNativeHostPath(manifest.path, wrapperPath)) return false;
+  const executable = await access(wrapperPath, constants.X_OK).then(() => true).catch(() => false);
+  if (!executable) return false;
+  const actualWrapper = await readFile(wrapperPath, "utf8").catch(() => undefined);
+  return actualWrapper === expectedWrapper;
+}
+
+function sameNativeHostPath(left: string, right: string): boolean {
+  const normalize = (value: string) => {
+    const resolved = path.resolve(value);
+    return process.platform === "darwin" || process.platform === "win32" ? resolved.toLocaleLowerCase("en-US") : resolved;
+  };
+  return normalize(left) === normalize(right);
 }
 
 async function repairRuntimeDescriptors(descriptorDir: string): Promise<DoctorRepairAction[]> {
@@ -1133,8 +1141,4 @@ function repairHint(id: string, status: DoctorStatus, details: Record<string, un
     default:
       return undefined;
   }
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/packages/cli/src/extension-update.test.ts
+++ b/packages/cli/src/extension-update.test.ts
@@ -41,6 +41,41 @@ test("updateExtension dry-run reports actions without writing", async (t) => {
   await assert.rejects(readFile(path.join(layout.extensionCurrentDir, "manifest.json"), "utf8"));
 });
 
+test("updateExtension verify action uses the requested target instead of stale user config", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-extension-update-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sourceDir = await extensionSource(root, "0.3.1");
+  const staleStoreId = "ponmlkjihgfedcbaponmlkjihgfedcba";
+  const currentExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const layout: RuntimeLayout = {
+    ...fakeLayout(root),
+    userConfig: {
+      schemaVersion: 1,
+      runtimeDir: path.join(root, "runtime"),
+      extensionCurrentDir: path.join(root, ".obu", "extension", "current"),
+      nativeHostInstallRoot: path.join(root, ".obu", "native-host"),
+      extensionChannel: "store",
+      storeExtensionId: staleStoreId,
+    },
+  };
+
+  const result = await updateExtension({
+    layout,
+    sourceDir,
+    noWait: true,
+    verifyTarget: {
+      channel: "unpacked-dev",
+      extensionId: currentExtensionId,
+    },
+  });
+
+  const values = result.nextActions.map((action) => action.value).join("\n");
+  assert.match(values, /--channel=unpacked-dev/);
+  assert.match(values, new RegExp(`--extension-id=${currentExtensionId}`));
+  assert.doesNotMatch(values, /--channel=store/);
+  assert.doesNotMatch(values, new RegExp(staleStoreId));
+});
+
 test("updateExtension ignores malformed runtime descriptor JSON", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "obu-extension-update-"));
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/packages/cli/src/extension-update.test.ts
+++ b/packages/cli/src/extension-update.test.ts
@@ -86,7 +86,9 @@ test("updateExtension reports complete when a runtime descriptor probes successf
   const result = await updateExtension({ layout, sourceDir });
 
   assert.equal(result.result, "complete");
-  assert.equal(result.nextActions[0]?.value, "obu doctor browser");
+  assert.equal(result.nextActions[0]?.kind, "manual");
+  assert.match(result.nextActions[0]?.value ?? "", /obu verify --agent=<agent-id>/);
+  assert.doesNotMatch(result.nextActions[0]?.value ?? "", /doctor browser/);
 });
 
 async function extensionSource(root: string, version: string): Promise<string> {

--- a/packages/cli/src/extension-update.ts
+++ b/packages/cli/src/extension-update.ts
@@ -2,6 +2,7 @@ import { cp, mkdir, readFile, rename, rm } from "node:fs/promises";
 import path from "node:path";
 
 import { hasActiveWebExtensionRuntimeDescriptor } from "./doctor-browser.js";
+import { extensionIdFromManifestKey, type ExtensionChannel } from "./extension-channel.js";
 import type { RuntimeLayout } from "./runtime-layout.js";
 
 export type ExtensionUpdateStatus = "applied" | "skipped" | "would_apply" | "manual_action_required" | "failed";
@@ -28,6 +29,10 @@ export type UpdateExtensionOptions = {
   sourceDir?: string;
   dryRun?: boolean;
   noWait?: boolean;
+  verifyTarget?: {
+    channel: ExtensionChannel;
+    extensionId?: string;
+  };
 };
 
 export async function updateExtension(options: UpdateExtensionOptions): Promise<ExtensionUpdateResult> {
@@ -54,7 +59,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
         message: `could not validate extension payload ${sourceDir}`,
         details: { sourceDir, error: String(error) },
       },
-    ]);
+    ], options.verifyTarget);
   }
 
   const versionDir = path.join(options.layout.extensionInstallRoot, "versions", manifest.version);
@@ -71,7 +76,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: `would refresh stable extension path ${currentDir}`,
       details: { currentDir },
     });
-    return result("manual_action_required", dryRun, options.layout, steps);
+    return result("manual_action_required", dryRun, options.layout, steps, options.verifyTarget, manifest);
   }
 
   try {
@@ -96,7 +101,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: `could not refresh stable extension path ${currentDir}`,
       details: { currentDir, error: String(error) },
     });
-    return result("failed", dryRun, options.layout, steps);
+    return result("failed", dryRun, options.layout, steps, options.verifyTarget, manifest);
   }
 
   if (noWait) {
@@ -106,7 +111,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: "skipped runtime descriptor wait",
       details: { runtimeDir: options.layout.runtimeDir },
     });
-    return result("manual_action_required", dryRun, options.layout, steps);
+    return result("manual_action_required", dryRun, options.layout, steps, options.verifyTarget, manifest);
   }
 
   if (await hasActiveWebExtensionRuntimeDescriptor(options.layout.runtimeDir)) {
@@ -116,7 +121,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: "found an active WebExtension runtime descriptor",
       details: { runtimeDir: options.layout.runtimeDir },
     });
-    return result("complete", dryRun, options.layout, steps);
+    return result("complete", dryRun, options.layout, steps, options.verifyTarget, manifest);
   }
 
   steps.push({
@@ -125,7 +130,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
     message: "no active WebExtension runtime descriptor found",
     details: { runtimeDir: options.layout.runtimeDir },
   });
-  return result("manual_action_required", dryRun, options.layout, steps);
+  return result("manual_action_required", dryRun, options.layout, steps, options.verifyTarget, manifest);
 }
 
 type ExtensionManifest = {
@@ -177,8 +182,10 @@ function result(
   dryRun: boolean,
   layout: RuntimeLayout,
   steps: ExtensionUpdateStep[],
+  verifyTarget?: UpdateExtensionOptions["verifyTarget"],
+  manifest?: ExtensionManifest,
 ): ExtensionUpdateResult {
-  const verifyAction = verifyNextAction(layout);
+  const verifyAction = verifyNextAction(verifyTarget, manifest);
   const nextActions: ExtensionUpdateResult["nextActions"] = state === "complete"
     ? [verifyAction]
     : [
@@ -199,13 +206,23 @@ function result(
   };
 }
 
-function verifyNextAction(layout: RuntimeLayout): ExtensionUpdateResult["nextActions"][number] {
-  const channel = layout.userConfig?.extensionChannel ?? "<channel>";
-  const extensionId = layout.userConfig?.extensionChannel === "store" && layout.userConfig.storeExtensionId
-    ? layout.userConfig.storeExtensionId
-    : "<extension-id>";
+function verifyNextAction(
+  verifyTarget: UpdateExtensionOptions["verifyTarget"],
+  manifest?: ExtensionManifest,
+): ExtensionUpdateResult["nextActions"][number] {
+  const channel = verifyTarget?.channel ?? "unpacked-dev";
+  const extensionId = verifyTarget?.extensionId ?? extensionIdForVerify(manifest) ?? "<extension-id>";
   return {
     kind: "manual",
     value: `Choose the agent and browser target, then run obu verify --agent=<agent-id> --browser=<browser> --channel=${channel} --extension-id=${extensionId}.`,
   };
+}
+
+function extensionIdForVerify(manifest: ExtensionManifest | undefined): string | undefined {
+  if (!manifest?.key) return undefined;
+  try {
+    return extensionIdFromManifestKey(manifest.key);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/cli/src/extension-update.ts
+++ b/packages/cli/src/extension-update.ts
@@ -47,7 +47,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       details: { sourceDir, version: manifest.version },
     });
   } catch (error) {
-    return result("failed", dryRun, currentDir, [
+    return result("failed", dryRun, options.layout, [
       {
         id: "extension-source",
         status: "failed",
@@ -71,7 +71,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: `would refresh stable extension path ${currentDir}`,
       details: { currentDir },
     });
-    return result("manual_action_required", dryRun, currentDir, steps);
+    return result("manual_action_required", dryRun, options.layout, steps);
   }
 
   try {
@@ -96,7 +96,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: `could not refresh stable extension path ${currentDir}`,
       details: { currentDir, error: String(error) },
     });
-    return result("failed", dryRun, currentDir, steps);
+    return result("failed", dryRun, options.layout, steps);
   }
 
   if (noWait) {
@@ -106,7 +106,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: "skipped runtime descriptor wait",
       details: { runtimeDir: options.layout.runtimeDir },
     });
-    return result("manual_action_required", dryRun, currentDir, steps);
+    return result("manual_action_required", dryRun, options.layout, steps);
   }
 
   if (await hasActiveWebExtensionRuntimeDescriptor(options.layout.runtimeDir)) {
@@ -116,7 +116,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
       message: "found an active WebExtension runtime descriptor",
       details: { runtimeDir: options.layout.runtimeDir },
     });
-    return result("complete", dryRun, currentDir, steps);
+    return result("complete", dryRun, options.layout, steps);
   }
 
   steps.push({
@@ -125,7 +125,7 @@ export async function updateExtension(options: UpdateExtensionOptions): Promise<
     message: "no active WebExtension runtime descriptor found",
     details: { runtimeDir: options.layout.runtimeDir },
   });
-  return result("manual_action_required", dryRun, currentDir, steps);
+  return result("manual_action_required", dryRun, options.layout, steps);
 }
 
 type ExtensionManifest = {
@@ -175,25 +175,37 @@ async function replaceCurrentDir(versionDir: string, currentDir: string): Promis
 function result(
   state: ExtensionUpdateResult["result"],
   dryRun: boolean,
-  extensionCurrentDir: string,
+  layout: RuntimeLayout,
   steps: ExtensionUpdateStep[],
 ): ExtensionUpdateResult {
+  const verifyAction = verifyNextAction(layout);
   const nextActions: ExtensionUpdateResult["nextActions"] = state === "complete"
-    ? [{ kind: "command", value: "obu doctor browser" }]
+    ? [verifyAction]
     : [
       {
         kind: "manual",
-        value: `Open chrome://extensions, enable Developer mode, then Load unpacked or Reload the open-browser-use extension from ${extensionCurrentDir}`,
+        value: `Open chrome://extensions, enable Developer mode, then Load unpacked or Reload the open-browser-use extension from ${layout.extensionCurrentDir}`,
       },
-      { kind: "command", value: "obu doctor browser" },
+      verifyAction,
     ];
   return {
     schemaVersion: 1,
     command: "update-extension",
     dryRun,
     result: state,
-    extensionCurrentDir,
+    extensionCurrentDir: layout.extensionCurrentDir,
     steps,
     nextActions,
+  };
+}
+
+function verifyNextAction(layout: RuntimeLayout): ExtensionUpdateResult["nextActions"][number] {
+  const channel = layout.userConfig?.extensionChannel ?? "<channel>";
+  const extensionId = layout.userConfig?.extensionChannel === "store" && layout.userConfig.storeExtensionId
+    ? layout.userConfig.storeExtensionId
+    : "<extension-id>";
+  return {
+    kind: "manual",
+    value: `Choose the agent and browser target, then run obu verify --agent=<agent-id> --browser=<browser> --channel=${channel} --extension-id=${extensionId}.`,
   };
 }

--- a/packages/cli/src/human-output.ts
+++ b/packages/cli/src/human-output.ts
@@ -160,7 +160,7 @@ function formatFailedSteps(steps: Array<{ status: string; id: string; message: s
   return ["Problems:", ...failed.map((step) => `  ${step.id}: ${step.message}`)];
 }
 
-function formatNextActions(actions: NextAction[], heading = "Next actions:"): string[] {
+export function formatNextActions(actions: NextAction[], heading = "Next actions:"): string[] {
   if (actions.length === 0) return [];
   const rows = ["", heading];
   for (const action of actions) {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import net from "node:net";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -198,7 +199,7 @@ test("verify treats missing Codex config as repairable when codex is not on PATH
   assert.equal(agentMcp?.actionCandidate?.kind, "run_repair");
 });
 
-test("verify accepts trusted agent-runtime hook result for a challenge", async (t) => {
+test("verify rejects file-backed agent-runtime hook result for a challenge", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -255,7 +256,13 @@ test("verify accepts trusted agent-runtime hook result for a challenge", async (
   assert.equal(issuedPayload.nextAction.kind, "collect_agent_runtime_status");
   assert.match(issuedPayload.nextAction.rerun, /--agent-runtime-challenge-json=/);
   const challenge = JSON.parse(await readFile(challengePath, "utf8"));
-  const resultPath = challenge.trustedHookResult.path;
+  assert.equal(challenge.trustedHookResult, undefined);
+  const resultPath = path.join(
+    runtimeDir,
+    "agent-runtime",
+    "codex-cli-runtime-status",
+    `${createHash("sha256").update(challenge.challenge.nonce).digest("hex")}.json`,
+  );
   await mkdir(path.dirname(resultPath), { recursive: true, mode: 0o700 });
   await writeFile(resultPath, `${JSON.stringify({
     schemaVersion: 1,
@@ -293,14 +300,17 @@ test("verify accepts trusted agent-runtime hook result for a challenge", async (
     "--json",
   ], baseEnv);
 
-  assert.equal(result.code, 0);
+  assert.equal(result.code, 1);
   const payload = JSON.parse(result.stdout);
-  assert.equal(payload.result, "ready");
-  assert.equal(payload.readiness.agentRuntime, "ready");
-  assert.equal(payload.agent.runtimeStatus.status, "pass");
-  assert.equal(payload.agent.runtimeStatus.hook.trusted, true);
-  assert.equal(payload.mcpRuntime.agentRuntime.source, "agent_runtime");
-  assert.equal(payload.mcpRuntime.agentRuntime.backendCount, 1);
+  assert.equal(payload.result, "needs_manual_action");
+  assert.equal(payload.readiness.cli, "ready");
+  assert.equal(payload.readiness.agentRuntime, "blocked");
+  assert.equal(payload.agent.runtimeStatus.status, "not_checked");
+  assert.equal(payload.agent.runtimeStatus.provenance, "not_applicable");
+  assert.equal(payload.agent.runtimeStatus.reason, "agent_runtime_challenge_pending");
+  assert.equal(payload.mcpRuntime.agentRuntime.source, "not_checked");
+  assert.equal(payload.mcpRuntime.agentRuntime.backendCount, null);
+  assert.equal(payload.nextAction.kind, "collect_agent_runtime_status");
 });
 
 test("agent doctor verifies Codex global config without codex on PATH", async (t) => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -411,6 +411,39 @@ test("agent doctor accepts Codex multiline TOML args", async (t) => {
   assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "pass");
 });
 
+test("agent doctor fails malformed Codex config even when the MCP table matches", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".codex"), { recursive: true });
+  await writeFile(path.join(home, ".codex", "config.toml"), [
+    "[broken",
+    "",
+    "[mcp_servers.open-browser-use]",
+    `command = "${shellEscapeForDoubleQuotes(process.execPath)}"`,
+    `args = ["${shellEscapeForDoubleQuotes(cliEntry)}", "mcp", "stdio"]`,
+    "",
+  ].join("\n"), "utf8");
+  await writeFile(path.join(home, ".codex", "AGENTS.md"), [
+    "## Browser Automation",
+    "",
+    "Use open-browser-use as the primary BrowserUse/browser automation tool.",
+    "",
+  ].join("\n"), "utf8");
+
+  const result = await runCli(["agent", "doctor", "--agent=codex-cli", "--json"], {
+    HOME: home,
+    PATH: "",
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  const check = payload.checks.find((row: any) => row.id === "agent-mcp-server");
+  assert.equal(check?.status, "fail");
+  assert.match(check?.message ?? "", /could not be parsed/);
+  assert.equal(check?.details?.code, "PARSE_ERROR");
+});
+
 test("agent doctor fails divergent Codex config instead of falling back to shell probe", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
@@ -1182,6 +1215,45 @@ test("setup can write Codex and Claude primary-browser instructions explicitly",
   assert.equal(payload.steps.find((step: any) => step.id === "agent-claude-code-instructions")?.status, "applied");
   assert.match(await readFile(path.join(home, ".codex", "AGENTS.md"), "utf8"), /primary BrowserUse\/browser automation tool/);
   assert.match(await readFile(path.join(home, ".claude", "CLAUDE.md"), "utf8"), /primary BrowserUse\/browser automation tool/);
+});
+
+test("setup returns a manual action instead of writing malformed Codex config", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  const hostBin = path.join(bin, "obu-host");
+  await writeFile(hostBin, "#!/bin/sh\n", "utf8");
+  await chmod(hostBin, 0o755);
+  const configPath = path.join(home, ".codex", "config.toml");
+  const malformed = "[broken\n";
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, malformed, "utf8");
+  const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+
+  const result = await runCli([
+    "setup",
+    "--yes",
+    "--channel=store",
+    "--extension-id",
+    storeExtensionId,
+    "--agents=codex-cli",
+    "--json",
+  ], {
+    HOME: home,
+    PATH: "",
+    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_HOST_BIN: hostBin,
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  const step = payload.steps.find((row: any) => row.id === "agent-codex-cli");
+  assert.equal(step?.status, "manual_action_required");
+  assert.match(step?.message ?? "", /could not be parsed/);
+  assert.equal(step?.details?.code, "PARSE_ERROR");
+  assert.equal(await readFile(configPath, "utf8"), malformed);
 });
 
 test("setup CLI rejects unknown requested agents before writing", async (t) => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import net from "node:net";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { nativeMessagingHostDir } from "./browser-paths.js";
+import { browserProfileRoot, nativeMessagingHostDir } from "./browser-paths.js";
 
 const cliEntry = fileURLToPath(new URL("./index.js", import.meta.url));
 
@@ -66,6 +67,240 @@ test("agent commands accept common human agent aliases", async (t) => {
   assert.equal(result.code, 0);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.agent, "codex-cli");
+});
+
+test("verify reports browser popup boundary with one next action", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  withTestXdgConfigHome(t, home);
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+  await writeCodexMcpConfig(home);
+  await writeNativeHostManifest(home, hostBin, extensionId);
+  const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
+  await writeChromePreferences(profilePath, extensionId, 1);
+  await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
+  await chmod(runtimeDir, 0o700);
+  await chmod(path.join(runtimeDir, "webextension"), 0o700);
+
+  const result = await runCli([
+    "verify",
+    "--agent=codex",
+    "--browser=chrome",
+    "--channel=store",
+    "--extension-id",
+    extensionId,
+    "--json",
+  ], {
+    HOME: home,
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: runtimeDir,
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.result, "needs_browser_popup");
+  assert.equal(payload.nextAction.kind, "open_popup");
+  assert.equal(payload.agent.id, "codex-cli");
+  assert.equal(payload.agent.runtimeStatus.reason, "verification_target_cli");
+  assert.equal(payload.browser.profile.path, profilePath);
+  assert.equal(payload.browser.profile.runtimeBinding, "not_available");
+  assert.equal(payload.browser.extensionInstalled, "pass");
+  assert.equal(payload.browser.extensionEnabled, "pass");
+  assert.equal(payload.checks.filter((check: any) => check.status === "fail" && check.actionCandidate).length > 0, true);
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.status, "warn");
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.reason, "missing_instruction");
+});
+
+test("verify asks for profile selection when multiple matching profiles are ambiguous", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  withTestXdgConfigHome(t, home);
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+  await writeCodexMcpConfig(home);
+  await writeNativeHostManifest(home, hostBin, extensionId);
+  const profileRoot = browserProfileRoot("chrome", process.platform, home);
+  const defaultProfile = path.join(profileRoot, "Default");
+  const secondProfile = path.join(profileRoot, "Profile 2");
+  await writeChromePreferences(secondProfile, extensionId, 1);
+  await writeChromePreferences(defaultProfile, extensionId, 1);
+  await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
+  await chmod(runtimeDir, 0o700);
+  await chmod(path.join(runtimeDir, "webextension"), 0o700);
+
+  const result = await runCli([
+    "verify",
+    "--agent=codex-cli",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+    "--json",
+  ], {
+    HOME: home,
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: runtimeDir,
+  });
+
+  assert.equal(result.code, 1);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.result, "needs_manual_action");
+  assert.equal(payload.nextAction.kind, "select_profile");
+  assert.equal(payload.browser.profile.path, null);
+  assert.equal(payload.browser.profile.suggestedPath, defaultProfile);
+  assert.deepEqual(payload.browser.profile.candidates.map((candidate: any) => candidate.path), [defaultProfile, secondProfile]);
+});
+
+test("verify treats missing Codex config as repairable when codex is not on PATH", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  withTestXdgConfigHome(t, home);
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+  await writeNativeHostManifest(home, hostBin, extensionId);
+  const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
+  await writeChromePreferences(profilePath, extensionId, 1);
+  await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
+  await chmod(runtimeDir, 0o700);
+  await chmod(path.join(runtimeDir, "webextension"), 0o700);
+
+  const result = await runCli([
+    "verify",
+    "--agent=codex-cli",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+    "--json",
+  ], {
+    HOME: home,
+    PATH: "",
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: runtimeDir,
+  });
+
+  assert.equal(result.code, 1);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.result, "needs_repair");
+  assert.equal(payload.nextAction.kind, "run_repair");
+  assert.match(payload.nextAction.command, /verify .*--repair/);
+  const agentMcp = payload.checks.find((check: any) => check.id === "agent-mcp-server");
+  assert.equal(agentMcp?.reason, "agent_mcp_missing");
+  assert.equal(agentMcp?.actionCandidate?.kind, "run_repair");
+});
+
+test("verify accepts trusted agent-runtime hook result for a challenge", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  withTestXdgConfigHome(t, home);
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+  const fakeObu = await writeFakeMcpObu(bin, extensionId);
+  await writeCodexMcpConfig(home, fakeObu, ["mcp", "stdio"]);
+  await writeNativeHostManifest(home, hostBin, extensionId);
+  const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
+  await writeChromePreferences(profilePath, extensionId, 1);
+  await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
+  await chmod(runtimeDir, 0o700);
+  await chmod(path.join(runtimeDir, "webextension"), 0o700);
+  const socketPath = path.join(runtimeDir, "webextension", "chrome.sock");
+  await startRuntimeDescriptorServer(t, socketPath);
+  await writeRuntimeDescriptor(path.join(runtimeDir, "webextension", "chrome.json"), {
+    schema_version: 1,
+    type: "webextension",
+    name: "chrome",
+    socketPath,
+    sdk_auth_token: "token",
+    pid: process.pid,
+    metadata: {
+      browser_kind: "chrome",
+      extension_id: extensionId,
+      profile_path: profilePath,
+    },
+  });
+  const challengePath = path.join(home, "challenge.json");
+  const baseEnv = {
+    HOME: home,
+    OBU_COMMAND: fakeObu,
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: runtimeDir,
+  };
+
+  const issued = await runCli([
+    "verify",
+    "--agent=codex-cli",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+    "--require-agent-runtime",
+    `--agent-runtime-challenge-out=${challengePath}`,
+    "--json",
+  ], baseEnv);
+
+  assert.equal(issued.code, 1);
+  const issuedPayload = JSON.parse(issued.stdout);
+  assert.equal(issuedPayload.readiness.cli, "ready");
+  assert.equal(issuedPayload.nextAction.kind, "collect_agent_runtime_status");
+  assert.match(issuedPayload.nextAction.rerun, /--agent-runtime-challenge-json=/);
+  const challenge = JSON.parse(await readFile(challengePath, "utf8"));
+  const resultPath = challenge.trustedHookResult.path;
+  await mkdir(path.dirname(resultPath), { recursive: true, mode: 0o700 });
+  await writeFile(resultPath, `${JSON.stringify({
+    schemaVersion: 1,
+    agentId: "codex-cli",
+    mcpServerName: "open-browser-use",
+    provenance: "agent_runtime_hook",
+    hook: challenge.trustedHook,
+    generatedAt: new Date().toISOString(),
+    challenge: challenge.challenge,
+    target: challenge.target,
+    status: {
+      sdk_bootstrap: "available",
+      backends: [
+        {
+          type: "webextension",
+          name: "chrome",
+          metadata: {
+            browser_kind: "chrome",
+            extension_id: extensionId,
+          },
+        },
+      ],
+    },
+  }, null, 2)}\n`, "utf8");
+  await chmod(resultPath, 0o600);
+
+  const result = await runCli([
+    "verify",
+    "--agent=codex-cli",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+    "--require-agent-runtime",
+    `--agent-runtime-challenge-json=${challengePath}`,
+    "--json",
+  ], baseEnv);
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.result, "ready");
+  assert.equal(payload.readiness.agentRuntime, "ready");
+  assert.equal(payload.agent.runtimeStatus.status, "pass");
+  assert.equal(payload.agent.runtimeStatus.hook.trusted, true);
+  assert.equal(payload.mcpRuntime.agentRuntime.source, "agent_runtime");
+  assert.equal(payload.mcpRuntime.agentRuntime.backendCount, 1);
 });
 
 test("agent doctor verifies Codex global config without codex on PATH", async (t) => {
@@ -519,7 +754,8 @@ test("setup summary preserves manual agent next actions", async (t) => {
   assert.equal(result.stderr, "");
   assert.match(result.stdout, /Setup needs 1 follow-up step\./);
   assert.match(result.stdout, new RegExp(`${escapeRegExp(obuCommand)} mcp-config --agent=continue --print`));
-  assert.match(result.stdout, new RegExp(`${escapeRegExp(obuCommand)} doctor browser --channel=store --extension-id=${storeExtensionId}`));
+  assert.match(result.stdout, new RegExp(`${escapeRegExp(obuCommand)} verify --agent=continue --browser=chrome --channel=store --extension-id=${storeExtensionId}`));
+  assert.doesNotMatch(result.stdout, /doctor browser/);
   assert.doesNotMatch(result.stdout, /agent-continue:/);
 
   const recovery = await runCli(["setup", "--yes", "--recovery", "--channel=store", "--extension-id", storeExtensionId, "--agents=continue"], {
@@ -960,6 +1196,165 @@ test("repl command is explicitly deferred in P4a", async (t) => {
   assert.match(result.stderr, /repl is deferred in P4a/);
 });
 
+function withTestXdgConfigHome(t: { after: (fn: () => void | Promise<void>) => void }, home: string): void {
+  const previous = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+  t.after(() => {
+    if (previous === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = previous;
+    }
+  });
+}
+
+async function writeExecutable(file: string, content: string): Promise<string> {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, content, "utf8");
+  await chmod(file, 0o755);
+  return file;
+}
+
+async function writeCodexMcpConfig(home: string, command = process.execPath, args = [cliEntry, "mcp", "stdio"]): Promise<void> {
+  await mkdir(path.join(home, ".codex"), { recursive: true });
+  await writeFile(path.join(home, ".codex", "config.toml"), [
+    "[mcp_servers.open-browser-use]",
+    `command = "${shellEscapeForDoubleQuotes(command)}"`,
+    `args = [${args.map((arg) => `"${shellEscapeForDoubleQuotes(arg)}"`).join(", ")}]`,
+    "",
+  ].join("\n"), "utf8");
+}
+
+async function writeFakeMcpObu(bin: string, extensionId: string): Promise<string> {
+  const mcpScript = path.join(bin, "fake-mcp.js");
+  await writeFile(mcpScript, `
+const extensionId = ${JSON.stringify(extensionId)};
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  for (;;) {
+    const index = buffer.indexOf("\\n");
+    if (index < 0) break;
+    const line = buffer.slice(0, index).trim();
+    buffer = buffer.slice(index + 1);
+    if (!line) continue;
+    const request = JSON.parse(line);
+    if (request.method === "initialize") {
+      send({ jsonrpc: "2.0", id: request.id, result: { capabilities: { tools: {} }, serverInfo: { name: "fake-obu", version: "0.0.0" } } });
+    } else if (request.method === "tools/call" && request.params?.name === "browser_status") {
+      send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          structuredContent: {
+            sdk_bootstrap: "available",
+            backends: [
+              { type: "webextension", name: "chrome", metadata: { browser_kind: "chrome", extension_id: extensionId } },
+            ],
+          },
+        },
+      });
+    }
+  }
+});
+function send(payload) {
+  process.stdout.write(JSON.stringify(payload) + "\\n");
+}
+`, "utf8");
+  const fakeObu = path.join(bin, "obu");
+  return writeExecutable(fakeObu, [
+    "#!/bin/sh",
+    "set -eu",
+    "if [ \"${1:-}\" = \"mcp\" ] && [ \"${2:-}\" = \"stdio\" ]; then",
+    `  exec ${shellQuote(process.execPath)} ${shellQuote(mcpScript)}`,
+    "fi",
+    "exit 1",
+    "",
+  ].join("\n"));
+}
+
+async function writeNativeHostManifest(home: string, hostBin: string, extensionId: string): Promise<void> {
+  const manifestPath = path.join(nativeMessagingHostDir("chrome", process.platform, home), "dev.obu.host.json");
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, JSON.stringify({
+    name: "dev.obu.host",
+    description: "open-browser-use native messaging host",
+    path: hostBin,
+    type: "stdio",
+    allowed_origins: [`chrome-extension://${extensionId}/`],
+  }, null, 2), "utf8");
+}
+
+async function writeChromePreferences(profilePath: string, extensionId: string, state: number): Promise<void> {
+  await mkdir(profilePath, { recursive: true });
+  await writeFile(path.join(profilePath, "Preferences"), JSON.stringify({
+    extensions: {
+      settings: {
+        [extensionId]: {
+          state,
+          manifest: { version: "0.1.0" },
+        },
+      },
+    },
+  }, null, 2), "utf8");
+}
+
+async function writeRuntimeDescriptor(file: string, value: Record<string, unknown>): Promise<void> {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(file, 0o600);
+}
+
+async function startRuntimeDescriptorServer(t: { after: (fn: () => void | Promise<void>) => void }, socketPath: string): Promise<void> {
+  const server = net.createServer((socket) => {
+    let authenticated = false;
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (buffer.length >= 4) {
+        const length = buffer.readUInt32LE(0);
+        if (buffer.length < 4 + length) return;
+        const body = buffer.subarray(4, 4 + length);
+        buffer = buffer.subarray(4 + length);
+        const request = JSON.parse(body.toString("utf8"));
+        if (request.method === "auth") {
+          authenticated = true;
+          socket.write(encodeTestFrame({ jsonrpc: "2.0", id: request.id, result: { ok: true } }));
+          continue;
+        }
+        if (authenticated && request.method === "getInfo") {
+          socket.write(encodeTestFrame({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: { type: "webextension", name: "chrome", metadata: { diagnostics: { lifecycle: {} } } },
+          }));
+          continue;
+        }
+        socket.write(encodeTestFrame({ jsonrpc: "2.0", id: request.id, error: { code: -32601, message: "method not found" } }));
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  await chmod(socketPath, 0o600);
+  t.after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+}
+
+function encodeTestFrame(payload: Record<string, unknown>): Buffer {
+  const body = Buffer.from(JSON.stringify(payload));
+  const frame = Buffer.alloc(4 + body.length);
+  frame.writeUInt32LE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
 function runCli(args: string[], env: NodeJS.ProcessEnv = {}): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [cliEntry, ...args], {
@@ -989,4 +1384,8 @@ function escapeRegExp(value: string): string {
 
 function shellEscapeForDoubleQuotes(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("$", "\\$").replaceAll("`", "\\`");
+}
+
+function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -37,6 +37,11 @@ test("mcp-config print emits agent-specific config shapes", async (t) => {
   assert.equal(zed.mode, "json");
   assert.equal(zed.config.context_servers["open-browser-use"].command, process.execPath);
 
+  const cursor = JSON.parse((await runCli(["mcp-config", "--agent=cursor", "--print"], { HOME: home })).stdout);
+  assert.equal(cursor.mode, "json");
+  assert.equal(cursor.config.mcpServers["open-browser-use"].command, process.execPath);
+  assert.equal("name" in cursor.config.mcpServers["open-browser-use"], false);
+
   const manual = JSON.parse((await runCli(["mcp-config", "--agent=continue", "--print"], { HOME: home })).stdout);
   assert.equal(manual.mode, "manual");
   assert.match(manual.instructions, /MCP server named open-browser-use/);
@@ -50,6 +55,119 @@ test("mcp-config rejects unknown agents", async (t) => {
   assert.equal(result.code, 2);
   assert.equal(result.stdout, "");
   assert.match(result.stderr, /unsupported agent/);
+});
+
+test("agent commands accept common human agent aliases", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+
+  const result = await runCli(["mcp-config", "--agent=codex", "--print"], { HOME: home });
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.agent, "codex-cli");
+});
+
+test("agent doctor verifies Codex global config without codex on PATH", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".codex"), { recursive: true });
+  await writeFile(path.join(home, ".codex", "config.toml"), [
+    "[mcp_servers.open-browser-use]",
+    `command = "${shellEscapeForDoubleQuotes(process.execPath)}"`,
+    `args = ["${shellEscapeForDoubleQuotes(cliEntry)}", "mcp", "stdio"]`,
+    "",
+  ].join("\n"), "utf8");
+  await writeFile(path.join(home, ".codex", "AGENTS.md"), [
+    "## Browser Automation",
+    "",
+    "Use open-browser-use as the primary BrowserUse/browser automation tool.",
+    "",
+  ].join("\n"), "utf8");
+
+  const result = await runCli(["agent", "doctor", "--agent=codex", "--json"], {
+    HOME: home,
+    PATH: "",
+  });
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.agent, "codex-cli");
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "pass");
+  assert.match(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.message ?? "", /configures open-browser-use/);
+});
+
+test("agent doctor accepts Codex multiline TOML args", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".codex"), { recursive: true });
+  await writeFile(path.join(home, ".codex", "config.toml"), [
+    "[mcp_servers.open-browser-use]",
+    `command = "${shellEscapeForDoubleQuotes(process.execPath)}"`,
+    "args = [",
+    `  "${shellEscapeForDoubleQuotes(cliEntry)}",`,
+    "  \"mcp\", # keep comments",
+    "  'stdio',",
+    "]",
+    "",
+  ].join("\n"), "utf8");
+  await writeFile(path.join(home, ".codex", "AGENTS.md"), [
+    "## Browser Automation",
+    "",
+    "Use open-browser-use as the primary BrowserUse/browser automation tool.",
+    "",
+  ].join("\n"), "utf8");
+
+  const result = await runCli(["agent", "doctor", "--agent=codex-cli", "--json"], {
+    HOME: home,
+    PATH: "",
+  });
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.checks.find((check: any) => check.id === "agent-mcp-server")?.status, "pass");
+});
+
+test("agent doctor fails divergent Codex config instead of falling back to shell probe", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  await mkdir(path.join(home, ".codex"), { recursive: true });
+  await writeFile(path.join(home, ".codex", "config.toml"), [
+    "[mcp_servers.open-browser-use]",
+    'command = "/custom/obu"',
+    'args = ["mcp", "stdio"]',
+    "",
+  ].join("\n"), "utf8");
+  await writeFile(path.join(home, ".codex", "AGENTS.md"), [
+    "## Browser Automation",
+    "",
+    "Use open-browser-use as the primary BrowserUse/browser automation tool.",
+    "",
+  ].join("\n"), "utf8");
+  const codex = path.join(bin, "codex");
+  await writeFile(codex, `#!/bin/sh
+if [ "$1 $2" = "mcp list" ]; then
+  echo "open-browser-use ${shellEscapeForDoubleQuotes(process.execPath)} ${shellEscapeForDoubleQuotes(cliEntry)} mcp stdio"
+  exit 0
+fi
+exit 1
+`, "utf8");
+  await chmod(codex, 0o755);
+
+  const result = await runCli(["agent", "doctor", "--agent=codex-cli", "--json"], {
+    HOME: home,
+    PATH: bin,
+  });
+
+  assert.equal(result.code, 1);
+  const payload = JSON.parse(result.stdout);
+  const check = payload.checks.find((row: any) => row.id === "agent-mcp-server");
+  assert.equal(check?.status, "fail");
+  assert.match(check?.message ?? "", /different settings/);
+  assert.equal(check?.details?.actual?.command, "/custom/obu");
 });
 
 test("agent doctor verifies shell MCP config and primary instructions", async (t) => {
@@ -452,6 +570,7 @@ test("bootstrap continues through manual agent setup and runs browser repair", a
   assert.equal(result.stderr, "");
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.command, "bootstrap");
+  assert.equal(payload.result, "manual_action_required");
   assert.equal(payload.setup.result, "manual_action_required");
   assert.equal(payload.setup.steps.some((step: any) => step.id === "agent-continue" && step.status === "manual_action_required"), true);
   assert.equal(payload.browserDoctor.extensionChannel, "store");
@@ -460,6 +579,36 @@ test("bootstrap continues through manual agent setup and runs browser repair", a
   assert.equal(payload.browserDoctor.repairs.some((repair: any) => repair.id === "runtime-descriptor-dir"), true);
   const nativeHost = JSON.parse(await readFile(path.join(nativeHostDir, "dev.obu.host.json"), "utf8"));
   assert.deepEqual(nativeHost.allowed_origins, [`chrome-extension://${storeExtensionId}/`]);
+});
+
+test("bootstrap summary reports skipped agent setup without naming the adapter placeholder", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  const hostBin = path.join(bin, "obu-host");
+  await writeFile(hostBin, "#!/bin/sh\nprintf 'obu-host 0.0.0\\n'\n", "utf8");
+  await chmod(hostBin, 0o755);
+  const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+
+  const result = await runCli([
+    "bootstrap",
+    "--yes",
+    "--channel=store",
+    "--extension-id",
+    storeExtensionId,
+    "--skip-agents",
+  ], {
+    HOME: home,
+    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_HOST_BIN: hostBin,
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, "");
+  assert.match(result.stdout, /MCP agent setup skipped\./);
+  assert.doesNotMatch(result.stdout, /MCP agents already configured: adapters/);
+  assert.match(result.stdout, /extension popup activation is still required/);
 });
 
 test("setup CLI accepts explicit auto and none agent modes", async (t) => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { browserProfileRoot, nativeMessagingHostDir } from "./browser-paths.js";
+import { nativeHostWrapperContent, nativeHostWrapperPath } from "./native-host.js";
 
 const cliEntry = fileURLToPath(new URL("./index.js", import.meta.url));
 
@@ -79,7 +80,7 @@ test("verify reports browser popup boundary with one next action", async (t) => 
   const runtimeDir = path.join(home, "runtime");
   const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
   await writeCodexMcpConfig(home);
-  await writeNativeHostManifest(home, hostBin, extensionId);
+  await writeNativeHostManifest(home, hostBin, extensionId, runtimeDir);
   const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
   await writeChromePreferences(profilePath, extensionId, 1);
   await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
@@ -116,6 +117,65 @@ test("verify reports browser popup boundary with one next action", async (t) => 
   assert.equal(payload.checks.find((check: any) => check.id === "agent-primary-instruction")?.reason, "missing_instruction");
 });
 
+test("verify repairs stale native-host manifests before popup handoff", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  withTestXdgConfigHome(t, home);
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  const staleHostBin = await writeExecutable(path.join(bin, "stale-obu-host"), "#!/bin/sh\nexit 0\n");
+  await writeCodexMcpConfig(home);
+  const manifestPath = path.join(nativeMessagingHostDir("chrome", process.platform, home), "dev.obu.host.json");
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, JSON.stringify({
+    name: "dev.obu.host",
+    description: "stale open-browser-use native messaging host",
+    path: staleHostBin,
+    type: "stdio",
+    allowed_origins: [`chrome-extension://${extensionId}/`],
+  }, null, 2), "utf8");
+  const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
+  await writeChromePreferences(profilePath, extensionId, 1);
+  await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
+  await chmod(runtimeDir, 0o700);
+  await chmod(path.join(runtimeDir, "webextension"), 0o700);
+
+  const env = {
+    HOME: home,
+    OBU_HOST_BIN: staleHostBin,
+    OBU_RUNTIME_DIR: runtimeDir,
+  };
+  const verifyArgs = [
+    "verify",
+    "--agent=codex-cli",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+    "--json",
+  ];
+  const result = await runCli(verifyArgs, env);
+
+  assert.equal(result.code, 1);
+  const payload = JSON.parse(result.stdout);
+  const nativeHost = payload.checks.find((check: any) => check.id === "native-host-manifest");
+  assert.equal(payload.result, "needs_repair");
+  assert.equal(payload.nextAction.kind, "run_repair");
+  assert.equal(nativeHost?.status, "fail");
+  assert.equal(nativeHost?.reason, "native_host_manifest_invalid");
+  assert.match(nativeHost?.message ?? "", /managed wrapper/);
+
+  const repaired = await runCli([...verifyArgs.slice(0, -1), "--repair", "--json"], env);
+  assert.equal(repaired.code, 1);
+  const repairedPayload = JSON.parse(repaired.stdout);
+  const repairedNativeHost = repairedPayload.checks.find((check: any) => check.id === "native-host-manifest");
+  const repairedManifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(repairedPayload.result, "needs_browser_popup");
+  assert.equal(repairedNativeHost?.status, "pass");
+  assert.match(repairedManifest.path, /native-host\/dev\.obu\.host\/chrome\/obu-host-wrapper$/);
+});
+
 test("verify asks for profile selection when multiple matching profiles are ambiguous", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
@@ -126,7 +186,7 @@ test("verify asks for profile selection when multiple matching profiles are ambi
   const runtimeDir = path.join(home, "runtime");
   const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
   await writeCodexMcpConfig(home);
-  await writeNativeHostManifest(home, hostBin, extensionId);
+  await writeNativeHostManifest(home, hostBin, extensionId, runtimeDir);
   const profileRoot = browserProfileRoot("chrome", process.platform, home);
   const defaultProfile = path.join(profileRoot, "Default");
   const secondProfile = path.join(profileRoot, "Profile 2");
@@ -184,7 +244,7 @@ test("verify treats missing Codex config as repairable when codex is not on PATH
   const extensionId = "abcdefghijklmnopabcdefghijklmnop";
   const runtimeDir = path.join(home, "runtime");
   const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
-  await writeNativeHostManifest(home, hostBin, extensionId);
+  await writeNativeHostManifest(home, hostBin, extensionId, runtimeDir);
   const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
   await writeChromePreferences(profilePath, extensionId, 1);
   await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
@@ -226,7 +286,7 @@ test("verify does not issue trusted agent-runtime challenges without a registere
   const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
   const fakeObu = await writeFakeMcpObu(bin, extensionId);
   await writeCodexMcpConfig(home, fakeObu, ["mcp", "stdio"]);
-  await writeNativeHostManifest(home, hostBin, extensionId);
+  await writeNativeHostManifest(home, hostBin, extensionId, runtimeDir);
   const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
   await writeChromePreferences(profilePath, extensionId, 1);
   await mkdir(path.join(runtimeDir, "webextension"), { recursive: true, mode: 0o700 });
@@ -1473,13 +1533,24 @@ function send(payload) {
   ].join("\n"));
 }
 
-async function writeNativeHostManifest(home: string, hostBin: string, extensionId: string): Promise<void> {
+async function writeNativeHostManifest(home: string, hostBin: string, extensionId: string, runtimeDir: string): Promise<void> {
   const manifestPath = path.join(nativeMessagingHostDir("chrome", process.platform, home), "dev.obu.host.json");
+  const wrapperPath = nativeHostWrapperPath({
+    nativeHostInstallRoot: path.join(home, ".obu", "native-host"),
+    browser: "chrome",
+  });
+  await mkdir(path.dirname(wrapperPath), { recursive: true });
+  await writeFile(wrapperPath, nativeHostWrapperContent({
+    hostBin,
+    browser: "chrome",
+    runtimeDir,
+  }), "utf8");
+  await chmod(wrapperPath, 0o755);
   await mkdir(path.dirname(manifestPath), { recursive: true });
   await writeFile(manifestPath, JSON.stringify({
     name: "dev.obu.host",
     description: "open-browser-use native messaging host",
-    path: hostBin,
+    path: wrapperPath,
     type: "stdio",
     allowed_origins: [`chrome-extension://${extensionId}/`],
   }, null, 2), "utf8");

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -704,6 +704,40 @@ test("update-extension CLI rejects a persisted Store channel by default", async 
   assert.match(result.stderr, /Chrome Web Store manages Store extension updates/);
 });
 
+test("update-extension CLI channel override does not reuse a stale Store verify target", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const source = await mkdtemp(path.join(os.tmpdir(), "obu-cli-extension-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(source, { recursive: true, force: true }));
+  await writeFile(path.join(source, "manifest.json"), JSON.stringify({ manifest_version: 3, version: "0.5.2" }), "utf8");
+  const configPath = path.join(home, ".obu", "config.json");
+  const staleStoreId = "ponmlkjihgfedcbaponmlkjihgfedcba";
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, JSON.stringify({
+    schemaVersion: 1,
+    runtimeDir: path.join(home, "runtime"),
+    extensionCurrentDir: path.join(home, ".obu", "extension", "current"),
+    nativeHostInstallRoot: path.join(home, ".obu", "native-host"),
+    extensionChannel: "store",
+    storeExtensionId: staleStoreId,
+  }), "utf8");
+
+  const result = await runCli(["update-extension", "--channel=unpacked-dev", "--path", source, "--no-wait", "--json"], {
+    HOME: home,
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  const nextActions = payload.nextActions.map((action: any) => action.value).join("\n");
+  assert.match(nextActions, /--channel=unpacked-dev --extension-id=<extension-id>/);
+  assert.doesNotMatch(nextActions, /--channel=store/);
+  assert.doesNotMatch(nextActions, new RegExp(staleStoreId));
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  assert.equal(config.extensionChannel, "unpacked-dev");
+  assert.equal("storeExtensionId" in config, false);
+});
+
 test("setup default output summarizes dry-run planned work and verbose keeps step ids", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const source = await mkdtemp(path.join(os.tmpdir(), "obu-cli-extension-"));
@@ -1037,6 +1071,47 @@ test("setup CLI runs deterministic steps before extension manual boundary", asyn
   assert.match(nativeHost.details.nativeManifestPath, new RegExp(`^${escapeRegExp(home)}`));
   assert.equal(payload.steps.some((step: any) => step.id === "extension-current" && step.status === "applied"), true);
   assert.equal(await readFile(path.join(home, ".obu", "extension", "current", "marker.txt"), "utf8"), "setup-extension");
+});
+
+test("setup next actions do not reuse a stale Store verify target for unpacked-dev", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const source = await mkdtemp(path.join(os.tmpdir(), "obu-cli-extension-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(source, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  await writeFile(path.join(source, "manifest.json"), JSON.stringify({
+    manifest_version: 3,
+    version: "0.8.3",
+    key: Buffer.from("open-browser-use cli setup target key").toString("base64"),
+  }), "utf8");
+  const hostBin = path.join(bin, "obu-host");
+  await writeFile(hostBin, "#!/bin/sh\n", "utf8");
+  await chmod(hostBin, 0o755);
+  const configPath = path.join(home, ".obu", "config.json");
+  const staleStoreId = "ponmlkjihgfedcbaponmlkjihgfedcba";
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, JSON.stringify({
+    schemaVersion: 1,
+    runtimeDir: path.join(home, "runtime"),
+    extensionCurrentDir: path.join(home, ".obu", "extension", "current"),
+    nativeHostInstallRoot: path.join(home, ".obu", "native-host"),
+    extensionChannel: "store",
+    storeExtensionId: staleStoreId,
+  }), "utf8");
+
+  const result = await runCli(["setup", "--yes", "--channel=unpacked-dev", "--path", source, "--agents=none", "--json"], {
+    HOME: home,
+    OBU_HOST_BIN: hostBin,
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, "");
+  const payload = JSON.parse(result.stdout);
+  const nextActions = payload.nextActions.map((action: any) => action.value).join("\n");
+  assert.match(nextActions, new RegExp(`--channel=unpacked-dev --extension-id=${payload.extensionId}`));
+  assert.doesNotMatch(nextActions, /--channel=store/);
+  assert.doesNotMatch(nextActions, new RegExp(staleStoreId));
 });
 
 test("setup CLI supports Store channel without staging an unpacked extension", async (t) => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -819,6 +819,8 @@ test("bootstrap continues through manual agent setup and runs browser repair", a
   assert.equal(payload.result, "manual_action_required");
   assert.equal(payload.setup.result, "manual_action_required");
   assert.equal(payload.setup.steps.some((step: any) => step.id === "agent-continue" && step.status === "manual_action_required"), true);
+  assert.equal(payload.nextActions.some((action: any) => action.value.includes("verify --agent=continue")), true);
+  assert.equal(payload.readinessVerification.status, "not_verified");
   assert.equal(payload.browserDoctor.extensionChannel, "store");
   assert.equal(payload.browserDoctor.extensionId, storeExtensionId);
   assert.equal(payload.browserDoctor.repairs.some((repair: any) => repair.id === "native-host-manifest"), true);
@@ -855,6 +857,9 @@ test("bootstrap summary reports skipped agent setup without naming the adapter p
   assert.match(result.stdout, /MCP agent setup skipped\./);
   assert.doesNotMatch(result.stdout, /MCP agents already configured: adapters/);
   assert.match(result.stdout, /extension popup activation is still required/);
+  assert.match(result.stdout, /verify .*'?--agent=<agent-id>'?/);
+  assert.doesNotMatch(result.stdout, /Browser pairing ready/);
+  assert.doesNotMatch(result.stdout, /doctor browser/);
 });
 
 test("setup CLI accepts explicit auto and none agent modes", async (t) => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
 import net from "node:net";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -157,6 +156,23 @@ test("verify asks for profile selection when multiple matching profiles are ambi
   assert.equal(payload.browser.profile.path, null);
   assert.equal(payload.browser.profile.suggestedPath, defaultProfile);
   assert.deepEqual(payload.browser.profile.candidates.map((candidate: any) => candidate.path), [defaultProfile, secondProfile]);
+
+  const human = await runCli([
+    "verify",
+    "--agent=codex-cli",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+  ], {
+    HOME: home,
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: runtimeDir,
+  });
+
+  assert.equal(human.code, 1);
+  assert.match(human.stdout, /Manual action required\./);
+  assert.match(human.stdout, new RegExp(`Profile:\\n  ${escapeRegExp(defaultProfile)}`));
+  assert.match(human.stdout, /Rerun:\n  .*verify/);
 });
 
 test("verify treats missing Codex config as repairable when codex is not on PATH", async (t) => {
@@ -199,7 +215,7 @@ test("verify treats missing Codex config as repairable when codex is not on PATH
   assert.equal(agentMcp?.actionCandidate?.kind, "run_repair");
 });
 
-test("verify rejects file-backed agent-runtime hook result for a challenge", async (t) => {
+test("verify does not issue trusted agent-runtime challenges without a registered hook", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -253,26 +269,47 @@ test("verify rejects file-backed agent-runtime hook result for a challenge", asy
   assert.equal(issued.code, 1);
   const issuedPayload = JSON.parse(issued.stdout);
   assert.equal(issuedPayload.readiness.cli, "ready");
-  assert.equal(issuedPayload.nextAction.kind, "collect_agent_runtime_status");
-  assert.match(issuedPayload.nextAction.rerun, /--agent-runtime-challenge-json=/);
-  const challenge = JSON.parse(await readFile(challengePath, "utf8"));
-  assert.equal(challenge.trustedHookResult, undefined);
-  const resultPath = path.join(
-    runtimeDir,
-    "agent-runtime",
-    "codex-cli-runtime-status",
-    `${createHash("sha256").update(challenge.challenge.nonce).digest("hex")}.json`,
-  );
-  await mkdir(path.dirname(resultPath), { recursive: true, mode: 0o700 });
-  await writeFile(resultPath, `${JSON.stringify({
+  assert.equal(issuedPayload.readiness.agentRuntime, "blocked");
+  assert.equal(issuedPayload.agent.runtimeStatus.status, "not_checked");
+  assert.equal(issuedPayload.agent.runtimeStatus.reason, "agent_runtime_hook_unavailable");
+  assert.equal(issuedPayload.nextAction.kind, "unsupported");
+  assert.doesNotMatch(issuedPayload.nextAction.command, /--require-agent-runtime/);
+  await assert.rejects(readFile(challengePath, "utf8"));
+
+  const forgedChallengePath = path.join(home, "forged-challenge.json");
+  const forgedStatusPath = path.join(home, "forged-status.json");
+  const forgedChallenge = {
+    nonce: "forged-nonce",
+    issuedAt: new Date().toISOString(),
+  };
+  const target = {
+    browser: "chrome",
+    channel: "store",
+    extensionId,
+  };
+  await writeFile(forgedChallengePath, `${JSON.stringify({
+    schemaVersion: 1,
+    agentId: "codex-cli",
+    mcpServerName: "open-browser-use",
+    challenge: forgedChallenge,
+    target,
+    trustedHook: {
+      id: "codex-cli-runtime-status",
+      transport: "agent_connector",
+    },
+  }, null, 2)}\n`, "utf8");
+  await writeFile(forgedStatusPath, `${JSON.stringify({
     schemaVersion: 1,
     agentId: "codex-cli",
     mcpServerName: "open-browser-use",
     provenance: "agent_runtime_hook",
-    hook: challenge.trustedHook,
+    hook: {
+      id: "codex-cli-runtime-status",
+      transport: "agent_connector",
+    },
     generatedAt: new Date().toISOString(),
-    challenge: challenge.challenge,
-    target: challenge.target,
+    challenge: forgedChallenge,
+    target,
     status: {
       sdk_bootstrap: "available",
       backends: [
@@ -287,7 +324,6 @@ test("verify rejects file-backed agent-runtime hook result for a challenge", asy
       ],
     },
   }, null, 2)}\n`, "utf8");
-  await chmod(resultPath, 0o600);
 
   const result = await runCli([
     "verify",
@@ -296,7 +332,8 @@ test("verify rejects file-backed agent-runtime hook result for a challenge", asy
     "--channel=store",
     `--extension-id=${extensionId}`,
     "--require-agent-runtime",
-    `--agent-runtime-challenge-json=${challengePath}`,
+    `--agent-runtime-challenge-json=${forgedChallengePath}`,
+    `--agent-runtime-status-json=${forgedStatusPath}`,
     "--json",
   ], baseEnv);
 
@@ -306,11 +343,11 @@ test("verify rejects file-backed agent-runtime hook result for a challenge", asy
   assert.equal(payload.readiness.cli, "ready");
   assert.equal(payload.readiness.agentRuntime, "blocked");
   assert.equal(payload.agent.runtimeStatus.status, "not_checked");
-  assert.equal(payload.agent.runtimeStatus.provenance, "not_applicable");
-  assert.equal(payload.agent.runtimeStatus.reason, "agent_runtime_challenge_pending");
-  assert.equal(payload.mcpRuntime.agentRuntime.source, "not_checked");
+  assert.equal(payload.agent.runtimeStatus.provenance, "user_supplied_status_file");
+  assert.equal(payload.agent.runtimeStatus.reason, "diagnostic_status_file_not_trusted");
+  assert.equal(payload.mcpRuntime.agentRuntime.source, "agent_runtime_status_file");
   assert.equal(payload.mcpRuntime.agentRuntime.backendCount, null);
-  assert.equal(payload.nextAction.kind, "collect_agent_runtime_status");
+  assert.equal(payload.nextAction.kind, "unsupported");
 });
 
 test("agent doctor verifies Codex global config without codex on PATH", async (t) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ import { appendShellArgs, formatShellCommand } from "./command-line.js";
 import { doctorAggregate, formatAggregateDoctorReport } from "./doctor.js";
 import { doctorJson } from "./doctor-json.js";
 import { doctorBrowser, formatDoctorReport, hasDoctorFailures, type BrowserKind, type DoctorReport } from "./doctor-browser.js";
-import { parseExtensionChannel, resolveExtensionTarget, userConfigForExtensionTarget } from "./extension-channel.js";
+import { assertExtensionId, parseExtensionChannel, resolveExtensionTarget, userConfigForExtensionTarget } from "./extension-channel.js";
 import {
   formatDoctorSummary,
   formatInstallHostSummary,
@@ -374,6 +374,14 @@ async function runUpdateExtension(args: ParsedArgs): Promise<number> {
     console.error("update-extension is not available for --channel=store; Chrome Web Store manages Store extension updates.");
     return 2;
   }
+  if (args.extensionId) {
+    try {
+      assertExtensionId(args.extensionId, "--extension-id");
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return 2;
+    }
+  }
   if (!args.dryRun) {
     const runtime = await ensureRuntimeDir(layout.runtimeDir);
     if (!runtime.ok) {
@@ -385,12 +393,17 @@ async function runUpdateExtension(args: ParsedArgs): Promise<number> {
       runtimeDir: layout.runtimeDir,
       extensionCurrentDir: layout.extensionCurrentDir,
       nativeHostInstallRoot: layout.nativeHostInstallRoot,
+      extensionChannel: channel,
     });
   }
   const report = await updateExtension({
     layout,
     dryRun: args.dryRun,
     noWait: args.noWait,
+    verifyTarget: {
+      channel,
+      ...(args.extensionId ? { extensionId: args.extensionId } : {}),
+    },
     ...(args.extensionPath ? { sourceDir: args.extensionPath } : {}),
   });
   if (args.json) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import {
   formatDoctorSummary,
   formatInstallHostSummary,
   formatInstallHostVerbose,
+  formatNextActions,
   formatSetupSummary,
   formatSetupVerbose,
   formatUpdateExtensionSummary,
@@ -196,12 +197,22 @@ async function runBootstrap(args: ParsedArgs): Promise<number> {
       command: "bootstrap";
       result: "complete" | "manual_action_required" | "failed";
       setup: SetupJson;
+      nextActions: SetupJson["nextActions"];
+      readinessVerification: {
+        status: "not_verified";
+        nextActions: SetupJson["nextActions"];
+      };
       browserDoctor?: DoctorReport;
     } = {
       schemaVersion: 1,
       command: "bootstrap",
       result,
       setup: setupReport,
+      nextActions: setupReport.nextActions,
+      readinessVerification: {
+        status: "not_verified",
+        nextActions: setupReport.nextActions,
+      },
     };
     if (browserReport) payload.browserDoctor = browserReport;
     console.log(JSON.stringify(payload, null, 2));
@@ -678,12 +689,12 @@ function formatBootstrapSummary(setupReport: SetupJson, browserReport: DoctorRep
     const browserFailed = hasDoctorFailures(browserReport);
     const needsPopup = browserResumeRequired(browserReport);
     rows.push(setupReport.dryRun
-      ? `Browser pairing would be checked for ${channelLabel} ${setupReport.extensionId}.`
+      ? `Browser setup checks would run for ${channelLabel} ${setupReport.extensionId}.`
       : browserFailed
         ? `Browser repair ran for ${channelLabel} ${setupReport.extensionId}.`
         : needsPopup
-          ? `Browser pairing repaired for ${channelLabel} ${setupReport.extensionId}; extension popup activation is still required.`
-          : `Browser pairing ready for ${channelLabel} ${setupReport.extensionId}.`);
+          ? `Browser setup checks completed for ${channelLabel} ${setupReport.extensionId}; extension popup activation is still required.`
+          : `Browser setup checks completed for ${channelLabel} ${setupReport.extensionId}.`);
     if (browserFailed) {
       const failed = browserReport.checks.filter((check) => check.status === "fail");
       rows.push(`Browser doctor still found ${plural(failed.length, "problem")}: ${failed.map((check) => check.label).join(", ")}.`);
@@ -695,6 +706,7 @@ function formatBootstrapSummary(setupReport: SetupJson, browserReport: DoctorRep
   if (browserResumeRequired(browserReport)) {
     rows.push("Open the extension popup; click Resume if it is enabled, otherwise wait for Connected and rerun verify.");
   }
+  rows.push(...formatNextActions(setupReport.nextActions));
   return rows.join("\n");
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,7 @@ import { updateExtension } from "./extension-update.js";
 import { installNativeHosts, supportedNativeHostBrowsers } from "./native-host.js";
 import { ensureRuntimeDir, executableExists, packageVersion, resolveRuntimeLayout, validateRuntimeDir, writeUserConfig } from "./runtime-layout.js";
 import { setupOpenBrowserUse, type SetupJson } from "./setup.js";
+import { formatVerifyReport, verifyExitCode, verifyOpenBrowserUse } from "./verify.js";
 
 type ParsedArgs = {
   command?: string;
@@ -55,6 +56,11 @@ type ParsedArgs = {
   skipExtension: boolean;
   skipAgents: boolean;
   writeInstructions: boolean;
+  requireAgentRuntime: boolean;
+  profile?: string;
+  agentRuntimeChallengeOut?: string;
+  agentRuntimeChallengeJson?: string;
+  agentRuntimeStatusJson?: string;
 };
 
 async function main(argv: string[]): Promise<number> {
@@ -69,6 +75,9 @@ async function main(argv: string[]): Promise<number> {
   }
   if (args.command === "doctor") {
     return runDoctor(args);
+  }
+  if (args.command === "verify") {
+    return runVerify(args);
   }
   if (args.command === "mcp-config") {
     return runMcpConfig(args);
@@ -276,6 +285,63 @@ async function runSetup(args: ParsedArgs): Promise<number> {
   if (report.result === "complete") return 0;
   if (report.result === "manual_action_required" && args.recovery && isBrowserRecoveryBoundary(report)) return 0;
   return 1;
+}
+
+async function runVerify(args: ParsedArgs): Promise<number> {
+  if (!args.agent) throw new Error("verify requires --agent=<id>");
+  const agent = normalizeAgentId(args.agent);
+  if (!agent) throw new Error(unsupportedAgentMessage([args.agent]));
+  const layout = await resolveRuntimeLayout();
+  if (layout.configIssue) {
+    console.error(`open-browser-use user config is invalid: ${layout.configIssue.message}. Fix or remove ${layout.configIssue.path}, then rerun obu verify.`);
+    return 2;
+  }
+  let extensionTarget;
+  try {
+    extensionTarget = await resolveExtensionTarget({
+      layout,
+      channel: args.channel,
+      explicitExtensionId: args.extensionId,
+      env: process.env,
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+  const browser = args.browser ?? ("chrome" as BrowserKind);
+  const invocation = await resolveMcpInvocation(layout.openBrowserUseCommand, layout.cliEntry);
+  const server: McpServerInvocation = {
+    name: "open-browser-use",
+    command: invocation.command,
+    args: invocation.args,
+  };
+  const commandPrefix = await resolveHumanCommandPrefix(layout);
+  const report = await verifyOpenBrowserUse({
+    layout,
+    agent,
+    agentInput: args.agent,
+    browser,
+    channel: extensionTarget.channel,
+    extensionId: extensionTarget.extensionId,
+    extensionIdSource: extensionTarget.extensionIdSource,
+    server,
+    commandPrefix,
+    repair: args.repair,
+    requireAgentRuntime: args.requireAgentRuntime,
+    env: process.env,
+    homeDir: path.dirname(path.dirname(layout.userConfigPath)),
+    projectDir: process.cwd(),
+    ...(args.profile ? { profile: args.profile } : {}),
+    ...(args.agentRuntimeChallengeOut ? { agentRuntimeChallengeOut: args.agentRuntimeChallengeOut } : {}),
+    ...(args.agentRuntimeChallengeJson ? { agentRuntimeChallengeJson: args.agentRuntimeChallengeJson } : {}),
+    ...(args.agentRuntimeStatusJson ? { agentRuntimeStatusJson: args.agentRuntimeStatusJson } : {}),
+  });
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatVerifyReport(report));
+  }
+  return verifyExitCode(report);
 }
 
 async function runShellenv(args: ParsedArgs): Promise<number> {
@@ -627,7 +693,7 @@ function formatBootstrapSummary(setupReport: SetupJson, browserReport: DoctorRep
   const agentLine = bootstrapAgentSummary(setupReport);
   if (agentLine) rows.push(agentLine);
   if (browserResumeRequired(browserReport)) {
-    rows.push("Open the extension popup; click Resume if it is enabled, otherwise wait for Connected and rerun doctor.");
+    rows.push("Open the extension popup; click Resume if it is enabled, otherwise wait for Connected and rerun verify.");
   }
   return rows.join("\n");
 }
@@ -701,6 +767,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     skipExtension: false,
     skipAgents: false,
     writeInstructions: false,
+    requireAgentRuntime: false,
     help: false,
     version: false,
   };
@@ -789,6 +856,21 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--write-instructions":
         args.writeInstructions = true;
         break;
+      case "--require-agent-runtime":
+        args.requireAgentRuntime = true;
+        break;
+      case "--profile":
+        args.profile = readValue();
+        break;
+      case "--agent-runtime-challenge-out":
+        args.agentRuntimeChallengeOut = readValue();
+        break;
+      case "--agent-runtime-challenge-json":
+        args.agentRuntimeChallengeJson = readValue();
+        break;
+      case "--agent-runtime-status-json":
+        args.agentRuntimeStatusJson = readValue();
+        break;
       case "--version":
       case "-V":
         args.version = true;
@@ -819,6 +901,7 @@ function printHelp(): void {
   obu --version
   obu bootstrap [--yes] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--agents=auto|none|<list>] [--channel unpacked-dev|store] [--extension-id <id>] [--skip-extension] [--write-instructions] [--dry-run] [--json]
   obu setup [--yes] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--agents=auto|none|<list>] [--channel unpacked-dev|store] [--extension-id <id>] [--skip-extension] [--skip-agents] [--write-instructions] [--dry-run] [--recovery] [--verbose] [--json]
+  obu verify --agent=<id> [--browser chrome|chrome-for-testing|edge|brave|arc|chromium] [--profile <path>] [--channel unpacked-dev|store] [--extension-id <id>] [--require-agent-runtime] [--agent-runtime-challenge-out <path>] [--agent-runtime-challenge-json <path>] [--agent-runtime-status-json <path>] [--repair] [--json]
   obu doctor [browser] [--browser chrome|chrome-for-testing|edge|brave|arc|chromium] [--channel unpacked-dev|store] [--extension-id <id>] [--verbose] [--json] [--strict] [--repair] [--clean-backups]
   obu install-host [--browser chrome|chrome-for-testing|edge|brave|arc|chromium|--all] [--channel unpacked-dev|store] [--extension-id <id>] [--dry-run] [--verbose] [--json]
   obu update-extension [--path <dir>] [--channel unpacked-dev] [--no-wait] [--dry-run] [--verbose] [--json]

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,14 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 
 import { doctorAgent, formatAgentDoctorReport, hasAgentDoctorFailures } from "./agents/doctor.js";
-import { isAgentId, renderAgentMcpConfig, supportedAgentIds, type AgentId, type McpServerInvocation } from "./agents/registry.js";
+import {
+  normalizeAgentId,
+  renderAgentMcpConfig,
+  supportedAgentAliasHelp,
+  supportedAgentIds,
+  type AgentId,
+  type McpServerInvocation,
+} from "./agents/registry.js";
 import { appendShellArgs, formatShellCommand } from "./command-line.js";
 import { doctorAggregate, formatAggregateDoctorReport } from "./doctor.js";
 import { doctorJson } from "./doctor-json.js";
@@ -125,9 +132,9 @@ async function runBootstrap(args: ParsedArgs): Promise<number> {
     console.error(`unsupported bootstrap browser target on ${process.platform}: ${unsupported.join(", ")}`);
     return 2;
   }
-  const unsupportedAgents = args.agents.filter((agent) => !isAgentId(agent));
-  if (unsupportedAgents.length > 0) {
-    console.error(`unsupported agent id(s): ${unsupportedAgents.join(", ")}. Supported agents: ${supportedAgentIds().join(", ")}`);
+  const requestedAgents = normalizeAgentArgs(args.agents);
+  if (requestedAgents.unsupported.length > 0) {
+    console.error(unsupportedAgentMessage(requestedAgents.unsupported));
     return 2;
   }
   const invocation = await resolveMcpInvocation(layout.openBrowserUseCommand, layout.cliEntry);
@@ -141,7 +148,7 @@ async function runBootstrap(args: ParsedArgs): Promise<number> {
     layout,
     obuVersion: await packageVersion(),
     browsers,
-    agents: args.agents as AgentId[],
+    agents: requestedAgents.agents,
     server,
     extensionChannel: extensionTarget.channel,
     extensionId: extensionTarget.extensionId,
@@ -172,7 +179,7 @@ async function runBootstrap(args: ParsedArgs): Promise<number> {
     const doctorExit = browserReport ? doctorExitCode(browserReport, false) : 0;
     const result = setupReport.result === "failed" || doctorExit !== 0
       ? "failed"
-      : setupReport.result === "manual_action_required"
+      : setupReport.result === "manual_action_required" || browserResumeRequired(browserReport)
         ? "manual_action_required"
         : "complete";
     const payload: {
@@ -195,7 +202,10 @@ async function runBootstrap(args: ParsedArgs): Promise<number> {
 
   if (setupReport.result === "failed") return 1;
   if (!browserReport) return 1;
-  return doctorExitCode(browserReport, false);
+  const doctorExit = doctorExitCode(browserReport, false);
+  if (doctorExit !== 0) return doctorExit;
+  if (setupReport.result === "manual_action_required" || browserResumeRequired(browserReport)) return 1;
+  return 0;
 }
 
 async function runSetup(args: ParsedArgs): Promise<number> {
@@ -228,9 +238,9 @@ async function runSetup(args: ParsedArgs): Promise<number> {
     console.error(`unsupported setup browser target on ${process.platform}: ${unsupported.join(", ")}`);
     return 2;
   }
-  const unsupportedAgents = args.agents.filter((agent) => !isAgentId(agent));
-  if (unsupportedAgents.length > 0) {
-    console.error(`unsupported agent id(s): ${unsupportedAgents.join(", ")}. Supported agents: ${supportedAgentIds().join(", ")}`);
+  const requestedAgents = normalizeAgentArgs(args.agents);
+  if (requestedAgents.unsupported.length > 0) {
+    console.error(unsupportedAgentMessage(requestedAgents.unsupported));
     return 2;
   }
   const invocation = await resolveMcpInvocation(layout.openBrowserUseCommand, layout.cliEntry);
@@ -244,7 +254,7 @@ async function runSetup(args: ParsedArgs): Promise<number> {
     layout,
     obuVersion: await packageVersion(),
     browsers,
-    agents: args.agents as AgentId[],
+    agents: requestedAgents.agents,
     server,
     extensionChannel: extensionTarget.channel,
     extensionId: extensionTarget.extensionId,
@@ -460,9 +470,8 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
 async function runMcpConfig(args: ParsedArgs): Promise<number> {
   if (!args.agent) throw new Error("mcp-config requires --agent=<id>");
   if (!args.print) throw new Error("mcp-config currently supports --print only");
-  if (!isAgentId(args.agent)) {
-    throw new Error(`unsupported agent: ${args.agent}. Supported agents: ${supportedAgentIds().join(", ")}`);
-  }
+  const agent = normalizeAgentId(args.agent);
+  if (!agent) throw new Error(unsupportedAgentMessage([args.agent]));
   const layout = await resolveRuntimeLayout();
   const invocation = await resolveMcpInvocation(layout.openBrowserUseCommand, layout.cliEntry);
   const server: McpServerInvocation = {
@@ -470,15 +479,14 @@ async function runMcpConfig(args: ParsedArgs): Promise<number> {
     command: invocation.command,
     args: invocation.args,
   };
-  console.log(JSON.stringify(renderAgentMcpConfig(args.agent, server), null, 2));
+  console.log(JSON.stringify(renderAgentMcpConfig(agent, server), null, 2));
   return 0;
 }
 
 async function runAgentDoctor(args: ParsedArgs): Promise<number> {
   if (!args.agent) throw new Error("agent doctor requires --agent=<id>");
-  if (!isAgentId(args.agent)) {
-    throw new Error(`unsupported agent: ${args.agent}. Supported agents: ${supportedAgentIds().join(", ")}`);
-  }
+  const agent = normalizeAgentId(args.agent);
+  if (!agent) throw new Error(unsupportedAgentMessage([args.agent]));
   const layout = await resolveRuntimeLayout();
   const invocation = await resolveMcpInvocation(layout.openBrowserUseCommand, layout.cliEntry);
   const server: McpServerInvocation = {
@@ -487,7 +495,7 @@ async function runAgentDoctor(args: ParsedArgs): Promise<number> {
     args: invocation.args,
   };
   const report = await doctorAgent({
-    agent: args.agent,
+    agent,
     server,
     env: process.env,
     homeDir: path.dirname(path.dirname(layout.userConfigPath)),
@@ -503,6 +511,24 @@ async function runAgentDoctor(args: ParsedArgs): Promise<number> {
     console.log(formatAgentDoctorReport(report));
   }
   return hasAgentDoctorFailures(report) ? 1 : 0;
+}
+
+function normalizeAgentArgs(values: string[]): { agents: AgentId[]; unsupported: string[] } {
+  const agents: AgentId[] = [];
+  const unsupported: string[] = [];
+  for (const value of values) {
+    const agent = normalizeAgentId(value);
+    if (!agent) {
+      unsupported.push(value);
+      continue;
+    }
+    if (!agents.includes(agent)) agents.push(agent);
+  }
+  return { agents, unsupported };
+}
+
+function unsupportedAgentMessage(values: string[]): string {
+  return `unsupported agent id(s): ${values.join(", ")}. Supported agents: ${supportedAgentIds().join(", ")}. ${supportedAgentAliasHelp()}`;
 }
 
 async function resolveHumanCommandPrefix(layout: Awaited<ReturnType<typeof resolveRuntimeLayout>>): Promise<string> {
@@ -584,11 +610,14 @@ function formatBootstrapSummary(setupReport: SetupJson, browserReport: DoctorRep
   if (browserReport) {
     const channelLabel = setupReport.extensionChannel === "store" ? "Chrome Web Store extension" : "extension";
     const browserFailed = hasDoctorFailures(browserReport);
+    const needsPopup = browserResumeRequired(browserReport);
     rows.push(setupReport.dryRun
       ? `Browser pairing would be checked for ${channelLabel} ${setupReport.extensionId}.`
       : browserFailed
         ? `Browser repair ran for ${channelLabel} ${setupReport.extensionId}.`
-        : `Browser pairing repaired for ${channelLabel} ${setupReport.extensionId}.`);
+        : needsPopup
+          ? `Browser pairing repaired for ${channelLabel} ${setupReport.extensionId}; extension popup activation is still required.`
+          : `Browser pairing ready for ${channelLabel} ${setupReport.extensionId}.`);
     if (browserFailed) {
       const failed = browserReport.checks.filter((check) => check.status === "fail");
       rows.push(`Browser doctor still found ${plural(failed.length, "problem")}: ${failed.map((check) => check.label).join(", ")}.`);
@@ -597,13 +626,15 @@ function formatBootstrapSummary(setupReport: SetupJson, browserReport: DoctorRep
 
   const agentLine = bootstrapAgentSummary(setupReport);
   if (agentLine) rows.push(agentLine);
-  rows.push("Return to the extension popup and click Resume.");
+  if (browserResumeRequired(browserReport)) {
+    rows.push("Open the extension popup; click Resume if it is enabled, otherwise wait for Connected and rerun doctor.");
+  }
   return rows.join("\n");
 }
 
 function bootstrapAgentSummary(setupReport: SetupJson): string | undefined {
   const agentSteps = setupReport.steps.filter((step) =>
-    step.id.startsWith("agent-") && !step.id.endsWith("-instructions")
+    step.id.startsWith("agent-") && step.id !== "agent-adapters" && !step.id.endsWith("-instructions")
   );
   const manualAgents = agentSteps
     .filter((step) => step.status === "manual_action_required")
@@ -625,6 +656,10 @@ function bootstrapAgentSummary(setupReport: SetupJson): string | undefined {
   if (/no supported coding agents detected/i.test(adapterStep.message)) return "No supported coding agents were detected.";
   if (/skipped agent adapter wiring/i.test(adapterStep.message)) return "MCP agent setup skipped.";
   return adapterStep.message;
+}
+
+function browserResumeRequired(report: DoctorReport | undefined): boolean {
+  return report?.checks.some((check) => check.details?.resume_required === true) ?? false;
 }
 
 function plural(count: number, label: string): string {
@@ -790,7 +825,9 @@ function printHelp(): void {
   obu mcp-config --agent=<id> --print
   obu agent doctor --agent=<id> [--json]
   obu shellenv [shell]
-  obu mcp stdio`);
+  obu mcp stdio
+
+Agent aliases: codex=codex-cli, claude=claude-code, gemini=gemini-cli.`);
 }
 
 main(process.argv.slice(2))

--- a/packages/cli/src/native-host.ts
+++ b/packages/cli/src/native-host.ts
@@ -87,11 +87,14 @@ async function installNativeHost(input: {
   extensionId: string;
   dryRun: boolean;
 }): Promise<InstallHostAction> {
-  const wrapperDir = path.join(input.layout.nativeHostInstallRoot, HOST_NAME, input.browser);
-  const wrapperPath = path.join(wrapperDir, "obu-host-wrapper");
+  const wrapperPath = nativeHostWrapperPath({
+    nativeHostInstallRoot: input.layout.nativeHostInstallRoot,
+    browser: input.browser,
+  });
+  const wrapperDir = path.dirname(wrapperPath);
   const nativeManifestDir = nativeMessagingHostDir(input.browser, input.platform, input.homeDir);
   const nativeManifestPath = path.join(nativeManifestDir, `${HOST_NAME}.json`);
-  const wrapper = nativeHostWrapper({
+  const wrapper = nativeHostWrapperContent({
     hostBin: input.layout.hostBin,
     browser: input.browser,
     runtimeDir: input.layout.runtimeDir,
@@ -129,7 +132,11 @@ async function installNativeHost(input: {
   };
 }
 
-function nativeHostWrapper(input: { hostBin: string; browser: BrowserKind; runtimeDir: string }): string {
+export function nativeHostWrapperPath(input: { nativeHostInstallRoot: string; browser: BrowserKind }): string {
+  return path.join(input.nativeHostInstallRoot, HOST_NAME, input.browser, "obu-host-wrapper");
+}
+
+export function nativeHostWrapperContent(input: { hostBin: string; browser: BrowserKind; runtimeDir: string }): string {
   return [
     "#!/bin/sh",
     "set -eu",

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -41,6 +41,10 @@ test("setupOpenBrowserUse composes runtime, native host, extension update, and m
   assert.match(await readFile(path.join(root, ".codex", "config.toml"), "utf8"), /\[mcp_servers\.open-browser-use\]/);
   assert.equal(await readFile(path.join(layout.extensionCurrentDir, "marker.txt"), "utf8"), "0.6.0");
   assert.equal(result.nextActions.some((action) => action.value === "obu mcp-config --agent=codex-cli --print"), false);
+  assert.ok(result.nextActions.some((action) =>
+    action.kind === "command" &&
+    action.value === `${layout.openBrowserUseCommand} verify --agent=codex-cli --browser=chrome --channel=unpacked-dev --extension-id=${extensionIdFromManifestKey(EXTENSION_KEY)}`
+  ));
 });
 
 test("setupOpenBrowserUse can complete deterministic setup when extension and agents are skipped", async (t) => {
@@ -102,8 +106,10 @@ test("setupOpenBrowserUse skips extension staging for Store channel", async (t) 
   await assert.rejects(readFile(path.join(layout.extensionCurrentDir, "marker.txt"), "utf8"));
   const nativeHostStep = result.steps.find((step) => step.id === "native-host-chrome");
   assert.equal(nativeHostStep?.details?.extensionId, storeExtensionId);
+  assert.equal(result.nextActions.some((action) => action.value.includes("doctor")), false);
   assert.ok(result.nextActions.some((action) =>
-    action.value === `${layout.openBrowserUseCommand} doctor browser --channel=store --extension-id=${storeExtensionId}`
+    action.kind === "manual" &&
+    action.value.includes(`${layout.openBrowserUseCommand} verify '--agent=<agent-id>' --browser=chrome --channel=store --extension-id=${storeExtensionId}`)
   ));
 });
 

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -37,9 +37,10 @@ test("setupOpenBrowserUse composes runtime, native host, extension update, and m
   assert.equal(result.steps.find((step) => step.id === "runtime-dir")?.status, "applied");
   assert.equal(result.steps.find((step) => step.id === "native-host-chrome")?.status, "applied");
   assert.equal(result.steps.find((step) => step.id === "extension-current")?.status, "applied");
-  assert.equal(result.steps.find((step) => step.id === "agent-codex-cli")?.status, "manual_action_required");
+  assert.equal(result.steps.find((step) => step.id === "agent-codex-cli")?.status, "applied");
+  assert.match(await readFile(path.join(root, ".codex", "config.toml"), "utf8"), /\[mcp_servers\.open-browser-use\]/);
   assert.equal(await readFile(path.join(layout.extensionCurrentDir, "marker.txt"), "utf8"), "0.6.0");
-  assert.ok(result.nextActions.some((action) => action.value === "obu mcp-config --agent=codex-cli --print"));
+  assert.equal(result.nextActions.some((action) => action.value === "obu mcp-config --agent=codex-cli --print"), false);
 });
 
 test("setupOpenBrowserUse can complete deterministic setup when extension and agents are skipped", async (t) => {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -166,16 +166,33 @@ export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJ
     }
   }
 
-  nextActions.push({
-    kind: "command",
-    value: formatSetupCommand(options, doctorCommandArgs(options)),
-  });
+  nextActions.push(...verificationActions(options, agents));
   return finalize(options, steps, dedupeActions(nextActions));
 }
 
-function doctorCommandArgs(options: SetupOptions): string[] {
-  if (options.extensionChannel !== "store") return ["doctor"];
-  return ["doctor", "browser", "--channel=store", `--extension-id=${options.extensionId}`];
+function verificationActions(options: SetupOptions, agents: AgentId[]): SetupJson["nextActions"] {
+  if (agents.length === 0) {
+    return options.browsers.map((browser) => ({
+      kind: "manual" as const,
+      value: `Choose the agent id to verify, then run ${formatSetupCommand(options, verifyCommandArgs(options, browser, "<agent-id>"))}.`,
+    }));
+  }
+  return agents.flatMap((agent) =>
+    options.browsers.map((browser) => ({
+      kind: "command" as const,
+      value: formatSetupCommand(options, verifyCommandArgs(options, browser, agent)),
+    }))
+  );
+}
+
+function verifyCommandArgs(options: SetupOptions, browser: BrowserKind, agent: AgentId | "<agent-id>"): string[] {
+  return [
+    "verify",
+    `--agent=${agent}`,
+    `--browser=${browser}`,
+    `--channel=${options.extensionChannel}`,
+    `--extension-id=${options.extensionId}`,
+  ];
 }
 
 function formatSetupCommand(options: SetupOptions, args: string[]): string {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -122,6 +122,10 @@ export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJ
     const extension = await updateExtension({
       layout: options.layout,
       dryRun,
+      verifyTarget: {
+        channel: options.extensionChannel,
+        extensionId: options.extensionId,
+      },
       ...(options.extensionPath ? { sourceDir: options.extensionPath } : {}),
     });
     for (const step of extension.steps) steps.push(mapExtensionStep(step));

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -1,0 +1,2605 @@
+import { createHash, randomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import { access, chmod, lstat, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+import { doctorAgent, type AgentDoctorCheck } from "./agents/doctor.js";
+import { configureAgents } from "./agents/configure.js";
+import { type AgentId, type McpServerInvocation } from "./agents/registry.js";
+import { appendShellArgs } from "./command-line.js";
+import { doctorBrowser } from "./doctor-browser.js";
+import { type ExtensionChannel, type ExtensionIdSource } from "./extension-channel.js";
+import { browserProfileRoot, nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
+import { supportedNativeHostBrowsers } from "./native-host.js";
+import { executableExists, packageVersion, type RuntimeLayout } from "./runtime-layout.js";
+
+const HOST_NAME = "dev.obu.host";
+const SERVER_NAME = "open-browser-use";
+const DEFAULT_MCP_PROBE_TIMEOUT_MS = 8_000;
+const AGENT_RUNTIME_FRESHNESS_MS = 60_000;
+
+export type VerificationTarget = "cli" | "agent_runtime";
+export type VerifyResult = "ready" | "needs_browser_popup" | "needs_repair" | "needs_manual_action";
+export type VerifyCheckStatus = "pass" | "warn" | "fail" | "not_checked";
+export type ReadinessStatus = "ready" | "blocked" | "not_checked";
+export type ComponentState =
+  | "pass"
+  | "warn"
+  | "fail"
+  | "missing"
+  | "unreadable"
+  | "disabled"
+  | "stale"
+  | "invalid"
+  | "not_checked";
+type RuntimeBinding = "profile_verified" | "single_candidate" | "browser_extension_scope" | "not_available";
+type VerifyLayer =
+  | "target_support"
+  | "cli_install"
+  | "native_host"
+  | "browser_profile"
+  | "browser_extension"
+  | "extension_runtime"
+  | "runtime_descriptor"
+  | "agent_mcp"
+  | "agent_instruction"
+  | "mcp_runtime"
+  | "agent_runtime";
+type EvidenceScope = "cli" | "browser_extension" | "profile" | "agent_runtime";
+type EvidenceProvenance =
+  | "runtime_descriptor_probe"
+  | "expected_obu_invocation"
+  | "agent_runtime_hook"
+  | "user_supplied_status_file"
+  | "not_applicable";
+type NextActionKind =
+  | "install_cli"
+  | "run_repair"
+  | "open_popup"
+  | "configure_agent"
+  | "resolve_config_conflict"
+  | "restart_agent"
+  | "collect_agent_runtime_status"
+  | "select_profile"
+  | "install_extension"
+  | "enable_extension"
+  | "unsupported";
+
+type VerifyTarget = {
+  agent?: AgentId;
+  browser?: BrowserKind;
+  channel?: ExtensionChannel;
+  extensionId?: string;
+  profile?: string;
+};
+
+type Evidence = {
+  scope: EvidenceScope;
+  provenance: EvidenceProvenance;
+  source: string;
+};
+
+type ActionCandidate = {
+  result: Exclude<VerifyResult, "ready">;
+  kind: NextActionKind;
+  priority: number;
+  message?: string;
+  command?: string;
+  url?: string;
+  browser?: BrowserKind;
+  profile?: { path: string | null; suggestedPath?: string | null; candidates?: ProfileCandidate[] };
+  rerun?: string;
+  challenge?: { path: string };
+  trustedHook?: TrustedRuntimeHook;
+};
+
+export type VerifyCheck = {
+  id: string;
+  layer: VerifyLayer;
+  status: VerifyCheckStatus;
+  message: string;
+  target: VerifyTarget;
+  evidence: Evidence;
+  reason?: string;
+  blocks?: Array<"cli" | "agent_runtime">;
+  details?: Record<string, unknown>;
+  actionCandidate?: ActionCandidate;
+};
+
+type VerifyNextAction = Omit<ActionCandidate, "result" | "priority">;
+
+type ProfileCandidate = {
+  path: string;
+  profileExists: ComponentState;
+  extensionInstalled: ComponentState;
+  extensionEnabled: ComponentState;
+  reasons?: Record<string, string>;
+};
+
+type VerifyBrowserProfile = {
+  path: string | null;
+  suggestedPath: string | null;
+  source: "explicit" | "default_discovery";
+  runtimeBinding: RuntimeBinding;
+  candidates: ProfileCandidate[];
+};
+
+type VerifyBrowser = {
+  kind: BrowserKind;
+  channel: ExtensionChannel;
+  extensionId: string;
+  extensionIdSource: ExtensionIdSource;
+  profile: VerifyBrowserProfile;
+  extensionInstalled: ComponentState;
+  extensionEnabled: ComponentState;
+  nativeHost: ComponentState;
+  runtimeDescriptor: ComponentState;
+  resumeRequired: boolean;
+  reasons?: Record<string, string>;
+  descriptor?: Record<string, unknown>;
+};
+
+type AgentRuntimeStatus =
+  | {
+    status: "pass";
+    provenance: "agent_runtime_hook";
+    hook: TrustedRuntimeHook & { trusted: true };
+    generatedAt: string;
+    targetBound: true;
+    challengeBound: true;
+  }
+  | {
+    status: "fail";
+    provenance: "agent_runtime_hook";
+    reason: string;
+    hook: TrustedRuntimeHook & { trusted: true };
+    targetBound?: boolean;
+    challengeBound?: boolean;
+  }
+  | {
+    status: "not_checked";
+    provenance: "user_supplied_status_file";
+    reason: "diagnostic_status_file_not_trusted";
+    diagnostic: {
+      statusFile: string;
+      targetBound: boolean;
+      challengeBound: boolean;
+    };
+  }
+  | {
+    status: "not_checked";
+    provenance: "not_applicable";
+    reason: string;
+    trustedHook?: TrustedRuntimeHook;
+  };
+
+type VerifyAgent = {
+  id: AgentId;
+  input?: string;
+  mcpConfig: {
+    status: VerifyCheckStatus;
+    serverName: "open-browser-use";
+    command: string;
+    args: string[];
+    path?: string;
+    reason?: string;
+    details?: Record<string, unknown>;
+  };
+  instructions: {
+    status: VerifyCheckStatus;
+    reason?: "missing_instruction" | "not_implemented";
+    path?: string;
+  };
+  runtimeStatus: AgentRuntimeStatus;
+};
+
+type NormalizedBackend = {
+  type: string;
+  browser: string | null;
+  extensionId: string | null;
+  extensionIdentity: {
+    source: "descriptor_metadata" | "missing";
+    verified: boolean;
+  };
+  metadata?: {
+    browserKind?: string;
+    extensionId?: string;
+    raw?: unknown;
+  };
+};
+
+type McpRuntimeStatus = {
+  source: "direct_mcp_probe" | "agent_runtime" | "agent_runtime_status_file" | "not_checked";
+  provenance: EvidenceProvenance;
+  probeCommandSource: "expected_obu_invocation" | "agent_runtime_hook" | "user_supplied_status_file" | "not_applicable";
+  mcpConfigured: boolean;
+  mcpStarts: boolean | null;
+  sdkBootstrap: string;
+  backendCount: number | null;
+  backends: NormalizedBackend[];
+  reason?: string;
+  details?: Record<string, unknown>;
+};
+
+export type VerifyReport = {
+  schemaVersion: 1;
+  command: "verify";
+  verificationTarget: VerificationTarget;
+  result: VerifyResult;
+  readiness: {
+    cli: ReadinessStatus;
+    agentRuntime: ReadinessStatus;
+  };
+  agent: VerifyAgent;
+  browser: VerifyBrowser;
+  mcpRuntime: {
+    cli: McpRuntimeStatus;
+    agentRuntime: McpRuntimeStatus;
+  };
+  nextAction: VerifyNextAction | null;
+  checks: VerifyCheck[];
+};
+
+export type VerifyOptions = {
+  layout: RuntimeLayout;
+  agent: AgentId;
+  agentInput?: string;
+  browser: BrowserKind;
+  channel: ExtensionChannel;
+  extensionId: string;
+  extensionIdSource: ExtensionIdSource;
+  server: McpServerInvocation;
+  commandPrefix: string;
+  repair?: boolean;
+  requireAgentRuntime?: boolean;
+  profile?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  projectDir?: string;
+  agentRuntimeChallengeOut?: string;
+  agentRuntimeChallengeJson?: string;
+  agentRuntimeStatusJson?: string;
+  mcpProbeTimeoutMs?: number;
+};
+
+type RuntimeDescriptorProbe =
+  | {
+    status: "pass";
+    state: "pass";
+    message: string;
+    descriptorFile: string;
+    descriptorPath: string;
+    metadata: Record<string, unknown>;
+    browserKind: string;
+    extensionId: string;
+    profilePath?: string;
+    details: Record<string, unknown>;
+  }
+  | {
+    status: "fail";
+    state: ComponentState;
+    reason: string;
+    message: string;
+    result: "needs_repair" | "needs_browser_popup";
+    details?: Record<string, unknown>;
+  };
+
+type ProfileResolution = {
+  profile: VerifyBrowserProfile;
+  extensionInstalled: ComponentState;
+  extensionEnabled: ComponentState;
+  reasons: Record<string, string>;
+  checks: VerifyCheck[];
+};
+
+type RpcResponse = Record<string, any>;
+
+type TrustedRuntimeResult =
+  | {
+    status: "pass";
+    runtimeStatus: Extract<AgentRuntimeStatus, { status: "pass" }>;
+    mcpRuntime: McpRuntimeStatus;
+    details: Record<string, unknown>;
+  }
+  | {
+    status: "fail";
+    reason: string;
+    message: string;
+    mcpRuntime: McpRuntimeStatus;
+    details?: Record<string, unknown>;
+  }
+  | {
+    status: "pending";
+    reason: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+
+const layerOrder: VerifyLayer[] = [
+  "target_support",
+  "cli_install",
+  "native_host",
+  "browser_profile",
+  "browser_extension",
+  "extension_runtime",
+  "runtime_descriptor",
+  "agent_mcp",
+  "agent_instruction",
+  "mcp_runtime",
+  "agent_runtime",
+];
+
+const resultPriority: Record<Exclude<VerifyResult, "ready">, number> = {
+  needs_manual_action: 1,
+  needs_repair: 2,
+  needs_browser_popup: 3,
+};
+
+const manualActionPriority: Record<NextActionKind, number> = {
+  install_cli: 1,
+  unsupported: 2,
+  resolve_config_conflict: 3,
+  select_profile: 4,
+  install_extension: 5,
+  enable_extension: 6,
+  collect_agent_runtime_status: 7,
+  restart_agent: 8,
+  configure_agent: 9,
+  run_repair: 99,
+  open_popup: 99,
+};
+
+export async function applyVerifyRepairs(options: VerifyOptions): Promise<void> {
+  await doctorBrowser({
+    browser: options.browser,
+    channel: options.channel,
+    extensionId: options.extensionId,
+    extensionIdSource: options.extensionIdSource,
+    ...(options.channel === "store" ? {} : { extensionCurrentDir: options.layout.mode === "repo" ? options.layout.extensionDir : options.layout.extensionCurrentDir }),
+    repair: true,
+    runtimeDir: options.layout.runtimeDir,
+    ...(options.env ? { env: options.env } : {}),
+    ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+  });
+  await configureAgents({
+    agents: [options.agent],
+    server: options.server,
+    dryRun: false,
+    writeInstructions: false,
+    commandPrefix: options.commandPrefix,
+    ...(options.env ? { env: options.env } : {}),
+    ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+    ...(options.projectDir ? { projectDir: options.projectDir } : {}),
+  });
+}
+
+export async function verifyOpenBrowserUse(options: VerifyOptions): Promise<VerifyReport> {
+  const targetSupported = supportedNativeHostBrowsers().includes(options.browser);
+  if (options.repair && targetSupported) await applyVerifyRepairs(options);
+
+  const verificationTarget: VerificationTarget = options.requireAgentRuntime ? "agent_runtime" : "cli";
+  const checks: VerifyCheck[] = [];
+  const targetBase = baseTarget(options);
+  const homeDir = options.homeDir ?? homeDirFromLayout(options.layout) ?? os.homedir();
+  const env = options.env ?? process.env;
+
+  checks.push(await checkCliInstall(options, targetBase));
+  checks.push(targetSupportCheck(options, targetSupported, targetBase));
+  const nativeHost = await checkNativeHost(options, homeDir, targetBase);
+  checks.push(nativeHost.check);
+
+  const descriptorProbe = await probeRuntimeDescriptor(options, targetBase);
+  const profileResolution = await resolveBrowserProfile(options, homeDir, descriptorProbe, targetBase);
+  checks.push(...profileResolution.checks);
+
+  const extensionCheck = browserExtensionCheck(options, profileResolution, targetBase);
+  checks.push(extensionCheck);
+
+  const runtimeChecks = runtimeChecksFromProbe(options, descriptorProbe, profileResolution.profile.path, targetBase);
+  checks.push(...runtimeChecks);
+
+  const agentReport = await doctorAgent({
+    agent: options.agent,
+    server: options.server,
+    env,
+    homeDir,
+    ...(options.projectDir ? { projectDir: options.projectDir } : {}),
+  });
+  const agentMcpDoctorCheck = agentReport.checks.find((row) => row.id === "agent-mcp-server");
+  const agentInstructionDoctorCheck = agentReport.checks.find((row) => row.id === "agent-primary-instruction");
+  const agentMcpCheck = normalizeAgentMcpCheck(options, agentMcpDoctorCheck, targetBase);
+  checks.push(agentMcpCheck);
+  const agentInstructionCheck = normalizeAgentInstructionCheck(options, agentInstructionDoctorCheck);
+  checks.push(agentInstructionCheck);
+
+  const mcpCli = descriptorProbe.status === "pass"
+    ? await probeDirectMcpRuntime(options)
+    : notCheckedMcpRuntime("runtime_descriptor_not_active");
+  checks.push(normalizeMcpRuntimeCheck(options, mcpCli, descriptorProbe, targetBase));
+
+  const cliReadyBeforeAgentRuntime = !checks.some((check) => check.status === "fail" && check.blocks?.includes("cli"));
+  const agentRuntime = await evaluateAgentRuntime(options, verificationTarget, cliReadyBeforeAgentRuntime, targetBase);
+  checks.push(agentRuntime.check);
+
+  const readiness = computeReadiness(verificationTarget, checks);
+  const { result, nextAction } = selectResultAndAction(verificationTarget, readiness, checks);
+
+  const browser: VerifyBrowser = {
+    kind: options.browser,
+    channel: options.channel,
+    extensionId: options.extensionId,
+    extensionIdSource: options.extensionIdSource,
+    profile: profileResolution.profile,
+    extensionInstalled: profileResolution.extensionInstalled,
+    extensionEnabled: profileResolution.extensionEnabled,
+    nativeHost: nativeHost.state,
+    runtimeDescriptor: descriptorProbe.state,
+    resumeRequired: descriptorProbe.status === "fail" && descriptorProbe.result === "needs_browser_popup",
+  };
+  const browserReasons = { ...profileResolution.reasons };
+  if (nativeHost.reason) browserReasons.nativeHost = nativeHost.reason;
+  if (descriptorProbe.status === "fail") browserReasons.runtimeDescriptor = descriptorProbe.message;
+  if (Object.keys(browserReasons).length > 0) browser.reasons = browserReasons;
+  if (descriptorProbe.status === "pass") {
+    browser.descriptor = {
+      file: descriptorProbe.descriptorFile,
+      probe: "getInfo",
+      lifecycle: "fresh",
+      metadata: descriptorProbe.metadata,
+    };
+  }
+
+  return {
+    schemaVersion: 1,
+    command: "verify",
+    verificationTarget,
+    result,
+    readiness,
+    agent: {
+      id: options.agent,
+      ...(options.agentInput ? { input: options.agentInput } : {}),
+      mcpConfig: agentMcpSummary(options, agentMcpDoctorCheck, agentMcpCheck),
+      instructions: agentInstructionSummary(agentInstructionDoctorCheck, agentInstructionCheck),
+      runtimeStatus: agentRuntime.runtimeStatus,
+    },
+    browser,
+    mcpRuntime: {
+      cli: mcpCli,
+      agentRuntime: agentRuntime.mcpRuntime,
+    },
+    nextAction,
+    checks,
+  };
+}
+
+export function verifyExitCode(report: VerifyReport): number {
+  return report.result === "ready" ? 0 : 1;
+}
+
+export function formatVerifyReport(report: VerifyReport): string {
+  if (report.result === "ready") {
+    const backend = report.mcpRuntime.cli.backends[0];
+    const descriptor = typeof report.browser.descriptor?.file === "string" ? report.browser.descriptor.file : "descriptor";
+    return [
+      `open-browser-use is ${report.verificationTarget === "agent_runtime" ? "agent-runtime-ready" : "CLI-ready"}.`,
+      `Agent: ${report.agent.id}`,
+      `Browser: ${report.browser.kind} ${report.browser.channel === "store" ? "Store extension" : "extension"} ${report.browser.extensionId}`,
+      `Backend: ${backend?.type ?? "webextension"} descriptor ${descriptor} responded to getInfo`,
+      `MCP runtime: direct probe found ${report.mcpRuntime.cli.backendCount ?? 0} usable backend${report.mcpRuntime.cli.backendCount === 1 ? "" : "s"}`,
+      `Agent runtime: ${report.readiness.agentRuntime === "ready" ? "ready" : "not checked"}`,
+    ].join("\n");
+  }
+
+  if (report.result === "needs_browser_popup") {
+    const rerun = report.nextAction?.rerun;
+    return [
+      "Browser popup required.",
+      "Local setup is correct, but no active WebExtension descriptor exists yet.",
+      report.nextAction?.message ?? "Open the open-browser-use extension popup. Click Resume if enabled.",
+      ...(rerun ? ["If it already shows Connected, wait briefly and rerun:", `  ${rerun}`] : []),
+    ].join("\n");
+  }
+
+  if (report.result === "needs_repair") {
+    return [
+      "Repair required.",
+      report.nextAction?.message ?? "A deterministic open-browser-use repair is available.",
+      ...(report.nextAction?.command ? ["Run:", `  ${report.nextAction.command}`] : []),
+    ].join("\n");
+  }
+
+  return [
+    "Manual action required.",
+    report.nextAction?.message ?? "The selected target needs manual action before open-browser-use can verify readiness.",
+    ...(report.nextAction?.command ? ["Run:", `  ${report.nextAction.command}`] : []),
+  ].join("\n");
+}
+
+function baseTarget(options: VerifyOptions): VerifyTarget {
+  return {
+    agent: options.agent,
+    browser: options.browser,
+    channel: options.channel,
+    extensionId: options.extensionId,
+    ...(options.profile ? { profile: options.profile } : {}),
+  };
+}
+
+async function checkCliInstall(options: VerifyOptions, target: VerifyTarget): Promise<VerifyCheck> {
+  const version = await packageVersion();
+  const versionLooksValid = /^\d+\.\d+\.\d+(?:[-+].*)?$/.test(version);
+  const expectedCommand = options.layout.openBrowserUseCommand;
+  const packagedCommandOk = options.layout.mode !== "packaged" || await executableExists(expectedCommand);
+  if (!versionLooksValid || !packagedCommandOk) {
+    const message = !versionLooksValid
+      ? "obu version is not parseable"
+      : `packaged obu command is not executable at ${expectedCommand}`;
+    return failCheck({
+      id: "cli-version",
+      layer: "cli_install",
+      reason: "cli_not_runnable",
+      message,
+      target,
+      evidence: expectedEvidence("cli_version"),
+      actionCandidate: {
+        result: "needs_manual_action",
+        kind: "install_cli",
+        priority: manualActionPriority.install_cli,
+        message: "Install or repair the open-browser-use CLI, then rerun verify.",
+      },
+    });
+  }
+  return passCheck({
+    id: "cli-version",
+    layer: "cli_install",
+    message: "obu version is parseable",
+    target: {},
+    evidence: expectedEvidence("cli_version"),
+    details: { version },
+  });
+}
+
+function targetSupportCheck(options: VerifyOptions, supported: boolean, target: VerifyTarget): VerifyCheck {
+  if (supported) {
+    return passCheck({
+      id: "target-support",
+      layer: "target_support",
+      message: "verification target is supported by this build",
+      target,
+      evidence: expectedEvidence("target_registry"),
+      details: { platform: process.platform, browser: options.browser },
+    });
+  }
+  return failCheck({
+    id: "target-support",
+    layer: "target_support",
+    reason: "unsupported_browser",
+    message: `browser target ${options.browser} is not supported on ${process.platform}`,
+    target,
+    evidence: expectedEvidence("target_registry"),
+    actionCandidate: {
+      result: "needs_manual_action",
+      kind: "unsupported",
+      priority: manualActionPriority.unsupported,
+      message: `open-browser-use cannot verify ${options.browser} on ${process.platform} in this build.`,
+    },
+  });
+}
+
+async function checkNativeHost(options: VerifyOptions, homeDir: string, target: VerifyTarget): Promise<{
+  check: VerifyCheck;
+  state: ComponentState;
+  reason?: string;
+}> {
+  const manifestPath = path.join(nativeMessagingHostDir(options.browser, process.platform, homeDir), `${HOST_NAME}.json`);
+  const manifest = await readJson(manifestPath).catch(() => undefined);
+  const command = repairCommand(options);
+  if (!isRecord(manifest)) {
+    return {
+      state: "missing",
+      reason: `native host manifest missing or invalid at ${manifestPath}`,
+      check: failCheck({
+        id: "native-host-manifest",
+        layer: "native_host",
+        reason: "native_host_manifest_missing",
+        message: `native host manifest missing or invalid at ${manifestPath}`,
+        target,
+        evidence: expectedEvidence("native_host_manifest"),
+        details: { path: manifestPath },
+        actionCandidate: repairAction(command, "Repair the native host manifest for the selected browser and extension."),
+      }),
+    };
+  }
+
+  const issues: string[] = [];
+  const allowedOrigin = `chrome-extension://${options.extensionId}/`;
+  if (manifest.name !== HOST_NAME) issues.push(`name must be ${HOST_NAME}`);
+  if (manifest.type !== "stdio") issues.push("type must be stdio");
+  if (typeof manifest.path !== "string" || !path.isAbsolute(manifest.path)) issues.push("path must be absolute");
+  if (!Array.isArray(manifest.allowed_origins) || !manifest.allowed_origins.includes(allowedOrigin)) {
+    issues.push(`allowed_origins must include ${allowedOrigin}`);
+  }
+  if (typeof manifest.path === "string" && !await access(manifest.path, constants.X_OK).then(() => true).catch(() => false)) {
+    issues.push(`native host path is not executable: ${manifest.path}`);
+  }
+  if (issues.length > 0) {
+    return {
+      state: "invalid",
+      reason: issues.join("; "),
+      check: failCheck({
+        id: "native-host-manifest",
+        layer: "native_host",
+        reason: "native_host_manifest_invalid",
+        message: issues.join("; "),
+        target,
+        evidence: expectedEvidence("native_host_manifest"),
+        details: { path: manifestPath, issues },
+        actionCandidate: repairAction(command, "Repair the native host manifest for the selected browser and extension."),
+      }),
+    };
+  }
+  return {
+    state: "pass",
+    check: passCheck({
+      id: "native-host-manifest",
+      layer: "native_host",
+      message: `native host allows ${allowedOrigin}`,
+      target,
+      evidence: expectedEvidence("native_host_manifest"),
+      details: { path: manifestPath },
+    }),
+  };
+}
+
+async function resolveBrowserProfile(
+  options: VerifyOptions,
+  homeDir: string,
+  descriptor: RuntimeDescriptorProbe,
+  target: VerifyTarget,
+): Promise<ProfileResolution> {
+  if (options.profile) {
+    return resolveExplicitProfile(options, descriptor, target);
+  }
+  const root = browserProfileRoot(options.browser, process.platform, homeDir);
+  const rootStats = await lstat(root).catch((error) => error as NodeJS.ErrnoException);
+  if (rootStats instanceof Error || !rootStats.isDirectory()) {
+    const reason = rootStats instanceof Error && rootStats.code !== "ENOENT" ? "profile_root_unreadable" : "profile_root_missing";
+    const message = rootStats instanceof Error && rootStats.code !== "ENOENT"
+      ? `browser profile root cannot be inspected: ${root}`
+      : `browser profile root not found at ${root}`;
+    return profileResolution({
+      profile: {
+        path: null,
+        suggestedPath: null,
+        source: "default_discovery",
+        runtimeBinding: "not_available",
+        candidates: [],
+      },
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        extensionInstalled: "no browser profile can be inspected",
+        extensionEnabled: "no browser profile can be inspected",
+      },
+      checks: [
+        failCheck({
+          id: "browser-profile",
+          layer: "browser_profile",
+          reason,
+          message,
+          target,
+          evidence: expectedEvidence("profile_discovery"),
+          details: { root },
+          actionCandidate: selectProfileAction(options, null, "Select or create the browser profile to verify."),
+        }),
+      ],
+    });
+  }
+
+  const profilePaths = await defaultProfileCandidates(root);
+  const candidates = await Promise.all(profilePaths.map((candidate) => inspectProfileCandidate(candidate, options.extensionId)));
+  if (candidates.length === 0) {
+    return profileResolution({
+      profile: {
+        path: null,
+        suggestedPath: null,
+        source: "default_discovery",
+        runtimeBinding: "not_available",
+        candidates: [],
+      },
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        extensionInstalled: "no browser profile can be inspected",
+        extensionEnabled: "no browser profile can be inspected",
+      },
+      checks: [
+        failCheck({
+          id: "browser-profile",
+          layer: "browser_profile",
+          reason: "profile_root_empty",
+          message: `no inspectable browser profiles found under ${root}`,
+          target,
+          evidence: expectedEvidence("profile_discovery"),
+          details: { root },
+          actionCandidate: selectProfileAction(options, null, "Select or create the browser profile to verify."),
+        }),
+      ],
+    });
+  }
+
+  const inspectable = candidates.filter((candidate) => candidate.profileExists === "pass");
+  const matching = inspectable.filter((candidate) => candidate.extensionInstalled === "pass");
+  const enabledMatching = matching.filter((candidate) => candidate.extensionEnabled === "pass");
+  const descriptorProfile = descriptor.status === "pass" ? descriptor.profilePath : undefined;
+  const profileVerified = descriptorProfile
+    ? matching.find((candidate) => samePath(candidate.path, descriptorProfile))
+    : undefined;
+  const resolved = profileVerified
+    ?? (matching.length === 1 ? matching[0] : undefined)
+    ?? (inspectable.length === 1 ? inspectable[0] : undefined);
+
+  if (matching.length > 1 && !profileVerified) {
+    const suggested = (enabledMatching[0] ?? matching[0])?.path ?? null;
+    return profileResolution({
+      profile: {
+        path: null,
+        suggestedPath: suggested,
+        source: "default_discovery",
+        runtimeBinding: descriptor.status === "pass" ? "browser_extension_scope" : "not_available",
+        candidates,
+      },
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        extensionInstalled: "multiple matching profiles require an explicit profile selection",
+        extensionEnabled: "multiple matching profiles require an explicit profile selection",
+      },
+      checks: [
+        failCheck({
+          id: "browser-profile",
+          layer: "browser_profile",
+          reason: "multiple_matching_profiles",
+          message: "multiple browser profiles contain the selected extension; select one explicitly",
+          target,
+          evidence: expectedEvidence("profile_discovery"),
+          details: { candidates, suggestedPath: suggested },
+          actionCandidate: selectProfileAction(options, suggested, "Select the browser profile to verify before continuing."),
+        }),
+      ],
+    });
+  }
+
+  if (!resolved) {
+    const suggested = inspectable[0]?.path ?? null;
+    return profileResolution({
+      profile: {
+        path: null,
+        suggestedPath: suggested,
+        source: "default_discovery",
+        runtimeBinding: "not_available",
+        candidates,
+      },
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        extensionInstalled: "profile choice is ambiguous before extension installation can be checked",
+        extensionEnabled: "profile choice is ambiguous before extension installation can be checked",
+      },
+      checks: [
+        failCheck({
+          id: "browser-profile",
+          layer: "browser_profile",
+          reason: "multiple_profiles_without_extension",
+          message: "multiple browser profiles were found, but none contains the selected extension",
+          target,
+          evidence: expectedEvidence("profile_discovery"),
+          details: { candidates, suggestedPath: suggested },
+          actionCandidate: selectProfileAction(options, suggested, "Choose the intended browser profile before installing the extension."),
+        }),
+      ],
+    });
+  }
+
+  const runtimeBinding = runtimeBindingForResolvedProfile({
+    options,
+    descriptor,
+    candidate: resolved,
+    source: "default_discovery",
+    matchingCount: matching.length,
+    explicit: false,
+  });
+  const checks: VerifyCheck[] = [
+    passCheck({
+      id: "browser-profile",
+      layer: "browser_profile",
+      message: profileVerified
+        ? "resolved profile from runtime descriptor evidence"
+        : matching.length === 1
+          ? "resolved one matching browser profile"
+          : "resolved the only inspectable browser profile",
+      target: { ...target, profile: resolved.path },
+      evidence: expectedEvidence("profile_discovery"),
+      details: { candidates },
+    }),
+  ];
+  return resolvedProfileResolution(options, resolved, candidates, "default_discovery", runtimeBinding, checks);
+}
+
+async function resolveExplicitProfile(
+  options: VerifyOptions,
+  descriptor: RuntimeDescriptorProbe,
+  target: VerifyTarget,
+): Promise<ProfileResolution> {
+  const profilePath = options.profile!;
+  const candidate = await inspectProfileCandidate(profilePath, options.extensionId);
+  if (candidate.profileExists !== "pass") {
+    const reason = candidate.profileExists === "missing" ? "profile_missing" : "profile_unreadable";
+    const message = candidate.profileExists === "missing"
+      ? `explicit profile path does not exist: ${profilePath}`
+      : `explicit profile path cannot be inspected: ${profilePath}`;
+    return profileResolution({
+      profile: {
+        path: profilePath,
+        suggestedPath: null,
+        source: "explicit",
+        runtimeBinding: "not_available",
+        candidates: [candidate],
+      },
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        extensionInstalled: "extension state cannot be inspected until the profile exists and is readable",
+        extensionEnabled: "extension state cannot be inspected until the profile exists and is readable",
+      },
+      checks: [
+        failCheck({
+          id: "browser-profile",
+          layer: "browser_profile",
+          reason,
+          message,
+          target: { ...target, profile: profilePath },
+          evidence: expectedEvidence("profile_discovery"),
+          details: { candidate },
+          actionCandidate: selectProfileAction(options, profilePath, "Select a readable browser profile to verify."),
+        }),
+      ],
+    });
+  }
+
+  const runtimeBinding = runtimeBindingForResolvedProfile({
+    options,
+    descriptor,
+    candidate,
+    source: "explicit",
+    matchingCount: candidate.extensionInstalled === "pass" ? 1 : 0,
+    explicit: true,
+  });
+  const checks: VerifyCheck[] = [
+    passCheck({
+      id: "browser-profile",
+      layer: "browser_profile",
+      message: "using explicit browser profile",
+      target: { ...target, profile: profilePath },
+      evidence: expectedEvidence("profile_discovery"),
+      details: { candidate },
+    }),
+  ];
+  if (descriptor.status === "pass" && runtimeBinding === "browser_extension_scope") {
+    checks.push(warnCheck({
+      id: "browser-profile-runtime-binding",
+      layer: "browser_profile",
+      reason: "profile_runtime_not_bound",
+      message: "runtime descriptor proves browser and extension identity, but not the explicit profile identity",
+      target: { ...target, profile: profilePath },
+      evidence: runtimeEvidence("runtime_descriptor_probe"),
+      details: { runtimeBinding },
+    }));
+  }
+  return resolvedProfileResolution(options, candidate, [candidate], "explicit", runtimeBinding, checks);
+}
+
+function resolvedProfileResolution(
+  options: VerifyOptions,
+  resolved: ProfileCandidate,
+  candidates: ProfileCandidate[],
+  source: "explicit" | "default_discovery",
+  runtimeBinding: RuntimeBinding,
+  checks: VerifyCheck[],
+): ProfileResolution {
+  if (resolved.extensionInstalled !== "pass") {
+    const reasons = {
+      extensionInstalled: resolved.reasons?.extensionInstalled ?? `extension ${options.extensionId} is not installed in the resolved profile`,
+      extensionEnabled: resolved.reasons?.extensionEnabled ?? "enablement was not inspected because the extension is missing",
+    };
+    return profileResolution({
+      profile: {
+        path: resolved.path,
+        suggestedPath: null,
+        source,
+        runtimeBinding,
+        candidates,
+      },
+      extensionInstalled: "missing",
+      extensionEnabled: "not_checked",
+      reasons,
+      checks,
+    });
+  }
+  if (resolved.extensionEnabled !== "pass") {
+    const reasons = {
+      extensionEnabled: resolved.reasons?.extensionEnabled ?? "extension is present but disabled in the resolved profile",
+    };
+    return profileResolution({
+      profile: {
+        path: resolved.path,
+        suggestedPath: null,
+        source,
+        runtimeBinding,
+        candidates,
+      },
+      extensionInstalled: "pass",
+      extensionEnabled: "disabled",
+      reasons,
+      checks,
+    });
+  }
+  return profileResolution({
+    profile: {
+      path: resolved.path,
+      suggestedPath: null,
+      source,
+      runtimeBinding,
+      candidates,
+    },
+    extensionInstalled: "pass",
+    extensionEnabled: "pass",
+    reasons: {},
+    checks,
+  });
+}
+
+function profileResolution(input: ProfileResolution): ProfileResolution {
+  return input;
+}
+
+function browserExtensionCheck(options: VerifyOptions, resolution: ProfileResolution, target: VerifyTarget): VerifyCheck {
+  const profile = resolution.profile.path;
+  if (!profile) {
+    return notCheckedCheck({
+      id: "browser-extension-installed",
+      layer: "browser_extension",
+      reason: "profile_not_resolved",
+      message: "extension installation was not checked because profile selection is ambiguous",
+      target,
+      evidence: expectedEvidence("profile_preferences"),
+    });
+  }
+  if (resolution.extensionInstalled !== "pass") {
+    return failCheck({
+      id: "browser-extension-installed",
+      layer: "browser_extension",
+      reason: "extension_missing",
+      message: `extension ${options.extensionId} is not installed in the resolved profile`,
+      target: { ...target, profile },
+      evidence: expectedEvidence("profile_preferences"),
+      actionCandidate: {
+        result: "needs_manual_action",
+        kind: "install_extension",
+        priority: manualActionPriority.install_extension,
+        message: `Install extension ${options.extensionId} in the resolved browser profile, then rerun verify.`,
+        browser: options.browser,
+        profile: { path: profile },
+        rerun: verifyCommand(options),
+      },
+    });
+  }
+  if (resolution.extensionEnabled !== "pass") {
+    return failCheck({
+      id: "browser-extension-installed",
+      layer: "browser_extension",
+      reason: "extension_disabled",
+      message: `extension ${options.extensionId} is installed but disabled in the resolved profile`,
+      target: { ...target, profile },
+      evidence: expectedEvidence("profile_preferences"),
+      actionCandidate: {
+        result: "needs_manual_action",
+        kind: "enable_extension",
+        priority: manualActionPriority.enable_extension,
+        message: `Enable extension ${options.extensionId} in the resolved browser profile, then rerun verify.`,
+        browser: options.browser,
+        profile: { path: profile },
+        rerun: verifyCommand(options),
+      },
+    });
+  }
+  return passCheck({
+    id: "browser-extension-installed",
+    layer: "browser_extension",
+    message: "extension is installed and enabled in the resolved profile",
+    target: { ...target, profile },
+    evidence: expectedEvidence("profile_preferences"),
+  });
+}
+
+function runtimeChecksFromProbe(
+  options: VerifyOptions,
+  descriptor: RuntimeDescriptorProbe,
+  profile: string | null,
+  target: VerifyTarget,
+): VerifyCheck[] {
+  const runtimeTarget = { ...target, ...(profile ? { profile } : {}) };
+  if (descriptor.status === "pass") {
+    return [
+      passCheck({
+        id: "extension-runtime",
+        layer: "extension_runtime",
+        message: "extension runtime inferred active from descriptor probe",
+        target: runtimeTarget,
+        evidence: runtimeEvidence("runtime_descriptor_probe"),
+        details: { source: "runtime_descriptor_probe" },
+      }),
+      passCheck({
+        id: "runtime-descriptor-probe",
+        layer: "runtime_descriptor",
+        message: descriptor.message,
+        target: runtimeTarget,
+        evidence: runtimeEvidence("runtime_descriptor_probe"),
+        details: descriptor.details,
+      }),
+    ];
+  }
+
+  const candidate: ActionCandidate = descriptor.result === "needs_browser_popup"
+    ? openPopupAction(options, profile)
+    : repairAction(repairCommand(options), descriptor.message);
+  return [
+    failCheck({
+      id: "extension-runtime",
+      layer: "extension_runtime",
+      reason: "runtime_descriptor_not_active",
+      message: "extension runtime is not active from CLI-observable evidence",
+      target: runtimeTarget,
+      evidence: runtimeEvidence("runtime_descriptor_probe"),
+      details: { source: "runtime_descriptor_probe" },
+      actionCandidate: candidate,
+    }),
+    failCheck({
+      id: "runtime-descriptor-probe",
+      layer: "runtime_descriptor",
+      reason: descriptor.reason,
+      message: descriptor.message,
+      target: runtimeTarget,
+      evidence: runtimeEvidence("runtime_descriptor_probe"),
+      actionCandidate: candidate,
+      ...(descriptor.details ? { details: descriptor.details } : {}),
+    }),
+  ];
+}
+
+function normalizeAgentMcpCheck(
+  options: VerifyOptions,
+  doctorCheck: AgentDoctorCheck | undefined,
+  target: VerifyTarget,
+): VerifyCheck {
+  if (!doctorCheck) {
+    return failCheck({
+      id: "agent-mcp-server",
+      layer: "agent_mcp",
+      reason: "agent_mcp_not_checked",
+      message: "agent MCP configuration was not checked",
+      target: { agent: options.agent },
+      evidence: expectedEvidence("agent_config_read"),
+      actionCandidate: configureAgentAction(options, "Configure the selected agent with the open-browser-use MCP server."),
+    });
+  }
+  if (doctorCheck.status === "pass") {
+    return passCheck({
+      id: "agent-mcp-server",
+      layer: "agent_mcp",
+      message: doctorCheck.message,
+      target: { agent: options.agent },
+      evidence: expectedEvidence("agent_config_read"),
+      ...(doctorCheck.details ? { details: doctorCheck.details } : {}),
+    });
+  }
+  if (doctorCheck.status === "warn") {
+    return failCheck({
+      id: "target-agent-mcp-support",
+      layer: "target_support",
+      reason: "agent_mcp_check_not_implemented",
+      message: doctorCheck.message,
+      target: { agent: options.agent },
+      evidence: expectedEvidence("agent_config_read"),
+      actionCandidate: {
+        result: "needs_manual_action",
+        kind: "unsupported",
+        priority: manualActionPriority.unsupported,
+        message: `Automatic MCP verification is not implemented for ${options.agent}. Configure the open-browser-use MCP server manually and verify from inside that agent.`,
+        command: mcpConfigCommand(options),
+      },
+      ...(doctorCheck.details ? { details: doctorCheck.details } : {}),
+    });
+  }
+  const conflict = /different settings|could not be read|could not be parsed/i.test(doctorCheck.message);
+  const executableMissing = /was not found on PATH/i.test(doctorCheck.message);
+  const directConfigRepairable = options.agent === "codex-cli" && executableMissing;
+  return failCheck({
+    id: "agent-mcp-server",
+    layer: "agent_mcp",
+    reason: conflict ? "config_conflict" : directConfigRepairable ? "agent_mcp_missing" : executableMissing ? "agent_executable_missing" : "agent_mcp_missing",
+    message: doctorCheck.message,
+    target: { agent: options.agent },
+    evidence: expectedEvidence("agent_config_read"),
+    actionCandidate: conflict
+      ? {
+        result: "needs_manual_action",
+        kind: "resolve_config_conflict",
+        priority: manualActionPriority.resolve_config_conflict,
+        message: "Review the selected agent MCP config and keep the intended open-browser-use command.",
+        command: mcpConfigCommand(options),
+      }
+      : directConfigRepairable
+        ? repairAction(repairCommand(options), "Configure codex-cli with the expected open-browser-use MCP server.")
+        : executableMissing
+        ? configureAgentAction(options, "Install the selected agent CLI or configure its MCP server manually.")
+        : repairAction(repairCommand(options), "Configure the selected agent with the expected open-browser-use MCP server."),
+    ...(doctorCheck.details ? { details: doctorCheck.details } : {}),
+  });
+}
+
+function normalizeAgentInstructionCheck(options: VerifyOptions, doctorCheck: AgentDoctorCheck | undefined): VerifyCheck {
+  if (!doctorCheck) {
+    return warnCheck({
+      id: "agent-primary-instruction",
+      layer: "agent_instruction",
+      reason: "not_implemented",
+      message: `instruction check is not implemented for ${options.agent}`,
+      target: { agent: options.agent },
+      evidence: expectedEvidence("agent_instruction_file"),
+    });
+  }
+  if (doctorCheck.status === "pass") {
+    return passCheck({
+      id: "agent-primary-instruction",
+      layer: "agent_instruction",
+      message: "primary browser instruction found",
+      target: { agent: options.agent },
+      evidence: expectedEvidence("agent_instruction_file"),
+      ...(doctorCheck.details ? { details: doctorCheck.details } : {}),
+    });
+  }
+  const reason = doctorCheck.status === "warn" ? "not_implemented" : "missing_instruction";
+  return warnCheck({
+    id: "agent-primary-instruction",
+    layer: "agent_instruction",
+    reason,
+    message: doctorCheck.message,
+    target: { agent: options.agent },
+    evidence: expectedEvidence("agent_instruction_file"),
+    ...(doctorCheck.details ? { details: doctorCheck.details } : {}),
+  });
+}
+
+function normalizeMcpRuntimeCheck(
+  options: VerifyOptions,
+  runtime: McpRuntimeStatus,
+  descriptor: RuntimeDescriptorProbe,
+  target: VerifyTarget,
+): VerifyCheck {
+  if (runtime.source === "not_checked") {
+    return notCheckedCheck({
+      id: "mcp-runtime-backend",
+      layer: "mcp_runtime",
+      reason: runtime.reason ?? "not_checked",
+      message: "direct MCP probe was not run",
+      target,
+      evidence: expectedEvidence("direct_mcp_probe"),
+      ...(runtime.details ? { details: runtime.details } : {}),
+    });
+  }
+  if (runtime.mcpStarts && runtime.sdkBootstrap === "available" && (runtime.backendCount ?? 0) > 0) {
+    return passCheck({
+      id: "mcp-runtime-backend",
+      layer: "mcp_runtime",
+      message: `direct MCP probe found ${runtime.backendCount} usable backend${runtime.backendCount === 1 ? "" : "s"}`,
+      target,
+      evidence: expectedEvidence("direct_mcp_probe"),
+      ...(runtime.details ? { details: runtime.details } : {}),
+    });
+  }
+  const popupBoundary = descriptor.status === "fail" && descriptor.result === "needs_browser_popup";
+  return failCheck({
+    id: "mcp-runtime-backend",
+    layer: "mcp_runtime",
+    reason: popupBoundary ? "zero_backends_after_popup_boundary" : runtime.reason ?? "mcp_runtime_not_ready",
+    message: runtime.reason ?? "direct MCP probe did not find a usable backend",
+    target,
+    evidence: expectedEvidence("direct_mcp_probe"),
+    actionCandidate: popupBoundary
+      ? openPopupAction(options, target.profile ?? null)
+      : repairAction(repairCommand(options), "Repair the open-browser-use MCP runtime and browser backend setup."),
+    ...(runtime.details ? { details: runtime.details } : {}),
+  });
+}
+
+async function evaluateAgentRuntime(
+  options: VerifyOptions,
+  verificationTarget: VerificationTarget,
+  cliReady: boolean,
+  target: VerifyTarget,
+): Promise<{ runtimeStatus: AgentRuntimeStatus; mcpRuntime: McpRuntimeStatus; check: VerifyCheck }> {
+  if (verificationTarget === "cli") {
+    const runtimeStatus: AgentRuntimeStatus = {
+      status: "not_checked",
+      provenance: "not_applicable",
+      reason: "verification_target_cli",
+    };
+    return {
+      runtimeStatus,
+      mcpRuntime: notCheckedAgentRuntimeMcp("verification_target_cli"),
+      check: notCheckedCheck({
+        id: "agent-runtime-status",
+        layer: "agent_runtime",
+        reason: "verification_target_cli",
+        message: "agent-runtime status was not requested",
+        target: { agent: options.agent },
+        evidence: {
+          scope: "agent_runtime",
+          provenance: "not_applicable",
+          source: "verification_target_cli",
+        },
+      }),
+    };
+  }
+
+  if (!cliReady) {
+    const runtimeStatus: AgentRuntimeStatus = {
+      status: "not_checked",
+      provenance: "not_applicable",
+      reason: "cli_readiness_blocked",
+    };
+    return {
+      runtimeStatus,
+      mcpRuntime: notCheckedAgentRuntimeMcp("cli_readiness_blocked"),
+      check: notCheckedCheck({
+        id: "agent-runtime-status",
+        layer: "agent_runtime",
+        reason: "cli_readiness_blocked",
+        message: "agent-runtime status was not checked because CLI readiness is blocked",
+        target: { agent: options.agent },
+        evidence: {
+          scope: "agent_runtime",
+          provenance: "not_applicable",
+          source: "cli_readiness_blocked",
+        },
+      }),
+    };
+  }
+
+  const hook = trustedRuntimeHook(options.agent);
+  let challengePath = options.agentRuntimeChallengeOut;
+  if (challengePath) {
+    await writeAgentRuntimeChallenge(challengePath, options, hook);
+  }
+
+  if (options.agentRuntimeStatusJson) {
+    const diagnostic = await diagnosticStatusFileBinding(options);
+    const runtimeStatus: AgentRuntimeStatus = {
+      status: "not_checked",
+      provenance: "user_supplied_status_file",
+      reason: "diagnostic_status_file_not_trusted",
+      diagnostic,
+    };
+    return {
+      runtimeStatus,
+      mcpRuntime: {
+        source: "agent_runtime_status_file",
+        provenance: "user_supplied_status_file",
+        probeCommandSource: "user_supplied_status_file",
+        mcpConfigured: true,
+        mcpStarts: null,
+        sdkBootstrap: "not_checked",
+        backendCount: null,
+        backends: [],
+        reason: "diagnostic_status_file_not_trusted",
+      },
+      check: failCheck({
+        id: "agent-runtime-status",
+        layer: "agent_runtime",
+        reason: "diagnostic_status_file_not_trusted",
+        message: "user-supplied agent runtime status files are diagnostic only",
+        target: { ...target, agent: options.agent },
+        evidence: {
+          scope: "agent_runtime",
+          provenance: "user_supplied_status_file",
+          source: "agent_runtime_status_file",
+        },
+        blocks: ["agent_runtime"],
+        actionCandidate: collectAgentRuntimeAction(options, hook, challengePath, "Collect agent-runtime status through the trusted OBU hook."),
+      }),
+    };
+  }
+
+  if (options.agentRuntimeChallengeJson) {
+    const trustedResult = await readTrustedRuntimeHookResult(options, hook);
+    if (trustedResult.status === "pass") {
+      return {
+        runtimeStatus: trustedResult.runtimeStatus,
+        mcpRuntime: trustedResult.mcpRuntime,
+        check: passCheck({
+          id: "agent-runtime-status",
+          layer: "agent_runtime",
+          message: "trusted agent-runtime hook reported a usable browser backend",
+          target: { ...target, agent: options.agent },
+          evidence: {
+            scope: "agent_runtime",
+            provenance: "agent_runtime_hook",
+            source: "agent_runtime_hook",
+          },
+          details: trustedResult.details,
+        }),
+      };
+    }
+    return {
+      runtimeStatus: trustedResult.status === "fail" && hook
+        ? {
+          status: "fail",
+          provenance: "agent_runtime_hook",
+          reason: trustedResult.reason,
+          hook: { ...hook, trusted: true },
+          targetBound: false,
+          challengeBound: false,
+        }
+        : {
+          status: "not_checked",
+          provenance: "not_applicable",
+          reason: trustedResult.reason,
+          ...(hook ? { trustedHook: hook } : {}),
+        },
+      mcpRuntime: trustedResult.status === "fail" ? trustedResult.mcpRuntime : notCheckedAgentRuntimeMcp(trustedResult.reason),
+      check: failCheck({
+        id: "agent-runtime-status",
+        layer: "agent_runtime",
+        reason: trustedResult.reason,
+        message: trustedResult.message,
+        target: { ...target, agent: options.agent },
+        evidence: {
+          scope: "agent_runtime",
+          provenance: hook ? "agent_runtime_hook" : "not_applicable",
+          source: "agent_runtime_hook",
+        },
+        blocks: ["agent_runtime"],
+        actionCandidate: collectAgentRuntimeAction(options, hook, options.agentRuntimeChallengeJson, "Collect agent-runtime status through the trusted OBU hook."),
+        ...(trustedResult.details ? { details: trustedResult.details } : {}),
+      }),
+    };
+  }
+
+  const reason = challengePath ? "agent_runtime_challenge_issued" : "agent_runtime_status_unavailable";
+  const runtimeStatus: AgentRuntimeStatus = {
+    status: "not_checked",
+    provenance: "not_applicable",
+    reason,
+    ...(hook ? { trustedHook: hook } : {}),
+  };
+  return {
+    runtimeStatus,
+    mcpRuntime: notCheckedAgentRuntimeMcp(reason),
+    check: failCheck({
+      id: "agent-runtime-status",
+      layer: "agent_runtime",
+      reason,
+      message: challengePath
+        ? "agent-runtime challenge was issued; status has not been returned by a trusted hook"
+        : "agent-runtime status is unavailable from this CLI process",
+      target: { ...target, agent: options.agent },
+      evidence: {
+        scope: "agent_runtime",
+        provenance: "not_applicable",
+        source: "agent_runtime_hook_registry",
+      },
+      blocks: ["agent_runtime"],
+      actionCandidate: collectAgentRuntimeAction(options, hook, challengePath, "Collect agent-runtime status through the trusted OBU hook."),
+    }),
+  };
+}
+
+async function probeDirectMcpRuntime(options: VerifyOptions): Promise<McpRuntimeStatus> {
+  if (!await executableExists(options.server.command)) {
+    return {
+      source: "direct_mcp_probe",
+      provenance: "expected_obu_invocation",
+      probeCommandSource: "expected_obu_invocation",
+      mcpConfigured: true,
+      mcpStarts: false,
+      sdkBootstrap: "not_checked",
+      backendCount: 0,
+      backends: [],
+      reason: `MCP command is not executable: ${options.server.command}`,
+      details: { command: options.server.command, args: options.server.args },
+    };
+  }
+
+  try {
+    const rawStatus = await runMcpBrowserStatusProbe(options.server.command, options.server.args, {
+      ...process.env,
+      ...(options.env ?? {}),
+      OBU_RUNTIME_DIR: options.layout.runtimeDir,
+    }, options.mcpProbeTimeoutMs ?? DEFAULT_MCP_PROBE_TIMEOUT_MS);
+    const rawBackends = Array.isArray(rawStatus.backends) ? rawStatus.backends : [];
+    const backends = rawBackends.map((backend) => normalizeBackend(backend, options));
+    const usable = backends.filter((backend) => backend.extensionIdentity.verified);
+    const sdkBootstrap = typeof rawStatus.sdk_bootstrap === "string" ? rawStatus.sdk_bootstrap : "missing";
+    return {
+      source: "direct_mcp_probe",
+      provenance: "expected_obu_invocation",
+      probeCommandSource: "expected_obu_invocation",
+      mcpConfigured: true,
+      mcpStarts: true,
+      sdkBootstrap,
+      backendCount: usable.length,
+      backends: usable,
+      ...(sdkBootstrap !== "available" ? { reason: `sdk bootstrap is ${sdkBootstrap}` } : usable.length === 0 ? { reason: "direct MCP probe found zero usable browser backends" } : {}),
+      details: { raw: rawStatus },
+    };
+  } catch (error) {
+    return {
+      source: "direct_mcp_probe",
+      provenance: "expected_obu_invocation",
+      probeCommandSource: "expected_obu_invocation",
+      mcpConfigured: true,
+      mcpStarts: false,
+      sdkBootstrap: "not_checked",
+      backendCount: 0,
+      backends: [],
+      reason: `direct MCP probe failed: ${error instanceof Error ? error.message : String(error)}`,
+      details: { command: options.server.command, args: options.server.args },
+    };
+  }
+}
+
+function runMcpBrowserStatusProbe(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): Promise<Record<string, any>> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { env, stdio: ["pipe", "pipe", "pipe"] });
+    let stdoutBuffer = "";
+    let stderr = "";
+    let settled = false;
+    const pending = new Map<number, (value: RpcResponse) => void>();
+    const timer = setTimeout(() => {
+      finish(new Error(`timed out after ${timeoutMs}ms`));
+    }, Math.max(1, timeoutMs));
+    const finish = (result: Error | Record<string, any>) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill("SIGTERM");
+      if (result instanceof Error) reject(result);
+      else resolve(result);
+    };
+    const send = (payload: Record<string, unknown>) => {
+      child.stdin.write(`${JSON.stringify(payload)}\n`);
+    };
+    const request = (id: number, method: string, params: Record<string, unknown>) => new Promise<RpcResponse>((requestResolve) => {
+      pending.set(id, requestResolve);
+      send({ jsonrpc: "2.0", id, method, params });
+    });
+    child.once("error", (error) => finish(error));
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdoutBuffer += chunk;
+      for (;;) {
+        const index = stdoutBuffer.indexOf("\n");
+        if (index < 0) break;
+        const line = stdoutBuffer.slice(0, index).trim();
+        stdoutBuffer = stdoutBuffer.slice(index + 1);
+        if (line.length === 0) continue;
+        let message: RpcResponse;
+        try {
+          message = JSON.parse(line);
+        } catch (error) {
+          finish(new Error(`invalid MCP JSON response: ${String(error)}`));
+          return;
+        }
+        const id = typeof message.id === "number" ? message.id : undefined;
+        if (id !== undefined) {
+          const resolver = pending.get(id);
+          if (resolver) {
+            pending.delete(id);
+            resolver(message);
+          }
+        }
+      }
+    });
+    child.once("exit", (code) => {
+      if (!settled && code !== 0) finish(new Error(`MCP process exited with code ${code}; stderr: ${stderr.trim()}`));
+    });
+
+    (async () => {
+      const init = await request(1, "initialize", {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "obu-verify", version: "0.0.0" },
+      });
+      if (init.error) throw new Error(`initialize failed: ${JSON.stringify(init.error)}`);
+      send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+      const status = await request(2, "tools/call", {
+        name: "browser_status",
+        arguments: {},
+      });
+      if (status.error) throw new Error(`browser_status failed: ${JSON.stringify(status.error)}`);
+      const structured = status.result?.structuredContent;
+      if (!isRecord(structured)) throw new Error("browser_status returned no structuredContent");
+      finish(structured);
+    })().catch((error) => finish(error instanceof Error ? error : new Error(String(error))));
+  });
+}
+
+async function probeRuntimeDescriptor(options: VerifyOptions, target: VerifyTarget): Promise<RuntimeDescriptorProbe> {
+  const descriptorDir = path.join(options.layout.runtimeDir, "webextension");
+  const dirStats = await lstat(descriptorDir).catch((error) => error as NodeJS.ErrnoException);
+  if (dirStats instanceof Error) {
+    if (dirStats.code === "ENOENT") {
+      return {
+        status: "fail",
+        state: "missing",
+        reason: "descriptor_dir_missing",
+        message: `runtime descriptor directory missing at ${descriptorDir}`,
+        result: "needs_repair",
+        details: { path: descriptorDir },
+      };
+    }
+    return {
+      status: "fail",
+      state: "unreadable",
+      reason: "descriptor_dir_unreadable",
+      message: `runtime descriptor directory cannot be read: ${descriptorDir}`,
+      result: "needs_repair",
+      details: { path: descriptorDir, error: dirStats.message },
+    };
+  }
+  if (dirStats.isSymbolicLink() || !dirStats.isDirectory()) {
+    return {
+      status: "fail",
+      state: "invalid",
+      reason: "descriptor_dir_invalid",
+      message: `runtime descriptor path is not an owner-only directory: ${descriptorDir}`,
+      result: "needs_repair",
+      details: { path: descriptorDir },
+    };
+  }
+  const ownerIssue = ownerOnlyIssue(dirStats, "runtime descriptor directory");
+  if (ownerIssue) {
+    return {
+      status: "fail",
+      state: "invalid",
+      reason: "descriptor_dir_permissions",
+      message: ownerIssue,
+      result: "needs_repair",
+      details: { path: descriptorDir },
+    };
+  }
+
+  const files = (await readdir(descriptorDir).catch(() => [])).filter((entry) => entry.endsWith(".json")).sort();
+  if (files.length === 0) {
+    return {
+      status: "fail",
+      state: "missing",
+      reason: "descriptor_missing",
+      message: "no active WebExtension descriptor found",
+      result: "needs_browser_popup",
+      details: {
+        resumeRequired: true,
+        resumeAction: "open the open-browser-use extension popup; click Resume if it is enabled, otherwise wait for Connected and rerun verify",
+      },
+    };
+  }
+
+  const errors: string[] = [];
+  for (const file of files) {
+    const descriptorPath = path.join(descriptorDir, file);
+    const fileIssue = await validateDescriptorFile(descriptorPath);
+    if (fileIssue) {
+      errors.push(`${file}: ${fileIssue}`);
+      continue;
+    }
+    const descriptor = await readJson(descriptorPath).catch((error) => {
+      errors.push(`${file}: invalid json (${error})`);
+      return undefined;
+    });
+    if (!isRecord(descriptor)) continue;
+    const probe = await probeOneDescriptor(descriptor, descriptorPath, file, options);
+    if (probe.status === "pass") return probe;
+    errors.push(`${file}: ${probe.message}`);
+  }
+
+  return {
+    status: "fail",
+    state: errors.some((error) => /extension id|browser kind|unknown/.test(error)) ? "invalid" : "stale",
+    reason: "descriptor_unusable",
+    message: errors.length > 0 ? errors.join("; ") : "no usable WebExtension descriptor found",
+    result: errors.some((error) => /extension id|browser kind|unknown/.test(error)) ? "needs_browser_popup" : "needs_repair",
+    details: {
+      resumeRequired: true,
+      descriptorErrors: errors,
+    },
+  };
+}
+
+async function probeOneDescriptor(
+  descriptor: Record<string, unknown>,
+  descriptorPath: string,
+  descriptorFile: string,
+  options: VerifyOptions,
+): Promise<RuntimeDescriptorProbe> {
+  if (descriptor.schema_version !== 1) return descriptorFailure("schema_version must be 1");
+  if (descriptor.type !== "webextension") return descriptorFailure("type must be webextension");
+  if (typeof descriptor.socketPath !== "string") return descriptorFailure("socketPath missing");
+  if (typeof descriptor.sdk_auth_token !== "string") return descriptorFailure("sdk_auth_token missing");
+  const processIssue = descriptorProcessIssue(descriptor);
+  if (processIssue) return descriptorFailure(processIssue);
+  const socketIssue = await validateDescriptorSocket(descriptor.socketPath);
+  if (socketIssue) return descriptorFailure(socketIssue);
+  try {
+    const [auth, info] = await rpcSequenceOverUnixSocket(descriptor.socketPath, [
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "auth",
+        params: { capability_token: descriptor.sdk_auth_token },
+      },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "getInfo",
+        params: {},
+      },
+    ]);
+    if (auth?.error) return descriptorFailure("auth rejected");
+    if (info?.error) return descriptorFailure(`getInfo failed: ${JSON.stringify(info.error)}`);
+    if (info?.result?.type !== "webextension") return descriptorFailure("getInfo type mismatch");
+    if (info?.result?.name !== descriptor.name) return descriptorFailure("getInfo name mismatch");
+    const metadata = mergedDescriptorMetadata(descriptor, info.result);
+    const browserKind = stringFromPath(metadata, ["browser_kind"]) ?? String(descriptor.name ?? "");
+    const extensionId = stringFromPath(metadata, ["extension_id"]) ?? "unknown";
+    if (browserKind !== runtimeBrowserKind(options.browser)) {
+      return descriptorFailure(`descriptor browser kind ${browserKind || "unknown"} does not match ${runtimeBrowserKind(options.browser)}`);
+    }
+    if (extensionId !== options.extensionId) {
+      return descriptorFailure(`descriptor extension id ${extensionId} does not match ${options.extensionId}`);
+    }
+    const profilePath = descriptorProfilePath(metadata);
+    return {
+      status: "pass",
+      state: "pass",
+      message: `${descriptorFile} responded to getInfo`,
+      descriptorFile,
+      descriptorPath,
+      metadata,
+      browserKind,
+      extensionId,
+      ...(profilePath ? { profilePath } : {}),
+      details: {
+        descriptor: descriptorFile,
+        descriptorPath,
+        source: "runtime_descriptor_probe",
+        resumeRequired: false,
+        metadata,
+      },
+    };
+  } catch (error) {
+    return descriptorFailure(`socket probe failed: ${String(error)}`);
+  }
+}
+
+function descriptorFailure(message: string): RuntimeDescriptorProbe {
+  return {
+    status: "fail",
+    state: "invalid",
+    reason: "descriptor_invalid",
+    message,
+    result: "needs_repair",
+  };
+}
+
+async function defaultProfileCandidates(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  const candidates = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(root, entry.name);
+    if (entry.name === "NativeMessagingHosts") continue;
+    if (entry.name === "Default" || /^Profile \d+$/.test(entry.name)) {
+      candidates.push(candidate);
+      continue;
+    }
+    if (await access(path.join(candidate, "Preferences"), constants.R_OK).then(() => true).catch(() => false)) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates.sort(compareProfilePaths);
+}
+
+async function inspectProfileCandidate(profilePath: string, extensionId: string): Promise<ProfileCandidate> {
+  const stats = await lstat(profilePath).catch((error) => error as NodeJS.ErrnoException);
+  if (stats instanceof Error) {
+    const missing = stats.code === "ENOENT";
+    return {
+      path: profilePath,
+      profileExists: missing ? "missing" : "unreadable",
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        profileExists: missing ? "profile path does not exist" : `profile path cannot be inspected: ${stats.message}`,
+        extensionInstalled: "extension state cannot be inspected until the profile exists and is readable",
+        extensionEnabled: "extension state cannot be inspected until the profile exists and is readable",
+      },
+    };
+  }
+  if (!stats.isDirectory()) {
+    return {
+      path: profilePath,
+      profileExists: "unreadable",
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        profileExists: "profile path is not a directory",
+        extensionInstalled: "extension state cannot be inspected until the profile path is a readable directory",
+        extensionEnabled: "extension state cannot be inspected until the profile path is a readable directory",
+      },
+    };
+  }
+  if (!await access(profilePath, constants.R_OK).then(() => true).catch(() => false)) {
+    return {
+      path: profilePath,
+      profileExists: "unreadable",
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        profileExists: "profile directory is not readable",
+        extensionInstalled: "extension state cannot be inspected until the profile is readable",
+        extensionEnabled: "extension state cannot be inspected until the profile is readable",
+      },
+    };
+  }
+
+  const preferenceFiles = [
+    path.join(profilePath, "Preferences"),
+    path.join(profilePath, "Secure Preferences"),
+  ];
+  let sawPreferenceFile = false;
+  for (const file of preferenceFiles) {
+    const preferences = await readJson(file).catch((error) => {
+      const nodeError = error as NodeJS.ErrnoException;
+      if (nodeError.code === "ENOENT") return undefined;
+      return { __obu_read_error: nodeError.message ?? String(error) };
+    });
+    if (preferences === undefined) continue;
+    sawPreferenceFile = true;
+    if (isRecord(preferences) && typeof preferences.__obu_read_error === "string") {
+      return {
+        path: profilePath,
+        profileExists: "unreadable",
+        extensionInstalled: "not_checked",
+        extensionEnabled: "not_checked",
+        reasons: {
+          profileExists: `profile preferences cannot be read: ${preferences.__obu_read_error}`,
+          extensionInstalled: "extension state cannot be inspected until profile preferences are readable",
+          extensionEnabled: "extension state cannot be inspected until profile preferences are readable",
+        },
+      };
+    }
+    const settings = extensionSettings(preferences, extensionId);
+    if (!settings) continue;
+    if (settings.state === 0 || hasDisableReasons(settings.disable_reasons)) {
+      return {
+        path: profilePath,
+        profileExists: "pass",
+        extensionInstalled: "pass",
+        extensionEnabled: "disabled",
+        reasons: {
+          extensionEnabled: `extension is disabled in ${file}`,
+        },
+      };
+    }
+    return {
+      path: profilePath,
+      profileExists: "pass",
+      extensionInstalled: "pass",
+      extensionEnabled: "pass",
+    };
+  }
+  return {
+    path: profilePath,
+    profileExists: "pass",
+    extensionInstalled: "missing",
+    extensionEnabled: "not_checked",
+    reasons: {
+      extensionInstalled: sawPreferenceFile
+        ? `extension ${extensionId} was not found in profile preferences`
+        : "profile preferences do not exist yet",
+      extensionEnabled: "enablement was not inspected because the extension is missing",
+    },
+  };
+}
+
+function extensionSettings(preferences: unknown, extensionId: string): Record<string, any> | undefined {
+  if (!isRecord(preferences)) return undefined;
+  const extensions = preferences.extensions;
+  if (!isRecord(extensions)) return undefined;
+  const settings = extensions.settings;
+  if (!isRecord(settings)) return undefined;
+  const extension = settings[extensionId];
+  return isRecord(extension) ? extension : undefined;
+}
+
+function hasDisableReasons(value: unknown): boolean {
+  if (value === undefined || value === null || value === false || value === 0) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true;
+}
+
+function runtimeBindingForResolvedProfile(input: {
+  options: VerifyOptions;
+  descriptor: RuntimeDescriptorProbe;
+  candidate: ProfileCandidate;
+  source: "explicit" | "default_discovery";
+  matchingCount: number;
+  explicit: boolean;
+}): RuntimeBinding {
+  if (input.descriptor.status !== "pass") return "not_available";
+  if (input.descriptor.profilePath && samePath(input.descriptor.profilePath, input.candidate.path)) return "profile_verified";
+  if (input.explicit) return "browser_extension_scope";
+  if (input.matchingCount === 1) return "single_candidate";
+  return "browser_extension_scope";
+}
+
+function computeReadiness(verificationTarget: VerificationTarget, checks: VerifyCheck[]): VerifyReport["readiness"] {
+  const cliBlocked = checks.some((check) => check.status === "fail" && check.blocks?.includes("cli"));
+  const agentRuntimeBlocked = checks.some((check) => check.status === "fail" && check.blocks?.includes("agent_runtime"));
+  return {
+    cli: cliBlocked ? "blocked" : "ready",
+    agentRuntime: verificationTarget === "cli" ? "not_checked" : cliBlocked ? "not_checked" : agentRuntimeBlocked ? "blocked" : "ready",
+  };
+}
+
+function selectResultAndAction(
+  verificationTarget: VerificationTarget,
+  readiness: VerifyReport["readiness"],
+  checks: VerifyCheck[],
+): { result: VerifyResult; nextAction: VerifyNextAction | null } {
+  const eligible = readiness.cli !== "ready"
+    ? checks.filter((check) => check.status === "fail" && check.blocks?.includes("cli"))
+    : verificationTarget === "agent_runtime" && readiness.agentRuntime !== "ready"
+      ? checks.filter((check) => check.status === "fail" && check.blocks?.includes("agent_runtime"))
+      : [];
+  if (eligible.length === 0) return { result: "ready", nextAction: null };
+  const candidates = eligible.flatMap((check) => check.actionCandidate ? [{ check, candidate: check.actionCandidate }] : []);
+  if (candidates.length === 0) {
+    return {
+      result: "needs_manual_action",
+      nextAction: {
+        kind: "unsupported",
+        message: "Verification found a blocking state without an automated next action.",
+      },
+    };
+  }
+  candidates.sort((left, right) => {
+    const resultDelta = resultPriority[left.candidate.result] - resultPriority[right.candidate.result];
+    if (resultDelta !== 0) return resultDelta;
+    const actionDelta = left.candidate.priority - right.candidate.priority;
+    if (actionDelta !== 0) return actionDelta;
+    return layerOrder.indexOf(left.check.layer) - layerOrder.indexOf(right.check.layer);
+  });
+  const selected = candidates[0]!.candidate;
+  const { result, priority, ...nextAction } = selected;
+  return { result, nextAction };
+}
+
+function agentMcpSummary(
+  options: VerifyOptions,
+  doctorCheck: AgentDoctorCheck | undefined,
+  normalized: VerifyCheck,
+): VerifyAgent["mcpConfig"] {
+  const details = doctorCheck?.details;
+  const summary: VerifyAgent["mcpConfig"] = {
+    status: normalized.status,
+    serverName: SERVER_NAME,
+    command: options.server.command,
+    args: options.server.args,
+  };
+  if (isRecord(details) && typeof details.path === "string") summary.path = details.path;
+  if (normalized.reason) summary.reason = normalized.reason;
+  if (details) summary.details = details;
+  return summary;
+}
+
+function agentInstructionSummary(
+  doctorCheck: AgentDoctorCheck | undefined,
+  normalized: VerifyCheck,
+): VerifyAgent["instructions"] {
+  const summary: VerifyAgent["instructions"] = {
+    status: normalized.status,
+  };
+  if (normalized.reason === "missing_instruction" || normalized.reason === "not_implemented") summary.reason = normalized.reason;
+  if (isRecord(doctorCheck?.details) && typeof doctorCheck.details.path === "string") summary.path = doctorCheck.details.path;
+  return summary;
+}
+
+function notCheckedMcpRuntime(reason: string): McpRuntimeStatus {
+  return {
+    source: "not_checked",
+    provenance: "not_applicable",
+    probeCommandSource: "not_applicable",
+    mcpConfigured: true,
+    mcpStarts: null,
+    sdkBootstrap: "not_checked",
+    backendCount: null,
+    backends: [],
+    reason,
+  };
+}
+
+function notCheckedAgentRuntimeMcp(reason: string): McpRuntimeStatus {
+  return {
+    source: "not_checked",
+    provenance: "not_applicable",
+    probeCommandSource: "not_applicable",
+    mcpConfigured: true,
+    mcpStarts: null,
+    sdkBootstrap: "not_checked",
+    backendCount: null,
+    backends: [],
+    reason,
+  };
+}
+
+function normalizeBackend(value: unknown, options: VerifyOptions): NormalizedBackend {
+  const row = isRecord(value) ? value : {};
+  const metadata = isRecord(row.metadata) ? row.metadata : {};
+  const browserKind = typeof metadata.browser_kind === "string" ? metadata.browser_kind : typeof row.name === "string" ? row.name : undefined;
+  const extensionId = typeof metadata.extension_id === "string" ? metadata.extension_id : undefined;
+  const verified = row.type === "webextension" &&
+    browserKind === runtimeBrowserKind(options.browser) &&
+    extensionId === options.extensionId;
+  return {
+    type: typeof row.type === "string" ? row.type : "unknown",
+    browser: browserKind ?? null,
+    extensionId: extensionId ?? null,
+    extensionIdentity: {
+      source: extensionId ? "descriptor_metadata" : "missing",
+      verified,
+    },
+    metadata: {
+      ...(browserKind ? { browserKind } : {}),
+      ...(extensionId ? { extensionId } : {}),
+      raw: metadata,
+    },
+  };
+}
+
+async function writeAgentRuntimeChallenge(file: string, options: VerifyOptions, hook: TrustedRuntimeHook | undefined): Promise<void> {
+  const nonce = randomBytes(24).toString("hex");
+  const resultPath = hook ? trustedRuntimeResultPath(options.layout.runtimeDir, hook, nonce) : undefined;
+  const payload = {
+    schemaVersion: 1,
+    agentId: options.agent,
+    mcpServerName: SERVER_NAME,
+    challenge: {
+      nonce,
+      issuedAt: new Date().toISOString(),
+    },
+    target: {
+      browser: options.browser,
+      channel: options.channel,
+      extensionId: options.extensionId,
+      ...(options.profile ? { profile: options.profile } : {}),
+    },
+    ...(hook ? { trustedHook: hook } : {}),
+    ...(resultPath ? { trustedHookResult: { path: resultPath } } : {}),
+  };
+  await mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+  if (resultPath) {
+    await mkdir(path.dirname(resultPath), { recursive: true, mode: 0o700 });
+    if (process.platform !== "win32") await chmod(path.dirname(resultPath), 0o700);
+  }
+  await writeFile(file, `${JSON.stringify(payload, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  if (process.platform !== "win32") await chmod(file, 0o600);
+}
+
+async function diagnosticStatusFileBinding(options: VerifyOptions): Promise<{
+  statusFile: string;
+  targetBound: boolean;
+  challengeBound: boolean;
+}> {
+  const statusFile = options.agentRuntimeStatusJson!;
+  const payload = await readJson(statusFile).catch(() => undefined);
+  const challenge = options.agentRuntimeChallengeJson ? await readJson(options.agentRuntimeChallengeJson).catch(() => undefined) : undefined;
+  const targetBound = isRecord(payload) && isRecord(payload.target) &&
+    payload.agentId === options.agent &&
+    payload.mcpServerName === SERVER_NAME &&
+    payload.target.browser === options.browser &&
+    payload.target.channel === options.channel &&
+    payload.target.extensionId === options.extensionId &&
+    ((options.profile ?? undefined) === (typeof payload.target.profile === "string" ? payload.target.profile : undefined));
+  const challengeBound = isRecord(payload) && isRecord(payload.challenge) && isRecord(challenge) && isRecord(challenge.challenge) &&
+    payload.challenge.nonce === challenge.challenge.nonce;
+  return { statusFile, targetBound, challengeBound };
+}
+
+async function readTrustedRuntimeHookResult(options: VerifyOptions, hook: TrustedRuntimeHook | undefined): Promise<TrustedRuntimeResult> {
+  if (!hook) {
+    return {
+      status: "pending",
+      reason: "agent_runtime_hook_unavailable",
+      message: `no trusted agent-runtime hook is registered for ${options.agent}`,
+    };
+  }
+  const challenge = await readAgentRuntimeChallenge(options, hook);
+  if (challenge.status === "fail") return challenge;
+
+  const resultPath = trustedRuntimeResultPath(options.layout.runtimeDir, hook, challenge.nonce);
+  const payload = await readJson(resultPath).catch((error) => {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") return undefined;
+    return { __obu_read_error: nodeError.message ?? String(error) };
+  });
+  if (payload === undefined) {
+    return {
+      status: "pending",
+      reason: "agent_runtime_challenge_pending",
+      message: "trusted agent-runtime hook result has not been delivered for this challenge",
+      details: { challengePath: options.agentRuntimeChallengeJson, resultPath },
+    };
+  }
+  if (isRecord(payload) && typeof payload.__obu_read_error === "string") {
+    return {
+      status: "fail",
+      reason: "agent_runtime_result_unreadable",
+      message: "trusted agent-runtime hook result could not be read",
+      mcpRuntime: notCheckedAgentRuntimeMcp("agent_runtime_result_unreadable"),
+      details: { challengePath: options.agentRuntimeChallengeJson, resultPath, error: payload.__obu_read_error },
+    };
+  }
+  return validateTrustedRuntimeEnvelope(payload, options, hook, challenge, resultPath);
+}
+
+async function readAgentRuntimeChallenge(
+  options: VerifyOptions,
+  hook: TrustedRuntimeHook,
+): Promise<
+  | { status: "pass"; nonce: string; issuedAt?: string }
+  | Extract<TrustedRuntimeResult, { status: "fail" }>
+> {
+  const challengePath = options.agentRuntimeChallengeJson!;
+  const payload = await readJson(challengePath).catch((error) => {
+    const nodeError = error as NodeJS.ErrnoException;
+    return { __obu_read_error: nodeError.message ?? String(error) };
+  });
+  if (!isRecord(payload)) {
+    return trustedHookFailure("agent_runtime_challenge_invalid", "agent-runtime challenge JSON is not an object", { challengePath });
+  }
+  if (typeof payload.__obu_read_error === "string") {
+    return trustedHookFailure("agent_runtime_challenge_unreadable", "agent-runtime challenge JSON could not be read", {
+      challengePath,
+      error: payload.__obu_read_error,
+    });
+  }
+  const challengeRecord = isRecord(payload.challenge) ? payload.challenge : {};
+  const nonce = typeof challengeRecord.nonce === "string" ? challengeRecord.nonce : undefined;
+  if (!nonce) {
+    return trustedHookFailure("agent_runtime_challenge_invalid", "agent-runtime challenge is missing a nonce", { challengePath });
+  }
+  const targetBound =
+    payload.schemaVersion === 1 &&
+    payload.agentId === options.agent &&
+    payload.mcpServerName === SERVER_NAME &&
+    targetMatches(payload.target, options);
+  if (!targetBound) {
+    return trustedHookFailure("agent_runtime_challenge_target_mismatch", "agent-runtime challenge does not match this verification target", {
+      challengePath,
+      target: payload.target,
+    });
+  }
+  const challengeHook = isRecord(payload.trustedHook) ? payload.trustedHook : undefined;
+  if (challengeHook && (challengeHook.id !== hook.id || challengeHook.transport !== hook.transport)) {
+    return trustedHookFailure("agent_runtime_challenge_hook_mismatch", "agent-runtime challenge was issued for a different trusted hook", {
+      challengePath,
+      trustedHook: challengeHook,
+    });
+  }
+  return {
+    status: "pass",
+    nonce,
+    ...(typeof challengeRecord.issuedAt === "string" ? { issuedAt: challengeRecord.issuedAt } : {}),
+  };
+}
+
+function validateTrustedRuntimeEnvelope(
+  payload: unknown,
+  options: VerifyOptions,
+  hook: TrustedRuntimeHook,
+  challenge: { nonce: string; issuedAt?: string },
+  resultPath: string,
+): TrustedRuntimeResult {
+  const detailsBase = { challengePath: options.agentRuntimeChallengeJson, resultPath };
+  if (!isRecord(payload)) {
+    return trustedHookFailure("agent_runtime_result_invalid", "trusted agent-runtime hook result is not an object", detailsBase);
+  }
+  const payloadHook = isRecord(payload.hook) ? payload.hook : undefined;
+  const hookBound = payloadHook?.id === hook.id && payloadHook.transport === hook.transport;
+  const targetBound =
+    payload.schemaVersion === 1 &&
+    payload.agentId === options.agent &&
+    payload.mcpServerName === SERVER_NAME &&
+    payload.provenance === "agent_runtime_hook" &&
+    targetMatches(payload.target, options);
+  const challengeBound = isRecord(payload.challenge) && payload.challenge.nonce === challenge.nonce;
+  const generatedAt = typeof payload.generatedAt === "string" ? payload.generatedAt : undefined;
+  const generatedAtMs = generatedAt === undefined ? NaN : Date.parse(generatedAt);
+  const fresh = Number.isFinite(generatedAtMs) &&
+    generatedAtMs <= Date.now() + 5_000 &&
+    Date.now() - generatedAtMs <= AGENT_RUNTIME_FRESHNESS_MS;
+  if (!hookBound || !targetBound || !challengeBound || generatedAt === undefined || !fresh) {
+    return trustedHookFailure("agent_runtime_result_untrusted", "trusted agent-runtime hook result is stale, unbound, or from the wrong hook", {
+      ...detailsBase,
+      hookBound,
+      targetBound,
+      challengeBound,
+      fresh,
+      generatedAt,
+    });
+  }
+  const trustedGeneratedAt = generatedAt;
+
+  const statusPayload = isRecord(payload.status) ? payload.status : {};
+  const rawBackends = Array.isArray(statusPayload.backends) ? statusPayload.backends : [];
+  const backends = rawBackends.map((backend) => normalizeBackend(backend, options));
+  const usable = backends.filter((backend) => backend.extensionIdentity.verified);
+  const sdkBootstrap = typeof statusPayload.sdk_bootstrap === "string" ? statusPayload.sdk_bootstrap : "missing";
+  const mcpRuntime: McpRuntimeStatus = {
+    source: "agent_runtime",
+    provenance: "agent_runtime_hook",
+    probeCommandSource: "agent_runtime_hook",
+    mcpConfigured: true,
+    mcpStarts: true,
+    sdkBootstrap,
+    backendCount: usable.length,
+    backends: usable,
+    details: { raw: statusPayload, resultPath },
+    ...(sdkBootstrap !== "available" ? { reason: `agent-runtime sdk bootstrap is ${sdkBootstrap}` } : usable.length === 0 ? { reason: "agent-runtime hook reported zero usable browser backends" } : {}),
+  };
+  if (sdkBootstrap !== "available") {
+    return {
+      status: "fail",
+      reason: "agent_runtime_sdk_unavailable",
+      message: `agent-runtime MCP status reported sdk bootstrap ${sdkBootstrap}`,
+      mcpRuntime,
+      details: { ...detailsBase, generatedAt },
+    };
+  }
+  if (usable.length === 0) {
+    return {
+      status: "fail",
+      reason: "agent_runtime_zero_backends",
+      message: "agent-runtime MCP status reported zero usable browser backends",
+      mcpRuntime,
+      details: { ...detailsBase, generatedAt },
+    };
+  }
+  return {
+    status: "pass",
+    runtimeStatus: {
+      status: "pass",
+      provenance: "agent_runtime_hook",
+      hook: { ...hook, trusted: true },
+      generatedAt: trustedGeneratedAt,
+      targetBound: true,
+      challengeBound: true,
+    },
+    mcpRuntime,
+    details: { ...detailsBase, generatedAt: trustedGeneratedAt, backendCount: usable.length },
+  };
+}
+
+function trustedHookFailure(reason: string, message: string, details?: Record<string, unknown>): Extract<TrustedRuntimeResult, { status: "fail" }> {
+  return {
+    status: "fail",
+    reason,
+    message,
+    mcpRuntime: notCheckedAgentRuntimeMcp(reason),
+    ...(details ? { details } : {}),
+  };
+}
+
+function targetMatches(value: unknown, options: VerifyOptions): boolean {
+  if (!isRecord(value)) return false;
+  return value.browser === options.browser &&
+    value.channel === options.channel &&
+    value.extensionId === options.extensionId &&
+    ((options.profile ?? undefined) === (typeof value.profile === "string" ? value.profile : undefined));
+}
+
+type TrustedRuntimeHook = {
+  id: string;
+  transport: "agent_connector" | "agent_owned_ipc" | "in_process_adapter";
+};
+
+function trustedRuntimeHook(agent: AgentId): TrustedRuntimeHook | undefined {
+  if (agent === "codex-cli") {
+    return {
+      id: "codex-cli-runtime-status",
+      transport: "agent_connector",
+    };
+  }
+  return undefined;
+}
+
+function trustedRuntimeResultPath(runtimeDir: string, hook: TrustedRuntimeHook, nonce: string): string {
+  const nonceHash = createHash("sha256").update(nonce).digest("hex");
+  return path.join(runtimeDir, "agent-runtime", hook.id, `${nonceHash}.json`);
+}
+
+function passCheck(input: {
+  id: string;
+  layer: VerifyLayer;
+  message: string;
+  target: VerifyTarget;
+  evidence: Evidence;
+  details?: Record<string, unknown>;
+}): VerifyCheck {
+  return {
+    id: input.id,
+    layer: input.layer,
+    status: "pass",
+    message: input.message,
+    target: input.target,
+    evidence: input.evidence,
+    ...(input.details && Object.keys(input.details).length > 0 ? { details: input.details } : {}),
+  };
+}
+
+function warnCheck(input: {
+  id: string;
+  layer: VerifyLayer;
+  reason: string;
+  message: string;
+  target: VerifyTarget;
+  evidence: Evidence;
+  details?: Record<string, unknown>;
+}): VerifyCheck {
+  return {
+    id: input.id,
+    layer: input.layer,
+    status: "warn",
+    reason: input.reason,
+    message: input.message,
+    target: input.target,
+    evidence: input.evidence,
+    ...(input.details && Object.keys(input.details).length > 0 ? { details: input.details } : {}),
+  };
+}
+
+function notCheckedCheck(input: {
+  id: string;
+  layer: VerifyLayer;
+  reason: string;
+  message: string;
+  target: VerifyTarget;
+  evidence: Evidence;
+  details?: Record<string, unknown>;
+}): VerifyCheck {
+  return {
+    id: input.id,
+    layer: input.layer,
+    status: "not_checked",
+    reason: input.reason,
+    message: input.message,
+    target: input.target,
+    evidence: input.evidence,
+    ...(input.details && Object.keys(input.details).length > 0 ? { details: input.details } : {}),
+  };
+}
+
+function failCheck(input: {
+  id: string;
+  layer: VerifyLayer;
+  reason: string;
+  message: string;
+  target: VerifyTarget;
+  evidence: Evidence;
+  details?: Record<string, unknown>;
+  blocks?: Array<"cli" | "agent_runtime">;
+  actionCandidate?: ActionCandidate;
+}): VerifyCheck {
+  return {
+    id: input.id,
+    layer: input.layer,
+    status: "fail",
+    reason: input.reason,
+    message: input.message,
+    target: input.target,
+    evidence: input.evidence,
+    blocks: input.blocks ?? ["cli"],
+    ...(input.details && Object.keys(input.details).length > 0 ? { details: input.details } : {}),
+    ...(input.actionCandidate ? { actionCandidate: input.actionCandidate } : {}),
+  };
+}
+
+function expectedEvidence(source: string): Evidence {
+  return {
+    scope: "cli",
+    provenance: "expected_obu_invocation",
+    source,
+  };
+}
+
+function runtimeEvidence(source: string): Evidence {
+  return {
+    scope: "browser_extension",
+    provenance: "runtime_descriptor_probe",
+    source,
+  };
+}
+
+function repairAction(command: string, message: string): ActionCandidate {
+  return {
+    result: "needs_repair",
+    kind: "run_repair",
+    priority: 1,
+    message,
+    command,
+  };
+}
+
+function openPopupAction(options: VerifyOptions, profile: string | null): ActionCandidate {
+  return {
+    result: "needs_browser_popup",
+    kind: "open_popup",
+    priority: 1,
+    message: "Open the open-browser-use extension popup. Click Resume if enabled; otherwise wait for Connected and rerun verify.",
+    url: `chrome-extension://${options.extensionId}/popup.html`,
+    browser: options.browser,
+    profile: { path: profile },
+    rerun: verifyCommand(options),
+  };
+}
+
+function selectProfileAction(options: VerifyOptions, suggestedPath: string | null, message: string): ActionCandidate {
+  return {
+    result: "needs_manual_action",
+    kind: "select_profile",
+    priority: manualActionPriority.select_profile,
+    message,
+    browser: options.browser,
+    profile: options.profile ? { path: options.profile, suggestedPath: null } : { path: null, suggestedPath },
+    rerun: verifyCommand(options),
+  };
+}
+
+function configureAgentAction(options: VerifyOptions, message: string): ActionCandidate {
+  return {
+    result: "needs_manual_action",
+    kind: "configure_agent",
+    priority: manualActionPriority.configure_agent,
+    message,
+    command: mcpConfigCommand(options),
+  };
+}
+
+function collectAgentRuntimeAction(
+  options: VerifyOptions,
+  hook: TrustedRuntimeHook | undefined,
+  challengePath: string | undefined,
+  message: string,
+): ActionCandidate {
+  return {
+    result: "needs_manual_action",
+    kind: "collect_agent_runtime_status",
+    priority: manualActionPriority.collect_agent_runtime_status,
+    message,
+    ...(challengePath ? { challenge: { path: challengePath } } : {}),
+    ...(hook ? { trustedHook: hook } : {}),
+    rerun: appendShellArgs(options.commandPrefix, verifyArgs(options, false, challengePath ? { agentRuntimeChallengeJson: challengePath } : {})),
+  };
+}
+
+function verifyCommand(options: VerifyOptions): string {
+  return appendShellArgs(options.commandPrefix, verifyArgs(options, false));
+}
+
+function repairCommand(options: VerifyOptions): string {
+  return appendShellArgs(options.commandPrefix, verifyArgs(options, true));
+}
+
+function mcpConfigCommand(options: VerifyOptions): string {
+  return appendShellArgs(options.commandPrefix, ["mcp-config", `--agent=${options.agent}`, "--print"]);
+}
+
+function verifyArgs(options: VerifyOptions, repair: boolean, extra: { agentRuntimeChallengeJson?: string } = {}): string[] {
+  const args = [
+    "verify",
+    `--agent=${options.agent}`,
+    `--browser=${options.browser}`,
+    `--channel=${options.channel}`,
+    `--extension-id=${options.extensionId}`,
+  ];
+  if (options.profile) args.push(`--profile=${options.profile}`);
+  if (options.requireAgentRuntime) args.push("--require-agent-runtime");
+  if (extra.agentRuntimeChallengeJson) args.push(`--agent-runtime-challenge-json=${extra.agentRuntimeChallengeJson}`);
+  if (repair) args.push("--repair");
+  return args;
+}
+
+function homeDirFromLayout(layout: RuntimeLayout): string | undefined {
+  const obuDir = path.dirname(layout.userConfigPath);
+  return path.basename(obuDir) === ".obu" ? path.dirname(obuDir) : undefined;
+}
+
+function runtimeBrowserKind(browser: BrowserKind): string {
+  return browser === "chrome-for-testing" ? "chrome" : browser;
+}
+
+function compareProfilePaths(left: string, right: string): number {
+  const leftName = path.basename(left);
+  const rightName = path.basename(right);
+  const leftRank = profileSortRank(leftName);
+  const rightRank = profileSortRank(rightName);
+  if (leftRank[0] !== rightRank[0]) return leftRank[0] - rightRank[0];
+  if (leftRank[1] !== rightRank[1]) return leftRank[1] - rightRank[1];
+  return path.resolve(left).localeCompare(path.resolve(right));
+}
+
+function profileSortRank(name: string): [number, number] {
+  if (name === "Default") return [0, 0];
+  const profile = /^Profile (\d+)$/.exec(name);
+  if (profile) return [1, Number(profile[1])];
+  return [2, 0];
+}
+
+function samePath(left: string, right: string): boolean {
+  const normalize = (value: string) => {
+    const resolved = path.resolve(value);
+    return process.platform === "darwin" || process.platform === "win32" ? resolved.toLocaleLowerCase("en-US") : resolved;
+  };
+  return normalize(left) === normalize(right);
+}
+
+async function validateDescriptorFile(file: string): Promise<string | undefined> {
+  const stats = await lstat(file).catch((error) => `stat descriptor failed: ${String(error)}`);
+  if (typeof stats === "string") return stats;
+  if (stats.isSymbolicLink()) return "descriptor is a symlink";
+  if (!stats.isFile()) return "descriptor is not a file";
+  return ownerOnlyIssue(stats, "descriptor");
+}
+
+function descriptorProcessIssue(descriptor: Record<string, unknown>): string | undefined {
+  if (process.platform === "win32") return undefined;
+  const pid = descriptor.pid;
+  if (!Number.isSafeInteger(pid) || Number(pid) <= 0 || Number(pid) > 2_147_483_647) {
+    return "descriptor pid missing or invalid";
+  }
+  try {
+    process.kill(Number(pid), 0);
+    return undefined;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM") return undefined;
+    return "descriptor process is not alive";
+  }
+}
+
+async function validateDescriptorSocket(socketPath: string): Promise<string | undefined> {
+  const stats = await stat(socketPath).catch((error) => `stat descriptor socket failed: ${String(error)}`);
+  if (typeof stats === "string") return stats;
+  if (process.platform !== "win32" && !stats.isSocket()) return "descriptor socket path is not a socket";
+  return ownerOnlyIssue(stats, "descriptor socket");
+}
+
+function ownerOnlyIssue(stats: { uid?: number; mode: number }, label: string): string | undefined {
+  if (process.platform === "win32") return undefined;
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  if (uid !== undefined && stats.uid !== undefined && stats.uid !== uid) return `${label} is not owned by current user`;
+  if ((stats.mode & 0o077) !== 0) return `${label} permissions must be owner-only`;
+  return undefined;
+}
+
+function rpcSequenceOverUnixSocket(socketPath: string, payloads: Record<string, unknown>[]): Promise<RpcResponse[]> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("timed out"));
+    }, 800);
+    let buffer = Buffer.alloc(0);
+    let nextRequest = 0;
+    const responses: RpcResponse[] = [];
+    const finish = (value: RpcResponse[]) => {
+      clearTimeout(timer);
+      socket.end();
+      resolve(value);
+    };
+    const fail = (error: unknown) => {
+      clearTimeout(timer);
+      socket.destroy();
+      reject(error);
+    };
+    const writeNext = () => {
+      if (nextRequest >= payloads.length) {
+        finish(responses);
+        return;
+      }
+      socket.write(encodeFrame(payloads[nextRequest]!));
+    };
+    socket.once("error", fail);
+    socket.once("connect", writeNext);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (buffer.length >= 4) {
+        const length = buffer.readUInt32LE(0);
+        if (buffer.length < 4 + length) return;
+        const body = buffer.subarray(4, 4 + length);
+        buffer = buffer.subarray(4 + length);
+        try {
+          responses.push(JSON.parse(body.toString("utf8")));
+        } catch (error) {
+          fail(error);
+          return;
+        }
+        nextRequest += 1;
+        writeNext();
+      }
+    });
+  });
+}
+
+function encodeFrame(payload: Record<string, unknown>): Buffer {
+  const body = Buffer.from(JSON.stringify(payload));
+  const frame = Buffer.alloc(4 + body.length);
+  frame.writeUInt32LE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+function mergedDescriptorMetadata(descriptor: Record<string, unknown>, infoResult: Record<string, any>): Record<string, unknown> {
+  const descriptorMetadata = isRecord(descriptor.metadata) ? descriptor.metadata : {};
+  const infoBackend = isRecord(infoResult.metadata?.backend) ? infoResult.metadata.backend : {};
+  return { ...infoBackend, ...descriptorMetadata };
+}
+
+function descriptorProfilePath(metadata: Record<string, unknown>): string | undefined {
+  for (const key of ["profile_path", "profilePath", "browser_profile_path"]) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function stringFromPath(value: Record<string, unknown>, pathParts: string[]): string | undefined {
+  let current: unknown = value;
+  for (const part of pathParts) {
+    if (!isRecord(current)) return undefined;
+    current = current[part];
+  }
+  return typeof current === "string" ? current : undefined;
+}
+
+async function readJson(file: string): Promise<any> {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { constants } from "node:fs";
 import { access, chmod, lstat, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import net from "node:net";
@@ -19,7 +19,6 @@ import { executableExists, packageVersion, type RuntimeLayout } from "./runtime-
 const HOST_NAME = "dev.obu.host";
 const SERVER_NAME = "open-browser-use";
 const DEFAULT_MCP_PROBE_TIMEOUT_MS = 8_000;
-const AGENT_RUNTIME_FRESHNESS_MS = 60_000;
 
 export type VerificationTarget = "cli" | "agent_runtime";
 export type VerifyResult = "ready" | "needs_browser_popup" | "needs_repair" | "needs_manual_action";
@@ -1345,21 +1344,12 @@ async function evaluateAgentRuntime(
       };
     }
     return {
-      runtimeStatus: trustedResult.status === "fail" && hook
-        ? {
-          status: "fail",
-          provenance: "agent_runtime_hook",
-          reason: trustedResult.reason,
-          hook: { ...hook, trusted: true },
-          targetBound: false,
-          challengeBound: false,
-        }
-        : {
-          status: "not_checked",
-          provenance: "not_applicable",
-          reason: trustedResult.reason,
-          ...(hook ? { trustedHook: hook } : {}),
-        },
+      runtimeStatus: {
+        status: "not_checked",
+        provenance: "not_applicable",
+        reason: trustedResult.reason,
+        ...(hook ? { trustedHook: hook } : {}),
+      },
       mcpRuntime: trustedResult.status === "fail" ? trustedResult.mcpRuntime : notCheckedAgentRuntimeMcp(trustedResult.reason),
       check: failCheck({
         id: "agent-runtime-status",
@@ -1369,8 +1359,8 @@ async function evaluateAgentRuntime(
         target: { ...target, agent: options.agent },
         evidence: {
           scope: "agent_runtime",
-          provenance: hook ? "agent_runtime_hook" : "not_applicable",
-          source: "agent_runtime_hook",
+          provenance: "not_applicable",
+          source: "agent_runtime_hook_registry",
         },
         blocks: ["agent_runtime"],
         actionCandidate: collectAgentRuntimeAction(options, hook, options.agentRuntimeChallengeJson, "Collect agent-runtime status through the trusted OBU hook."),
@@ -1993,7 +1983,6 @@ function normalizeBackend(value: unknown, options: VerifyOptions): NormalizedBac
 
 async function writeAgentRuntimeChallenge(file: string, options: VerifyOptions, hook: TrustedRuntimeHook | undefined): Promise<void> {
   const nonce = randomBytes(24).toString("hex");
-  const resultPath = hook ? trustedRuntimeResultPath(options.layout.runtimeDir, hook, nonce) : undefined;
   const payload = {
     schemaVersion: 1,
     agentId: options.agent,
@@ -2009,13 +1998,8 @@ async function writeAgentRuntimeChallenge(file: string, options: VerifyOptions, 
       ...(options.profile ? { profile: options.profile } : {}),
     },
     ...(hook ? { trustedHook: hook } : {}),
-    ...(resultPath ? { trustedHookResult: { path: resultPath } } : {}),
   };
   await mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
-  if (resultPath) {
-    await mkdir(path.dirname(resultPath), { recursive: true, mode: 0o700 });
-    if (process.platform !== "win32") await chmod(path.dirname(resultPath), 0o700);
-  }
   await writeFile(file, `${JSON.stringify(payload, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
   if (process.platform !== "win32") await chmod(file, 0o600);
 }
@@ -2051,30 +2035,12 @@ async function readTrustedRuntimeHookResult(options: VerifyOptions, hook: Truste
   const challenge = await readAgentRuntimeChallenge(options, hook);
   if (challenge.status === "fail") return challenge;
 
-  const resultPath = trustedRuntimeResultPath(options.layout.runtimeDir, hook, challenge.nonce);
-  const payload = await readJson(resultPath).catch((error) => {
-    const nodeError = error as NodeJS.ErrnoException;
-    if (nodeError.code === "ENOENT") return undefined;
-    return { __obu_read_error: nodeError.message ?? String(error) };
-  });
-  if (payload === undefined) {
-    return {
-      status: "pending",
-      reason: "agent_runtime_challenge_pending",
-      message: "trusted agent-runtime hook result has not been delivered for this challenge",
-      details: { challengePath: options.agentRuntimeChallengeJson, resultPath },
-    };
-  }
-  if (isRecord(payload) && typeof payload.__obu_read_error === "string") {
-    return {
-      status: "fail",
-      reason: "agent_runtime_result_unreadable",
-      message: "trusted agent-runtime hook result could not be read",
-      mcpRuntime: notCheckedAgentRuntimeMcp("agent_runtime_result_unreadable"),
-      details: { challengePath: options.agentRuntimeChallengeJson, resultPath, error: payload.__obu_read_error },
-    };
-  }
-  return validateTrustedRuntimeEnvelope(payload, options, hook, challenge, resultPath);
+  return {
+    status: "pending",
+    reason: "agent_runtime_challenge_pending",
+    message: "agent-runtime challenge is valid, but no trusted hook transport has delivered status for this CLI process",
+    details: { challengePath: options.agentRuntimeChallengeJson, trustedHook: hook },
+  };
 }
 
 async function readAgentRuntimeChallenge(
@@ -2128,93 +2094,6 @@ async function readAgentRuntimeChallenge(
   };
 }
 
-function validateTrustedRuntimeEnvelope(
-  payload: unknown,
-  options: VerifyOptions,
-  hook: TrustedRuntimeHook,
-  challenge: { nonce: string; issuedAt?: string },
-  resultPath: string,
-): TrustedRuntimeResult {
-  const detailsBase = { challengePath: options.agentRuntimeChallengeJson, resultPath };
-  if (!isRecord(payload)) {
-    return trustedHookFailure("agent_runtime_result_invalid", "trusted agent-runtime hook result is not an object", detailsBase);
-  }
-  const payloadHook = isRecord(payload.hook) ? payload.hook : undefined;
-  const hookBound = payloadHook?.id === hook.id && payloadHook.transport === hook.transport;
-  const targetBound =
-    payload.schemaVersion === 1 &&
-    payload.agentId === options.agent &&
-    payload.mcpServerName === SERVER_NAME &&
-    payload.provenance === "agent_runtime_hook" &&
-    targetMatches(payload.target, options);
-  const challengeBound = isRecord(payload.challenge) && payload.challenge.nonce === challenge.nonce;
-  const generatedAt = typeof payload.generatedAt === "string" ? payload.generatedAt : undefined;
-  const generatedAtMs = generatedAt === undefined ? NaN : Date.parse(generatedAt);
-  const fresh = Number.isFinite(generatedAtMs) &&
-    generatedAtMs <= Date.now() + 5_000 &&
-    Date.now() - generatedAtMs <= AGENT_RUNTIME_FRESHNESS_MS;
-  if (!hookBound || !targetBound || !challengeBound || generatedAt === undefined || !fresh) {
-    return trustedHookFailure("agent_runtime_result_untrusted", "trusted agent-runtime hook result is stale, unbound, or from the wrong hook", {
-      ...detailsBase,
-      hookBound,
-      targetBound,
-      challengeBound,
-      fresh,
-      generatedAt,
-    });
-  }
-  const trustedGeneratedAt = generatedAt;
-
-  const statusPayload = isRecord(payload.status) ? payload.status : {};
-  const rawBackends = Array.isArray(statusPayload.backends) ? statusPayload.backends : [];
-  const backends = rawBackends.map((backend) => normalizeBackend(backend, options));
-  const usable = backends.filter((backend) => backend.extensionIdentity.verified);
-  const sdkBootstrap = typeof statusPayload.sdk_bootstrap === "string" ? statusPayload.sdk_bootstrap : "missing";
-  const mcpRuntime: McpRuntimeStatus = {
-    source: "agent_runtime",
-    provenance: "agent_runtime_hook",
-    probeCommandSource: "agent_runtime_hook",
-    mcpConfigured: true,
-    mcpStarts: true,
-    sdkBootstrap,
-    backendCount: usable.length,
-    backends: usable,
-    details: { raw: statusPayload, resultPath },
-    ...(sdkBootstrap !== "available" ? { reason: `agent-runtime sdk bootstrap is ${sdkBootstrap}` } : usable.length === 0 ? { reason: "agent-runtime hook reported zero usable browser backends" } : {}),
-  };
-  if (sdkBootstrap !== "available") {
-    return {
-      status: "fail",
-      reason: "agent_runtime_sdk_unavailable",
-      message: `agent-runtime MCP status reported sdk bootstrap ${sdkBootstrap}`,
-      mcpRuntime,
-      details: { ...detailsBase, generatedAt },
-    };
-  }
-  if (usable.length === 0) {
-    return {
-      status: "fail",
-      reason: "agent_runtime_zero_backends",
-      message: "agent-runtime MCP status reported zero usable browser backends",
-      mcpRuntime,
-      details: { ...detailsBase, generatedAt },
-    };
-  }
-  return {
-    status: "pass",
-    runtimeStatus: {
-      status: "pass",
-      provenance: "agent_runtime_hook",
-      hook: { ...hook, trusted: true },
-      generatedAt: trustedGeneratedAt,
-      targetBound: true,
-      challengeBound: true,
-    },
-    mcpRuntime,
-    details: { ...detailsBase, generatedAt: trustedGeneratedAt, backendCount: usable.length },
-  };
-}
-
 function trustedHookFailure(reason: string, message: string, details?: Record<string, unknown>): Extract<TrustedRuntimeResult, { status: "fail" }> {
   return {
     status: "fail",
@@ -2246,11 +2125,6 @@ function trustedRuntimeHook(agent: AgentId): TrustedRuntimeHook | undefined {
     };
   }
   return undefined;
-}
-
-function trustedRuntimeResultPath(runtimeDir: string, hook: TrustedRuntimeHook, nonce: string): string {
-  const nonceHash = createHash("sha256").update(nonce).digest("hex");
-  return path.join(runtimeDir, "agent-runtime", hook.id, `${nonceHash}.json`);
 }
 
 function passCheck(input: {

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -506,15 +506,30 @@ export function formatVerifyReport(report: VerifyReport): string {
     return [
       "Repair required.",
       report.nextAction?.message ?? "A deterministic open-browser-use repair is available.",
-      ...(report.nextAction?.command ? ["Run:", `  ${report.nextAction.command}`] : []),
+      ...formatVerifyNextActionDetails(report.nextAction),
     ].join("\n");
   }
 
   return [
     "Manual action required.",
     report.nextAction?.message ?? "The selected target needs manual action before open-browser-use can verify readiness.",
-    ...(report.nextAction?.command ? ["Run:", `  ${report.nextAction.command}`] : []),
+    ...formatVerifyNextActionDetails(report.nextAction),
   ].join("\n");
+}
+
+function formatVerifyNextActionDetails(action: VerifyNextAction | null): string[] {
+  if (!action) return [];
+  const rows: string[] = [];
+  if (action.command) rows.push("Run:", `  ${action.command}`);
+  if (action.url) rows.push("Open:", `  ${action.url}`);
+  if (action.profile) {
+    const profile = action.profile.suggestedPath ?? action.profile.path;
+    if (profile) rows.push("Profile:", `  ${profile}`);
+  }
+  if (action.challenge) rows.push("Challenge:", `  ${action.challenge.path}`);
+  if (action.trustedHook) rows.push("Trusted hook:", `  ${action.trustedHook.id} (${action.trustedHook.transport})`);
+  if (action.rerun) rows.push("Rerun:", `  ${action.rerun}`);
+  return rows;
 }
 
 function baseTarget(options: VerifyOptions): VerifyTarget {
@@ -1280,10 +1295,6 @@ async function evaluateAgentRuntime(
   }
 
   const hook = trustedRuntimeHook(options.agent);
-  let challengePath = options.agentRuntimeChallengeOut;
-  if (challengePath) {
-    await writeAgentRuntimeChallenge(challengePath, options, hook);
-  }
 
   if (options.agentRuntimeStatusJson) {
     const diagnostic = await diagnosticStatusFileBinding(options);
@@ -1318,9 +1329,44 @@ async function evaluateAgentRuntime(
           source: "agent_runtime_status_file",
         },
         blocks: ["agent_runtime"],
-        actionCandidate: collectAgentRuntimeAction(options, hook, challengePath, "Collect agent-runtime status through the trusted OBU hook."),
+        actionCandidate: hook
+          ? collectAgentRuntimeAction(options, hook, options.agentRuntimeChallengeOut, "Collect agent-runtime status through the trusted OBU hook.")
+          : agentRuntimeHookUnavailableAction(options, "This build cannot prove readiness from inside the selected running agent process."),
       }),
     };
+  }
+
+  if (!hook) {
+    const reason = "agent_runtime_hook_unavailable";
+    const message = `no trusted agent-runtime hook is registered for ${options.agent}`;
+    const runtimeStatus: AgentRuntimeStatus = {
+      status: "not_checked",
+      provenance: "not_applicable",
+      reason,
+    };
+    return {
+      runtimeStatus,
+      mcpRuntime: notCheckedAgentRuntimeMcp(reason),
+      check: failCheck({
+        id: "agent-runtime-status",
+        layer: "agent_runtime",
+        reason,
+        message,
+        target: { ...target, agent: options.agent },
+        evidence: {
+          scope: "agent_runtime",
+          provenance: "not_applicable",
+          source: "agent_runtime_hook_registry",
+        },
+        blocks: ["agent_runtime"],
+        actionCandidate: agentRuntimeHookUnavailableAction(options, "This build cannot prove readiness from inside the selected running agent process."),
+      }),
+    };
+  }
+
+  let challengePath = options.agentRuntimeChallengeOut;
+  if (challengePath) {
+    await writeAgentRuntimeChallenge(challengePath, options, hook);
   }
 
   if (options.agentRuntimeChallengeJson) {
@@ -2117,13 +2163,7 @@ type TrustedRuntimeHook = {
   transport: "agent_connector" | "agent_owned_ipc" | "in_process_adapter";
 };
 
-function trustedRuntimeHook(agent: AgentId): TrustedRuntimeHook | undefined {
-  if (agent === "codex-cli") {
-    return {
-      id: "codex-cli-runtime-status",
-      transport: "agent_connector",
-    };
-  }
+function trustedRuntimeHook(_agent: AgentId): TrustedRuntimeHook | undefined {
   return undefined;
 }
 
@@ -2274,6 +2314,16 @@ function configureAgentAction(options: VerifyOptions, message: string): ActionCa
   };
 }
 
+function agentRuntimeHookUnavailableAction(options: VerifyOptions, message: string): ActionCandidate {
+  return {
+    result: "needs_manual_action",
+    kind: "unsupported",
+    priority: manualActionPriority.unsupported,
+    message,
+    command: appendShellArgs(options.commandPrefix, verifyArgs(options, false, { requireAgentRuntime: false })),
+  };
+}
+
 function collectAgentRuntimeAction(
   options: VerifyOptions,
   hook: TrustedRuntimeHook | undefined,
@@ -2303,7 +2353,7 @@ function mcpConfigCommand(options: VerifyOptions): string {
   return appendShellArgs(options.commandPrefix, ["mcp-config", `--agent=${options.agent}`, "--print"]);
 }
 
-function verifyArgs(options: VerifyOptions, repair: boolean, extra: { agentRuntimeChallengeJson?: string } = {}): string[] {
+function verifyArgs(options: VerifyOptions, repair: boolean, extra: { agentRuntimeChallengeJson?: string; requireAgentRuntime?: boolean } = {}): string[] {
   const args = [
     "verify",
     `--agent=${options.agent}`,
@@ -2312,7 +2362,7 @@ function verifyArgs(options: VerifyOptions, repair: boolean, extra: { agentRunti
     `--extension-id=${options.extensionId}`,
   ];
   if (options.profile) args.push(`--profile=${options.profile}`);
-  if (options.requireAgentRuntime) args.push("--require-agent-runtime");
+  if (extra.requireAgentRuntime ?? options.requireAgentRuntime) args.push("--require-agent-runtime");
   if (extra.agentRuntimeChallengeJson) args.push(`--agent-runtime-challenge-json=${extra.agentRuntimeChallengeJson}`);
   if (repair) args.push("--repair");
   return args;

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -13,7 +13,7 @@ import { appendShellArgs } from "./command-line.js";
 import { doctorBrowser } from "./doctor-browser.js";
 import { type ExtensionChannel, type ExtensionIdSource } from "./extension-channel.js";
 import { browserProfileRoot, nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
-import { supportedNativeHostBrowsers } from "./native-host.js";
+import { nativeHostWrapperContent, nativeHostWrapperPath, supportedNativeHostBrowsers } from "./native-host.js";
 import { executableExists, packageVersion, type RuntimeLayout } from "./runtime-layout.js";
 
 const HOST_NAME = "dev.obu.host";
@@ -611,6 +611,10 @@ async function checkNativeHost(options: VerifyOptions, homeDir: string, target: 
   const manifestPath = path.join(nativeMessagingHostDir(options.browser, process.platform, homeDir), `${HOST_NAME}.json`);
   const manifest = await readJson(manifestPath).catch(() => undefined);
   const command = repairCommand(options);
+  const expectedWrapperPath = nativeHostWrapperPath({
+    nativeHostInstallRoot: options.layout.nativeHostInstallRoot,
+    browser: options.browser,
+  });
   if (!isRecord(manifest)) {
     return {
       state: "missing",
@@ -633,11 +637,32 @@ async function checkNativeHost(options: VerifyOptions, homeDir: string, target: 
   if (manifest.name !== HOST_NAME) issues.push(`name must be ${HOST_NAME}`);
   if (manifest.type !== "stdio") issues.push("type must be stdio");
   if (typeof manifest.path !== "string" || !path.isAbsolute(manifest.path)) issues.push("path must be absolute");
+  if (typeof manifest.path === "string" && path.isAbsolute(manifest.path) && !samePath(manifest.path, expectedWrapperPath)) {
+    issues.push(`path must be the open-browser-use managed wrapper: ${expectedWrapperPath}`);
+  }
   if (!Array.isArray(manifest.allowed_origins) || !manifest.allowed_origins.includes(allowedOrigin)) {
     issues.push(`allowed_origins must include ${allowedOrigin}`);
   }
   if (typeof manifest.path === "string" && !await access(manifest.path, constants.X_OK).then(() => true).catch(() => false)) {
     issues.push(`native host path is not executable: ${manifest.path}`);
+  }
+  if (!await access(options.layout.hostBin, constants.X_OK).then(() => true).catch(() => false)) {
+    issues.push(`obu-host is not executable: ${options.layout.hostBin}`);
+  }
+  if (typeof manifest.path === "string" && path.isAbsolute(manifest.path) && samePath(manifest.path, expectedWrapperPath)) {
+    const expectedWrapper = nativeHostWrapperContent({
+      hostBin: options.layout.hostBin,
+      browser: options.browser,
+      runtimeDir: options.layout.runtimeDir,
+    });
+    const actualWrapper = await readFile(expectedWrapperPath, "utf8").catch((error) => {
+      const nodeError = error as NodeJS.ErrnoException;
+      issues.push(`native host wrapper cannot be read: ${nodeError.message ?? String(error)}`);
+      return undefined;
+    });
+    if (actualWrapper !== undefined && actualWrapper !== expectedWrapper) {
+      issues.push(`native host wrapper is stale: ${expectedWrapperPath}`);
+    }
   }
   if (issues.length > 0) {
     return {
@@ -650,7 +675,7 @@ async function checkNativeHost(options: VerifyOptions, homeDir: string, target: 
         message: issues.join("; "),
         target,
         evidence: expectedEvidence("native_host_manifest"),
-        details: { path: manifestPath, issues },
+        details: { path: manifestPath, expectedWrapperPath, issues },
         actionCandidate: repairAction(command, "Repair the native host manifest for the selected browser and extension."),
       }),
     };
@@ -663,7 +688,7 @@ async function checkNativeHost(options: VerifyOptions, homeDir: string, target: 
       message: `native host allows ${allowedOrigin}`,
       target,
       evidence: expectedEvidence("native_host_manifest"),
-      details: { path: manifestPath },
+      details: { path: manifestPath, expectedWrapperPath },
     }),
   };
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/extension",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "open-browser-use Chromium MV3 extension.",
   "license": "MIT",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "default_locale": "en",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA19raOghahuNORvUNtnkVqp9T+fNn3TBxyajKRpHPsWwfNDLaruz73Wn9S7fvCPyyFROJ+lOYH/72Iw/njYHLpNiKhyxphQE8oON2izCzz3KNkRaEsdzZ4utBlsFMABgxKybMEu9osjmj2n91Q4fFMqBv5eCpdl2dEp5KPO6tnNLspRwQMttKU/KqBAjGDkbSBuAlaSKkaAC8IVBqrBBTzcvH7AYXYjOLL9ZJ5a01QnFkyXtEyDvnmxbNRDvF7/8pmryq3E+Ue/COBqHWp57EKUNFHH2r/0ZczELo+6rYlH0mDGdr1hpVIiAAnoGu8XTlQ5vp4GH60+VszbNa9zLi2QIDAQAB",
   "minimum_chrome_version": "116",

--- a/packages/extension/scripts/test-popup.mjs
+++ b/packages/extension/scripts/test-popup.mjs
@@ -59,11 +59,11 @@ function assertAgentHandoff(elements, channel = "unpacked-dev") {
   assert.match(handoff, /primary BrowserUse\/browser automation tool/);
   assert.match(handoff, /~\/\.codex\/AGENTS\.md/);
   assert.match(handoff, /~\/\.claude\/CLAUDE\.md/);
-  assert.match(handoff, /Codex, Cursor, or Claude Code/);
+  assert.match(handoff, /Codex \(OBU id: codex-cli\), Cursor, or Claude Code \(OBU id: claude-code\)/);
+  assert.match(handoff, /~\/\.obu\/bin\/obu exists/);
   assert.doesNotMatch(handoff, /Terminal command/i);
   assert.doesNotMatch(handoff, /curl -fsSL/);
   assert.doesNotMatch(handoff, /obu bootstrap/);
-  assert.doesNotMatch(handoff, /~\/\.obu\/bin\/obu/);
   assert.doesNotMatch(handoff, /Bootstrap:/);
   assert.doesNotMatch(handoff, /Verify:/);
 }

--- a/packages/extension/scripts/test-popup.mjs
+++ b/packages/extension/scripts/test-popup.mjs
@@ -61,6 +61,8 @@ function assertAgentHandoff(elements, channel = "unpacked-dev") {
   assert.match(handoff, /~\/\.claude\/CLAUDE\.md/);
   assert.match(handoff, /Codex \(OBU id: codex-cli\), Cursor, or Claude Code \(OBU id: claude-code\)/);
   assert.match(handoff, /~\/\.obu\/bin\/obu exists/);
+  assert.match(handoff, /run obu verify/);
+  assert.doesNotMatch(handoff, /rerun doctor/);
   assert.doesNotMatch(handoff, /Terminal command/i);
   assert.doesNotMatch(handoff, /curl -fsSL/);
   assert.doesNotMatch(handoff, /obu bootstrap/);

--- a/packages/extension/src/popup.ts
+++ b/packages/extension/src/popup.ts
@@ -503,7 +503,7 @@ function agentHandoffForChannel(channel: string, runtimeExtensionId: string | un
     "Make open-browser-use the primary BrowserUse/browser automation tool for this agent.",
     "Configure the current agent, and any other supported agent the user requests, such as Codex (OBU id: codex-cli), Cursor, or Claude Code (OBU id: claude-code).",
     "Update the project's core AGENTS.md, AGENT.md, CLAUDE.md, or the agent's global instruction file such as ~/.codex/AGENTS.md or ~/.claude/CLAUDE.md when one exists; otherwise show the instruction snippet.",
-    "After setup or repair, verify browser/native-host state. If doctor reports resume_required, open this popup; click Resume if enabled, otherwise wait for Connected and rerun doctor.",
+    "After setup or repair, run obu verify with the exact extension channel and id. If verify reports a browser popup boundary, open this popup; click Resume if enabled, otherwise wait for Connected and rerun verify.",
   ].join("\n");
 }
 

--- a/packages/extension/src/popup.ts
+++ b/packages/extension/src/popup.ts
@@ -497,12 +497,13 @@ function agentHandoffForChannel(channel: string, runtimeExtensionId: string | un
     `Extension channel: ${resolvedChannel}`,
     `Extension id: ${extensionId}`,
     "Use the exact extension channel and id when native-host repair or browser pairing is needed.",
+    "First ensure ~/.obu/bin/obu exists; if it is missing, install the latest release before writing MCP config.",
     "Let the linked prompt choose the install, repair, MCP config, and agent-instruction steps for this agent and project.",
     "Configure MCP with the generic open-browser-use stdio server first; use OBU's built-in adapter commands as secondary helpers.",
     "Make open-browser-use the primary BrowserUse/browser automation tool for this agent.",
-    "Configure the current agent, and any other supported agent the user requests, such as Codex, Cursor, or Claude Code.",
+    "Configure the current agent, and any other supported agent the user requests, such as Codex (OBU id: codex-cli), Cursor, or Claude Code (OBU id: claude-code).",
     "Update the project's core AGENTS.md, AGENT.md, CLAUDE.md, or the agent's global instruction file such as ~/.codex/AGENTS.md or ~/.claude/CLAUDE.md when one exists; otherwise show the instruction snippet.",
-    "After setup or repair, verify browser/native-host state and return to this popup to click Resume when needed.",
+    "After setup or repair, verify browser/native-host state. If doctor reports resume_required, open this popup; click Resume if enabled, otherwise wait for Connected and rerun doctor.",
   ].join("\n");
 }
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "open-browser-use agent-facing SDK: Playwright-shaped API over the open-browser-use broker wire.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/browsers.ts
+++ b/packages/sdk/src/browsers.ts
@@ -111,6 +111,6 @@ function noBackend(kind: string, diagnostics: BackendDiscoveryDiagnostic[]): Obu
       message += `; +${diagnostics.length - visibleDiagnostics.length} more`;
     }
   }
-  message += ". Run obu doctor browser for setup diagnostics.";
+  message += ". Run obu verify for readiness; use obu doctor browser only for lower-level browser diagnostics.";
   return new ObuError(ERR_NO_BACKEND, message);
 }

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "0.1.5";
+export const SDK_VERSION = "0.1.6";

--- a/packages/sdk/tests/browsers.test.ts
+++ b/packages/sdk/tests/browsers.test.ts
@@ -51,14 +51,15 @@ describe("selectBackend", () => {
   });
 
   it("includes backend discovery diagnostics when no backend matches", () => {
-    expect(() =>
+    const fail = () =>
       selectBackend([], "chrome", [
         {
           source: "/tmp/obu/webextension/future.json",
           reason: "unsupported schema_version 999",
         },
-      ]),
-    ).toThrow(/Ignored backend descriptors: .*future\.json: unsupported schema_version 999/);
+      ]);
+    expect(fail).toThrow(/Run obu verify for readiness/);
+    expect(fail).toThrow(/Ignored backend descriptors: .*future\.json: unsupported schema_version 999/);
   });
 });
 

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -215,29 +215,30 @@ common human names, but older OBU releases may reject them as agent ids.
    `open-browser-use` server already points to the same command and args, leave
    it alone.
 
-4. Run browser verification when browser/native-host state may have changed:
+4. Run readiness verification when browser/native-host state may have changed:
 
    ```sh
-   ~/.obu/bin/obu doctor browser --channel=<extension-channel> --extension-id=<extension-id>
+   ~/.obu/bin/obu verify --agent=<agent-id> --browser=<browser> --channel=<extension-channel> --extension-id=<extension-id>
    ```
 
    For the Store channel, include the exact Store extension id from the handoff
    unless it is already configured. If `browser_status` says the SDK is
    available but `backends` is empty, the MCP server is reachable but the
-   browser backend is not. Run the doctor command above; for Store repair, use
-   the exact handoff id:
+   browser backend is not. Run verify as above; for deterministic repair, use
+   the exact handoff id and keep the same agent/browser target:
 
    ```sh
-   ~/.obu/bin/obu doctor browser --repair --channel=store --extension-id=<extension-id>
+   ~/.obu/bin/obu verify --repair --agent=<agent-id> --browser=<browser> --channel=store --extension-id=<extension-id>
    ```
 
-   Repair can fix the native-host manifest and runtime descriptor directory, but
-   it cannot force Chrome to reconnect the extension. If doctor still reports
-   no active WebExtension runtime descriptor after repair, tell the user to open
-   the open-browser-use extension popup. Click Resume if it is enabled; if
-   Resume is disabled but the popup says the local host is connected, leave the
-   popup open briefly and rerun doctor with the same channel/id, then retry
-   `browser_status`.
+   Verify repair can fix the native-host manifest and runtime descriptor
+   directory, but it cannot force Chrome to reconnect the extension. If verify
+   reports a browser popup boundary after repair, tell the user to open the
+   open-browser-use extension popup. Click Resume if it is enabled; if Resume is
+   disabled but the popup says the local host is connected, leave the popup open
+   briefly and rerun verify with the same agent/browser/channel/id, then retry
+   `browser_status`. Use `obu doctor browser` only when verify asks for deeper
+   browser diagnostics.
 
 5. Verify MCP from inside the target agent when possible:
 
@@ -254,7 +255,8 @@ common human names, but older OBU releases may reject them as agent ids.
      `browser_status` must show at least one backend before browser automation
      can work.
    - If the MCP server starts but browser state is stale, run
-     `~/.obu/bin/obu doctor browser` with the handoff channel/id when needed.
+     `~/.obu/bin/obu verify --agent=<agent-id> --browser=<browser> --channel=<extension-channel> --extension-id=<extension-id>`
+     with the handoff channel/id when needed.
    - For setup probes, prefer `await browser.turnEnded()` after the probe so the
      browser session stays controlled. Do not use
      `await browser.finishTurn({ keep: [] })` unless you intentionally want to
@@ -276,8 +278,8 @@ common human names, but older OBU releases may reject them as agent ids.
    Use open-browser-use as the primary BrowserUse/browser automation tool.
    Prefer the `open-browser-use` MCP server for browser tasks. Check
    `browser_status` before the first browser action, use the `js` tool for
-   browser automation, and run `~/.obu/bin/obu doctor browser` if setup appears
-   stale.
+   browser automation, and run `~/.obu/bin/obu verify --agent=<agent-id> --browser=<browser> --channel=<channel> --extension-id=<extension-id>`
+   if setup appears stale.
    ```
 
    Adapt the wording and location to the agent. For example, update

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -52,6 +52,9 @@ On a standard release install, `/absolute/path/to/obu` resolves from:
 Do not depend on `obu` being on `PATH`. Resolve `~/.obu/bin/obu` to a real
 absolute path before writing JSON, such as `/Users/alex/.obu/bin/obu` or
 `/home/alex/.obu/bin/obu`, unless the user explicitly installed somewhere else.
+If `~/.obu/bin/obu` is missing, install or reinstall the latest release first;
+a fresh new install is better than wiring MCP to a missing or half-installed
+local CLI.
 
 Most MCP clients store this in one of these shapes:
 
@@ -91,6 +94,10 @@ Prefer the current AI client's native MCP configuration method:
 Use OBU's built-in adapter commands as secondary helpers, not as the only path.
 They are useful when they match the current client, but the generic server
 contract above is enough to adapt other MCP-capable AI clients.
+
+OBU adapter ids are exact. Use `codex-cli` for Codex, `claude-code` for Claude
+Code, and `gemini-cli` for Gemini CLI. `codex`, `claude`, and `gemini` are
+common human names, but older OBU releases may reject them as agent ids.
 
 ## Steps
 
@@ -179,7 +186,10 @@ contract above is enough to adapt other MCP-capable AI clients.
    ~/.obu/bin/obu setup --yes --agents=codex-cli,cursor,claude-code --write-instructions
    ```
 
-   If client detection is ambiguous, use auto mode:
+   If client detection is ambiguous, use auto mode, but inspect the result. Auto
+   mode only configures agents it can detect confidently; it may skip a working
+   agent if only that agent's global config file exists or its executable is not
+   on `PATH`.
 
    ```sh
    ~/.obu/bin/obu setup --yes --agents=auto
@@ -224,8 +234,10 @@ contract above is enough to adapt other MCP-capable AI clients.
    Repair can fix the native-host manifest and runtime descriptor directory, but
    it cannot force Chrome to reconnect the extension. If doctor still reports
    no active WebExtension runtime descriptor after repair, tell the user to open
-   the open-browser-use extension popup and click Resume. Then rerun doctor with
-   the same channel/id and retry `browser_status`.
+   the open-browser-use extension popup. Click Resume if it is enabled; if
+   Resume is disabled but the popup says the local host is connected, leave the
+   popup open briefly and rerun doctor with the same channel/id, then retry
+   `browser_status`.
 
 5. Verify MCP from inside the target agent when possible:
 

--- a/scripts/cargo-dist-smoke.mjs
+++ b/scripts/cargo-dist-smoke.mjs
@@ -24,7 +24,7 @@ const plan = JSON.parse(run(cargoDist, [
   "plan",
   "--output-format=json",
   "--tag",
-  "v0.1.5",
+  "v0.1.6",
   "--allow-dirty",
 ]).stdout);
 


### PR DESCRIPTION
## Summary

- Add `obu verify` as the canonical CLI readiness surface for agent/browser setup.
- Route setup, extension handoff, install docs, troubleshooting, and release gates through `obu verify` instead of asking agents to stitch together setup, doctor, popup, and MCP signals.
- Preserve exact Store extension targets across setup, repair, update-extension, popup handoff, and release verification.
- Keep agent-runtime proof honest: direct MCP probes prove CLI readiness only, while trusted agent-runtime hooks remain a separate, currently unavailable boundary.
- Expose MCP `browser_status.verify_hint` while keeping `doctor_hint` as a compatibility alias, and make SDK no-backend errors point to `obu verify` first.

## Why

Agents were getting partial and sometimes stale setup guidance from several surfaces: setup output, browser doctor, agent doctor, popup copy text, MCP `browser_status`, and docs. That made it easy to verify the wrong agent, reuse stale Store extension ids, or treat lower-level diagnostics as final readiness.

This branch closes that loop by making one command answer the product question: whether the selected agent/browser pair is ready at the requested verification level.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `cargo test --workspace`
- `git diff --check`

## Notes

This PR is opened as a draft. Before a formal release, run the release checklist packaging/install smoke gates and any browser/profile/manual Store-channel gates that require a real browser or Chrome Web Store environment.
