### PR TITLE
ci: build JS artifacts before typecheck (fix TS2307 on main)

### DIFF
--- a/.github/workflows/p4-packaging-ci.yml
+++ b/.github/workflows/p4-packaging-ci.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Descriptor vocab generation check
         run: pnpm check:descriptor-vocab
 
+      # Build before typecheck: packages/sdk and extension resolve the
+      # @open-browser-use/browser-control-core types from its built dist/*.d.ts.
+      - name: Build JS artifacts
+        run: pnpm -r build
+
       - name: Typecheck
         run: pnpm -r typecheck
 
@@ -68,9 +73,6 @@ jobs:
           OBU_WEBEXT_E2E_AUTO_INSTALL: "1"
           OBU_WEBEXT_E2E_HEADLESS: "1"
         run: pnpm -C packages/extension test:browser
-
-      - name: Build JS artifacts
-        run: pnpm -r build
 
       - name: Rust tests
         run: cargo test -p obu-wire -p obu-node-repl -p obu-host --lib --tests --no-fail-fast


### PR DESCRIPTION
## Problem

`P4 Packaging CI` failed on `main` at the **Typecheck** step:

```
packages/sdk typecheck: src/browser-tasks.ts(6,54): error TS2307:
  Cannot find module '@open-browser-use/browser-control-core' or its corresponding type declarations.
```

## Cause

The workflow ran `pnpm -r typecheck` **before** `pnpm -r build`. `packages/sdk` (and `packages/extension`) resolve `@open-browser-use/browser-control-core`'s types from its built `dist/*.d.ts`, which don't exist on a clean checkout until the build runs — so typecheck fails with `TS2307`. It passed locally only because `dist/` was already built.

This is pre-existing (since `browser-control-core` was introduced); it surfaced on `main` once CI ran against the current tree.

## Fix

Move **Build JS artifacts** (`pnpm -r build`) ahead of **Typecheck** in the current-platform packaging job, so sibling workspace declarations exist before typechecking.

## Verification

Reproduced locally by removing `browser-control-core/dist/` → exact same three `TS2307` errors. After rebuilding `dist/`, `pnpm -r typecheck` is green across all packages (core / cli / sdk / extension).

Note: the failing run stopped at Typecheck, so the downstream steps (JS tests, Rust tests, packaging smokes) were skipped and will run for the first time once this lands.
