### PR TITLE
[codex] Streamline agent install handoff

### DIFF
--- a/packages/extension/scripts/test-popup.mjs
+++ b/packages/extension/scripts/test-popup.mjs
@@ -51,14 +51,16 @@ await runPopupInitialFailure("runtime rejection", [new Error("status boom")], "R
 
 function assertAgentHandoff(elements, channel = "unpacked-dev") {
   const handoff = elements.agentHandoff.textContent;
-  assert.match(handoff, /github\.com\/open-browser-use\/open-browser-use\/blob\/main\/prompts\/agent-install-prompt\.md/);
+  assert.match(handoff, /raw\.githubusercontent\.com\/open-browser-use\/open-browser-use\/main\/prompts\/agent-install-prompt\.md/);
   assert.doesNotMatch(handoff, /blob\/v0\.1\.2\/prompts\/agent-install-prompt\.md/);
+  assert.doesNotMatch(handoff, /github\.com\/open-browser-use\/open-browser-use\/blob\/main/);
   assert.match(handoff, new RegExp(`Extension channel: ${channel}`));
   assert.match(handoff, new RegExp(`Extension id: ${runtimeExtensionId}`));
   assert.match(handoff, /generic open-browser-use stdio server/);
   assert.match(handoff, /primary BrowserUse\/browser automation tool/);
   assert.match(handoff, /~\/\.codex\/AGENTS\.md/);
   assert.match(handoff, /~\/\.claude\/CLAUDE\.md/);
+  assert.match(handoff, /currently executing this prompt/);
   assert.match(handoff, /Codex \(OBU id: codex-cli\), Cursor, or Claude Code \(OBU id: claude-code\)/);
   assert.match(handoff, /~\/\.obu\/bin\/obu exists/);
   assert.match(handoff, /run obu verify/);

--- a/packages/extension/src/popup.ts
+++ b/packages/extension/src/popup.ts
@@ -490,7 +490,7 @@ function disconnectedPortObjectAdvice(): NativeHostAdvice {
 function agentHandoffForChannel(channel: string, runtimeExtensionId: string | undefined): string {
   const resolvedChannel: ExtensionChannel = channel === "store" ? "store" : "unpacked-dev";
   const extensionId = isExtensionId(runtimeExtensionId) ? runtimeExtensionId : "<extension-id>";
-  const promptUrl = "https://github.com/open-browser-use/open-browser-use/blob/main/prompts/agent-install-prompt.md";
+  const promptUrl = "https://raw.githubusercontent.com/open-browser-use/open-browser-use/main/prompts/agent-install-prompt.md";
   return [
     "Install, repair, or adapt open-browser-use for this browser extension.",
     `Prompt: ${promptUrl}`,
@@ -501,7 +501,7 @@ function agentHandoffForChannel(channel: string, runtimeExtensionId: string | un
     "Let the linked prompt choose the install, repair, MCP config, and agent-instruction steps for this agent and project.",
     "Configure MCP with the generic open-browser-use stdio server first; use OBU's built-in adapter commands as secondary helpers.",
     "Make open-browser-use the primary BrowserUse/browser automation tool for this agent.",
-    "Configure the current agent, and any other supported agent the user requests, such as Codex (OBU id: codex-cli), Cursor, or Claude Code (OBU id: claude-code).",
+    "Configure the agent/client currently executing this prompt. Configure other agents only when the user explicitly names them, such as Codex (OBU id: codex-cli), Cursor, or Claude Code (OBU id: claude-code).",
     "Update the project's core AGENTS.md, AGENT.md, CLAUDE.md, or the agent's global instruction file such as ~/.codex/AGENTS.md or ~/.claude/CLAUDE.md when one exists; otherwise show the instruction snippet.",
     "After setup or repair, run obu verify with the exact extension channel and id. If verify reports a browser popup boundary, open this popup; click Resume if enabled, otherwise wait for Connected and rerun verify.",
   ].join("\n");

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -3,6 +3,16 @@
 You are helping the user install, repair, or adapt `open-browser-use` for
 browser automation.
 
+## Execution Rules
+
+This prompt is the source of truth. Do not use README files, local copies, repo
+search, or inferred project state as substitutes.
+
+Configure the agent/client currently executing this prompt. Configure other
+agents only when the user explicitly names them.
+
+If this prompt cannot be read, stop and report the blocker.
+
 The user should paste a handoff block from the extension popup with:
 
 - `Extension channel`
@@ -22,13 +32,13 @@ profile when the handoff includes a concrete Store id.
 Make `open-browser-use` work as the user's primary BrowserUse/browser automation
 tool from this browser extension. Use the pasted extension channel/id exactly,
 but adapt the install, MCP wiring, and persistent agent instructions to the
-current project and the agent clients the user wants to use.
+current executing agent and any additional agents the user explicitly names.
 
-The user may already have one working agent, such as Codex, and now want to add
+The user may already have one working agent and now explicitly ask to add
 another one, such as Cursor or Claude Code. In that case, do not reinstall or
 rewrite unrelated setup just because the native host is already connected.
-Configure the additional agent and verify that the browser connection still
-works.
+Configure the explicitly requested additional agent and verify that the browser
+connection still works.
 
 ## MCP Contract
 
@@ -87,9 +97,8 @@ Prefer the current AI client's native MCP configuration method:
   `open-browser-use` server there.
 - If the client uses a global config and the user is asking for global agent
   access, update the global config carefully.
-- If the client is unknown, inspect existing config files and docs available in
-  the project before choosing a schema. Do not invent a config shape when the
-  client requires a different one.
+- If the client is unknown or its MCP config format is unclear, stop and report
+  the blocker. Do not invent a config shape.
 
 Use OBU's built-in adapter commands as secondary helpers, not as the only path.
 They are useful when they match the current client, but the generic server
@@ -139,8 +148,8 @@ common human names, but older OBU releases may reject them as agent ids.
    that agent. Configure the target agent's MCP settings directly with the
    generic MCP contract above.
 
-3. Configure MCP for the current agent and for any other agent the user wants
-   connected.
+3. Configure MCP for the current executing agent first. Additional agents are
+   out of scope unless explicitly requested by the user.
 
    Primary method: add this server to the client's MCP configuration using the
    client's own mechanism:
@@ -186,10 +195,8 @@ common human names, but older OBU releases may reject them as agent ids.
    ~/.obu/bin/obu setup --yes --agents=codex-cli,cursor,claude-code --write-instructions
    ```
 
-   If client detection is ambiguous, use auto mode, but inspect the result. Auto
-   mode only configures agents it can detect confidently; it may skip a working
-   agent if only that agent's global config file exists or its executable is not
-   on `PATH`.
+   Do not use auto mode to infer extra agents from config files. Use auto mode
+   only when the user explicitly asks for automatic multi-agent setup.
 
    ```sh
    ~/.obu/bin/obu setup --yes --agents=auto

--- a/scripts/make-extension-store-artifact.mjs
+++ b/scripts/make-extension-store-artifact.mjs
@@ -91,7 +91,7 @@ function assertStorePopup(contents) {
   if (!/const EXTENSION_CHANNEL = "store";/.test(contents)) {
     issues.push("popup.js must be built with EXTENSION_CHANNEL store");
   }
-  if (!contents.includes("blob/main/prompts/agent-install-prompt.md")) {
+  if (!contents.includes("raw.githubusercontent.com/open-browser-use/open-browser-use/main/prompts/agent-install-prompt.md")) {
     issues.push("popup.js must include the agent install prompt handoff");
   }
   if (!contents.includes("Extension channel:") || !contents.includes("Extension id:")) {


### PR DESCRIPTION
## Summary

- Switch the extension handoff prompt URL from GitHub /blob/ to the raw Markdown URL.
- Tighten the agent install prompt so agents treat it as source of truth and configure only the currently executing client unless additional agents are explicitly requested.
- Update popup tests and store artifact validation for the new raw URL and current-agent wording.

## Validation

- pnpm -C packages/extension test
- node --check scripts/make-extension-store-artifact.mjs
- git diff --check