### PR TITLE
test(cli): de-flake hung-adapter timeout test on CI

### DIFF
--- a/packages/cli/src/agents/configure.test.ts
+++ b/packages/cli/src/agents/configure.test.ts
@@ -84,12 +84,16 @@ test("configureAgents times out hung shell adapters with a manual action", async
     agents: ["claude-code"],
     server: server(root),
     env: { PATH: bin },
-    adapterTimeoutMs: 25,
+    // Comfortably longer than shell-process startup. A tiny value (e.g. 25ms)
+    // races process spawn on slow CI runners, so the exit/error event can beat
+    // the timer and the run is misclassified as "did not complete". The adapter
+    // sleeps 5s, so this still fires well before the process would finish.
+    adapterTimeoutMs: 500,
   });
 
   assert.equal(steps[0]?.status, "manual_action_required");
   assert.match(steps[0]?.message ?? "", /timed out/);
-  assert.equal(steps[0]?.details?.timeout_ms, 25);
+  assert.equal(steps[0]?.details?.timeout_ms, 500);
   assert.match(steps[0]?.nextActions?.[0]?.value ?? "", /mcp-config --agent=claude-code --print/);
 });
 


### PR DESCRIPTION
Fixes the JS-tests failure on `main` (P4 Packaging CI).

The `configureAgents times out hung shell adapters` test set `adapterTimeoutMs: 25`. On slower CI runners 25ms races shell-process startup, so the exit/error event beats the timer and the run is misclassified as "did not complete" — failing `assert.match(message, /timed out/)`. It passed locally only because spawn is faster there (sibling tests spawning the same script passed on CI, confirming spawn works; only the 25ms-timeout test failed).

Raise the timeout to 500ms; the adapter sleeps 5s, so it still fires well before completion, now reliably across environments. Verified locally: `@open-browser-use/cli` suite 154/154 pass.