### PR TITLE
fix(test): hung-adapter test needs a real PATH so sleep resolves on CI

### DIFF
--- a/packages/cli/src/agents/configure.test.ts
+++ b/packages/cli/src/agents/configure.test.ts
@@ -82,12 +82,12 @@ test("configureAgents times out hung shell adapters with a manual action", async
 
   const steps = await configureAgents({
     agents: ["claude-code"],
+    // Include a real PATH so the adapter's `sleep` resolves. With only `bin` on
+    // PATH, some shells (notably the CI runner's) can't find `sleep`, so the
+    // script exits 127 immediately and the run is misclassified as "did not
+    // complete" instead of timing out — this reproduced only on CI.
+    env: { PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}` },
     server: server(root),
-    env: { PATH: bin },
-    // Comfortably longer than shell-process startup. A tiny value (e.g. 25ms)
-    // races process spawn on slow CI runners, so the exit/error event can beat
-    // the timer and the run is misclassified as "did not complete". The adapter
-    // sleeps 5s, so this still fires well before the process would finish.
     adapterTimeoutMs: 500,
   });
 


### PR DESCRIPTION
## Problem

After the typecheck and timeout fixes, P4 Packaging CI still failed at JS tests on `configureAgents times out hung shell adapters` (did not match /timed out/; got "claude adapter did not complete").

## Root cause

The fake `claude` runs `sleep 5` under `env: { PATH: bin }` (temp dir only). The CI runner shell cannot resolve `sleep` under that restricted PATH, so the script exits 127 immediately, the adapter never hangs, and the timeout path is never taken. It passed locally only because the local shell falls back to a default utils path. (The earlier timeout bump treated the wrong cause.)

## Fix

Prepend `bin` to the real process PATH so the fake `claude` still wins resolution but `sleep` resolves on any environment and the adapter genuinely hangs.

## Verified locally

runAdapter with PATH=bin only reproduces code 127 / "did not complete"; PATH=bin+real reliably times out. cli 154/154; JS (all pkgs) and Rust crate tests green.