### PR TITLE
test: decouple tests from gitignored docs (fix clean-checkout CI failures)

### DIFF
--- a/crates/obu-host/tests/method_name_sync.rs
+++ b/crates/obu-host/tests/method_name_sync.rs
@@ -133,8 +133,11 @@ fn backend_capabilities_follow_generated_support_matrix() {
 fn backend_capability_docs_list_agent_visible_differences() {
     let doc_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../docs/current-product-architecture.md");
-    let doc =
-        std::fs::read_to_string(&doc_path).expect("current-product-architecture.md is missing");
+    // docs/current-product-architecture.md is gitignored (developer-local), so it
+    // is absent on clean checkouts/CI. Validate it only when present.
+    let Ok(doc) = std::fs::read_to_string(&doc_path) else {
+        return;
+    };
     for expected in [
         "Backend differences that agents and SDK code should treat as capabilities",
         "| Surface | CDP backend | WebExtension backend | Capability signal |",

--- a/crates/obu-node-repl/tests/description_snapshot.rs
+++ b/crates/obu-node-repl/tests/description_snapshot.rs
@@ -6,7 +6,13 @@ fn js_tool_description() {
 
 #[test]
 fn agent_browser_mcp_usage_fast_work_rules() {
-    let body = include_str!("../../../docs/agent-browser-mcp-usage.md");
+    // docs/agent-browser-mcp-usage.md is gitignored (developer-local), so it is
+    // absent on clean checkouts/CI. Validate it only when present.
+    let doc_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../docs/agent-browser-mcp-usage.md");
+    let Ok(body) = std::fs::read_to_string(&doc_path) else {
+        return;
+    };
     let required = [
         "Call `browser_status` before the first `js` cell",
         "Call `browser.name(\"short task label\")` early",

--- a/packages/sdk/tests/help.test.ts
+++ b/packages/sdk/tests/help.test.ts
@@ -45,7 +45,6 @@ describe("help", () => {
 
   it("keeps overview docs on the safe user-tab discovery surface", async () => {
     const sdkReadme = await readFile(new URL("../README.md", import.meta.url), "utf8");
-    const architecture = await readFile(new URL("../../../docs/current-product-architecture.md", import.meta.url), "utf8");
 
     expect(sdkReadme).toContain("browser.tabs.current()");
     expect(sdkReadme).toContain("browser.tabs.selected()");
@@ -53,6 +52,13 @@ describe("help", () => {
     expect(sdkReadme).not.toContain("browser.user.openTabs/history/claimTab");
     expect(sdkReadme).not.toContain("browser.user.openTabs()` |");
 
+    // docs/current-product-architecture.md is gitignored (developer-local), so it
+    // is absent on clean checkouts/CI. Validate it only when present.
+    const architecture = await readFile(
+      new URL("../../../docs/current-product-architecture.md", import.meta.url),
+      "utf8",
+    ).catch(() => undefined);
+    if (architecture === undefined) return;
     expect(architecture).toContain("tabs.create/list/get/current/selected");
     expect(architecture).toContain("user.discoverTabs/history/claimTab");
     expect(architecture).not.toContain("user.openTabs/history/claimTab");


### PR DESCRIPTION
## Problem

After the typecheck and sleep/PATH fixes, P4 Packaging CI still failed at JS tests, and would then fail at Rust tests: three committed tests read developer-local, gitignored docs as spec inputs, so they fail on a clean CI checkout where the files are absent (they pass locally only because the files exist there).

Affected:
- `sdk/tests/help.test.ts` reads `docs/current-product-architecture.md`
- `obu-host/tests/method_name_sync.rs` reads `docs/current-product-architecture.md`
- `obu-node-repl/tests/description_snapshot.rs` `include_str!`s `docs/agent-browser-mcp-usage.md` (compile-time, so the crate would not even build on a clean checkout)

## Fix

Skip the doc-dependent assertions when the doc is absent: the sdk test guards the architecture block, the two Rust tests return early, and description_snapshot switches from compile-time `include_str!` to a runtime read so a missing file no longer breaks compilation. The docs stay developer-local (intentionally gitignored); these checks still validate locally where the docs exist.

## Verified locally (simulated clean checkout)

Hid both untracked docs and ran the three tests: all pass (skip). Restored the docs: all pass with full assertions. JS (all packages) and Rust crate tests green.