### PR TITLE
[codex] Fix browser runtime activation readiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "obu-host"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "obu-node-repl"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "obu-wire"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/obu-node-repl/tests/description_snapshot.rs
+++ b/crates/obu-node-repl/tests/description_snapshot.rs
@@ -108,6 +108,24 @@ fn agent_install_prompt_closeout_rules() {
     insta::assert_snapshot!("agent_install_prompt_closeout_rules", excerpt);
 }
 
+#[test]
+fn agent_install_prompt_path_rules() {
+    let body = include_str!("../../../prompts/agent-install-prompt.md");
+    let required = [
+        "The installer may add open-browser-use to shell profiles",
+        "Keep using the `\"$OBU\"` absolute path",
+        "Do not depend on `obu` being on `PATH`, even after the",
+        "beyond the official",
+        "installer's own managed env/profile updates.",
+    ];
+    for needle in required {
+        assert!(
+            body.contains(needle),
+            "missing agent install prompt PATH rule: {needle}"
+        );
+    }
+}
+
 fn fenced_block_after(body: &str, marker: &str) -> String {
     let mut seen_marker = false;
     let mut in_block = false;

--- a/docs/superpowers/specs/2026-05-26-agent-queryable-dev-logs-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-queryable-dev-logs-design.md
@@ -1,0 +1,470 @@
+# Agent-Queryable Dev Logs Design
+
+**Status:** P0 approved in brainstorming; pending written-spec review, then implementation plan.
+
+**Date:** 2026-05-26
+
+## Goal
+
+Add a local-first dev log mode that lets agents inspect, query, and study OBU's
+browser automation behavior across MCP, node-repl, SDK, host, and extension
+boundaries.
+
+The primary user is an agent debugging or improving OBU itself. The log must
+answer questions such as:
+
+- What happened in this run, in exact order?
+- Which state machine transitioned into a bad or surprising state?
+- What did `browser_status`, `observe`, `action`, RPC, native transport, and
+  extension diagnostics return?
+- Which historical failures look similar?
+- What facts can be recovered after pruning large payloads?
+
+This is not a hosted telemetry feature. P0 keeps all records local, disabled by
+default, and queryable without running an external service.
+
+## Chosen Open-Source Building Blocks
+
+P0 uses mature embedded components instead of adopting a hosted observability
+product as the primary data model.
+
+| Component | Role | Why it fits P0 |
+|---|---|---|
+| SQLite | Durable local index | Single file, local, already used through Rust `rusqlite`, easy for agents to query. |
+| SQLite FTS5 | Full-text search | Lets agents search events, errors, methods, state names, and redacted summaries without a separate search server. |
+| NDJSON | Append-only source log | Easy to stream, recover, diff, and inspect manually; remains useful if the SQLite index is rebuilt. |
+| DuckDB | Optional research/export path | Strong for later batch analysis over NDJSON or Parquet, without becoming a runtime dependency in P0. |
+| OpenTelemetry | Optional export compatibility | Good standard mapping for spans/logs later, but not the source of truth for OBU trajectory semantics. |
+
+Not selected for P0 as core storage:
+
+- Phoenix, Langfuse, SigNoz, Grafana Tempo/Loki: useful UIs and collectors, but
+  they add service dependencies and do not naturally model OBU's browser
+  observation/action/recovery semantics.
+- LanceDB/Qdrant: useful later for semantic similarity over summaries, but
+  embedding generation and privacy controls should be designed after the local
+  schema is stable.
+- rrweb/OpenReplay: useful for optional replay artifacts, but too sensitive and
+  large for default dev logging.
+
+## Product Principles
+
+1. **Agent-queryable first.** A log is successful when an agent can query it
+   without needing a human dashboard.
+2. **Append-only evidence first, indexes second.** NDJSON is the recovery source;
+   SQLite/FTS is a rebuildable query index.
+3. **State machines are first-class.** Transitions are explicit events, not
+   incidental strings inside generic debug messages.
+4. **Observe/action/return are paired.** Each request-shaped event should have a
+   start and completion event with correlation ids.
+5. **Pruning preserves reasoning.** Large payloads may be dropped or summarized,
+   but the event timeline, state transitions, statuses, error codes, and
+   recovery hints remain.
+6. **Local and private by default.** No upload, no remote collector, no page
+   storage capture, and no cookies/passwords/tokens in normal logs.
+
+## Scope
+
+P0 covers developer runs started through `obu mcp stdio` or a dev-mode MCP
+configuration. It records:
+
+- MCP tool calls: `browser_status`, `js`, `js_reset`, and later log-query tools.
+- node-repl execution lifecycle: turn id, kernel generation, duration, stdout
+  budget/truncation flags, structured user-code error detail.
+- SDK runtime: `browser_status` discovery, `tab.observe()`, `tab.step()`,
+  high-level action state traces, request lifecycle diagnostics.
+- Host/native-pipe RPC: method, request id, duration, success/error, timeout and
+  late-response lifecycle.
+- Host state machines and diagnostics exposed through existing `tracing` sites
+  where practical.
+- WebExtension debug events that already flow through `appendDebugLog`, mirrored
+  into the dev log through host-visible responses or a future export bridge.
+
+P0 does not add:
+
+- Hosted telemetry.
+- Semantic embeddings.
+- Browser replay recording.
+- Automatic action replay.
+- A graphical dashboard.
+- New behavior in normal non-dev runs.
+
+## Runtime Enablement
+
+Dev logs are disabled unless one of these is true:
+
+- `OBU_DEV_LOG=1`
+- `obu mcp stdio --dev-logs`
+- an MCP config generated with an explicit dev flag, such as
+  `obu mcp-config --agent=codex-cli --print --dev-logs`
+
+The CLI wrapper propagates the log configuration into `obu-node-repl` and the
+Node kernel:
+
+```text
+OBU_DEV_LOG=1
+OBU_DEV_LOG_DIR=$OBU_RUNTIME_DIR/logs/dev
+OBU_DEV_LOG_RUN_ID=<generated-run-id>
+```
+
+The default run id is time-sortable:
+
+```text
+YYYYMMDDTHHMMSSmmmZ-<short-random>
+```
+
+All files live under:
+
+```text
+$OBU_RUNTIME_DIR/logs/dev/<run_id>/
+  manifest.json
+  events.ndjson
+  events.sqlite
+  artifacts/
+```
+
+The runtime directory owner-only validation already used by OBU applies before
+writing logs.
+
+## Event Model
+
+Every event is a JSON object with a stable envelope:
+
+```ts
+type DevLogEvent = {
+  schemaVersion: 1;
+  seq: number;
+  ts: string;
+  monotonicMs?: number;
+  runId: string;
+  component: "cli" | "mcp" | "node_repl" | "sdk" | "host" | "extension";
+  event: string;
+  level: "debug" | "info" | "warn" | "error";
+  ids: {
+    sessionId?: string;
+    turnId?: string;
+    taskId?: string;
+    tabId?: string | number;
+    requestId?: string | number;
+    actionId?: string;
+    observationId?: string;
+    correlationId?: string;
+  };
+  state?: {
+    machine: string;
+    from?: string;
+    to?: string;
+    trace?: Array<{ state: string; at: number }>;
+  };
+  operation?: {
+    kind: "mcp_tool" | "js_exec" | "rpc" | "observe" | "action" | "high_level_action" | "transport" | "extension_event";
+    name: string;
+    status?: "started" | "succeeded" | "partial" | "blocked" | "failed" | "cancelled";
+    durationMs?: number;
+  };
+  input?: unknown;
+  output?: unknown;
+  error?: {
+    code?: string | number;
+    message: string;
+    productErrorCode?: string;
+    data?: unknown;
+  };
+  nextAction?: string;
+  pruning?: {
+    payloadBytes?: number;
+    storedBytes?: number;
+    strategy?: "inline" | "summary" | "artifact_ref" | "dropped";
+  };
+  text?: string;
+};
+```
+
+The envelope is intentionally close to OpenTelemetry concepts, but names remain
+OBU-native so browser-control semantics are not forced into generic span fields.
+
+### Required Event Families
+
+P0 defines these event names:
+
+| Event | Meaning |
+|---|---|
+| `run.started` / `run.finished` | Log run envelope. |
+| `mcp.tool.started` / `mcp.tool.finished` | MCP request lifecycle. |
+| `node.exec.started` / `node.exec.finished` | `js` kernel execution lifecycle. |
+| `browser_status.returned` | Readiness, backend discovery, product error, advisories. |
+| `observe.started` / `observe.finished` | `tab.observe()` input mode, result status, sections, state trace. |
+| `action.started` / `action.finished` | `tab.step(action)` input kind, result status/effect, state trace. |
+| `high_level_action.transition` | High-level action state transition and current step summary. |
+| `rpc.request.started` / `rpc.request.finished` | SDK/native-pipe/host RPC method, result/error, duration. |
+| `transport.lifecycle` | Timeout, late response, close, reconnect, native status change. |
+| `extension.debug` | Sanitized extension debug event mirrored from existing debug log vocabulary. |
+| `log.pruned` | A pruning operation changed retention or payload storage. |
+| `index.rebuilt` | SQLite/FTS index was rebuilt from NDJSON. |
+
+## SQLite Query Model
+
+The SQLite database is a rebuildable index over `events.ndjson`.
+
+```sql
+CREATE TABLE runs (
+  run_id TEXT PRIMARY KEY,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  schema_version INTEGER NOT NULL,
+  obu_version TEXT,
+  runtime_dir TEXT NOT NULL,
+  status TEXT NOT NULL
+);
+
+CREATE TABLE events (
+  run_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  ts TEXT NOT NULL,
+  component TEXT NOT NULL,
+  event TEXT NOT NULL,
+  level TEXT NOT NULL,
+  session_id TEXT,
+  turn_id TEXT,
+  task_id TEXT,
+  tab_id TEXT,
+  request_id TEXT,
+  action_id TEXT,
+  observation_id TEXT,
+  correlation_id TEXT,
+  machine TEXT,
+  state_from TEXT,
+  state_to TEXT,
+  operation_kind TEXT,
+  operation_name TEXT,
+  operation_status TEXT,
+  duration_ms INTEGER,
+  error_code TEXT,
+  product_error_code TEXT,
+  next_action TEXT,
+  summary TEXT,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (run_id, seq)
+);
+
+CREATE VIRTUAL TABLE events_fts USING fts5(
+  run_id UNINDEXED,
+  seq UNINDEXED,
+  event,
+  component,
+  operation_name,
+  summary,
+  error_code,
+  product_error_code,
+  next_action
+);
+```
+
+Useful indexes:
+
+```sql
+CREATE INDEX events_by_correlation ON events(run_id, correlation_id, seq);
+CREATE INDEX events_by_state ON events(machine, state_to, ts);
+CREATE INDEX events_by_error ON events(error_code, product_error_code, ts);
+CREATE INDEX events_by_operation ON events(operation_kind, operation_name, operation_status, ts);
+CREATE INDEX events_by_turn ON events(session_id, turn_id, seq);
+```
+
+## Agent Query Surfaces
+
+P0 exposes query tools through MCP so an agent can study logs without shelling
+out or knowing file paths. The same logic can also back CLI commands.
+
+| Tool | Purpose |
+|---|---|
+| `logs_list_runs` | Return recent runs with status, counts, first error, size, and prune state. |
+| `logs_timeline` | Return ordered events for one run, optionally filtered by component, turn, machine, or error. |
+| `logs_search` | FTS search over summaries, event names, operation names, error codes, and next actions. |
+| `logs_sql` | Read-only SQL over the SQLite index with guardrails. |
+| `logs_failure_context` | Return the smallest useful context around an error, including previous state transitions and correlated request/action/observe events. |
+| `logs_rebuild_index` | Rebuild SQLite/FTS from NDJSON for the selected run or all runs. |
+
+Read-only SQL guardrails:
+
+- allow only `SELECT`, `WITH`, `EXPLAIN QUERY PLAN`;
+- reject multiple statements;
+- enforce a row limit;
+- expose only log database tables;
+- use a dedicated read-only SQLite connection.
+
+Example agent queries:
+
+```sql
+SELECT machine, state_to, count(*) AS n
+FROM events
+WHERE operation_status IN ('failed', 'blocked')
+GROUP BY machine, state_to
+ORDER BY n DESC;
+```
+
+```sql
+SELECT run_id, seq, event, operation_name, error_code, summary
+FROM events
+WHERE product_error_code = 'dialog_requires_decision'
+ORDER BY ts DESC
+LIMIT 20;
+```
+
+## Pruning And Recovery
+
+P0 pruning is deterministic and visible in the log.
+
+Default retention:
+
+- keep last 20 runs;
+- keep at most 500 MB total under `$OBU_RUNTIME_DIR/logs/dev`;
+- inline event payloads up to 32 KB after redaction;
+- larger payloads become summaries or artifact references;
+- screenshots and binary displays are artifact refs, never inline base64 in the
+  SQLite summary path.
+
+Pruning order:
+
+1. Remove expired artifacts that are not referenced by retained events.
+2. Drop or summarize large payload fields inside old events when a summary
+   exists.
+3. Delete oldest complete runs until total size is under budget.
+4. Never partially delete the active run.
+
+Recovery guarantees after pruning:
+
+- run manifest survives for retained runs;
+- event order, component, event name, ids, operation status, state transition,
+  error code, product error code, next action, and summary survive;
+- full payload may be absent, but absence is explicit through `pruning.strategy`;
+- SQLite can be rebuilt from remaining NDJSON records;
+- deleted runs are represented by aggregate retention metadata in the parent
+  log manifest.
+
+P0 recovery means reconstructing the debugging timeline and last known state. It
+does not mean replaying browser actions, because browser actions may have side
+effects and depend on external page state.
+
+## Redaction
+
+P0 uses a shared redaction helper for Node/SDK log payloads and mirrors the
+extension's existing debug-data sanitization rules.
+
+Rules:
+
+- redact keys matching `token`, `password`, `secret`, `auth`, `cookie`,
+  `credential`, `session`, and `api_key`;
+- cap string lengths in summaries;
+- cap object depth and array length;
+- do not log raw cookies, local storage, session storage, password values, or
+  complete page text by default;
+- allow richer artifacts only when a dev flag explicitly requests them.
+
+The redaction decision is part of the event's `pruning` or `summary` metadata so
+agents can tell whether an absence is expected.
+
+## Integration Points
+
+### CLI
+
+- Add `--dev-logs` to `obu mcp stdio`.
+- Add `--dev-logs` to `obu mcp-config --print` so generated agent configs can
+  opt into the mode.
+- Add `obu logs` commands only after MCP query tools are available.
+
+### Node REPL MCP Server
+
+- Create the run manifest and log writer.
+- Wrap `call_tool` so every MCP tool has `mcp.tool.started/finished`.
+- Wrap `call_js` for `node.exec.started/finished`.
+- Register MCP query tools backed by the SQLite index.
+
+### SDK
+
+- Add a small log sink interface with a no-op default.
+- Emit observe/action/high-level action events from existing state trace points.
+- Record RPC lifecycle through `Transport.sendRequest`.
+- Keep SDK event emission best-effort: logging failures must not break browser
+  automation.
+
+### Host
+
+- Keep stderr tracing for protocol safety.
+- Add optional JSON file layer only in dev log mode, or forward selected host
+  lifecycle events into the node-repl log through existing response/diagnostic
+  surfaces first.
+- Reuse existing structured diagnostics where possible, especially request
+  lifecycle and task-store events.
+
+### Extension
+
+- P0 does not require the extension to write to the filesystem.
+- Existing `appendDebugLog` events remain the source vocabulary for extension
+  diagnostics.
+- When a host response includes extension diagnostics, node-repl/SDK records the
+  sanitized event into the run log.
+- A later bridge can export extension debug snapshots on demand.
+
+## Testing Strategy
+
+Unit tests:
+
+- event redaction and payload caps;
+- NDJSON append format and sequence allocation;
+- SQLite index insertion and FTS search;
+- read-only SQL guardrails;
+- pruning keeps timeline-critical fields;
+- rebuild index from NDJSON.
+
+Integration tests:
+
+- `obu mcp stdio --dev-logs` starts with clean MCP stdout and writes logs under
+  the runtime directory;
+- `browser_status` creates a queryable `browser_status.returned` event;
+- a simulated `js` call with `tab.observe()` and `tab.step()` creates correlated
+  observe/action/RPC events;
+- a timeout or structured RPC error appears in `logs_failure_context`;
+- non-dev mode writes no dev log files.
+
+Smoke tests:
+
+- packaged MCP stdio stays protocol-clean;
+- generated MCP config can include dev logs without altering normal config;
+- rebuild command reconstructs SQLite from NDJSON after deleting the SQLite file.
+
+## Risks
+
+- **Sensitive data:** mitigated by default-off mode, owner-only runtime dir,
+  shared redaction, payload caps, and no browser storage capture.
+- **MCP protocol pollution:** logs must never write to stdout. All file writes
+  are side-channel only.
+- **Performance:** writer uses buffered append and bounded SQLite transactions;
+  if indexing fails, NDJSON remains the source log.
+- **Schema drift:** schema version is required in every event and in the run
+  manifest.
+- **Partial cross-process coverage:** P0 favors SDK/node-repl/host-visible
+  events first. Direct extension filesystem logging is deferred.
+
+## Future Extensions
+
+- DuckDB/Parquet export for broad research over many runs.
+- OpenTelemetry OTLP export for Phoenix, SigNoz, or Grafana deployments.
+- LanceDB or Qdrant semantic search over redacted run summaries.
+- Optional rrweb-style replay artifacts behind a separate explicit flag.
+- Human UI over the same SQLite query API.
+
+## File Structure For Implementation
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/obu-node-repl/src/dev_log/` | create | Run manifest, NDJSON writer, SQLite indexer, query API. |
+| `crates/obu-node-repl/src/mcp_server.rs` | modify | Wrap MCP calls and expose log query tools. |
+| `crates/obu-node-repl/src/cli.rs` | modify | Add `--dev-logs` and log path options. |
+| `packages/cli/src/index.ts` | modify | Pass dev-log env to node-repl and print dev MCP config. |
+| `packages/sdk/src/dev-log.ts` | create | Browser-runtime log sink and redaction helpers. |
+| `packages/sdk/src/wire/transport.ts` | modify | Emit RPC lifecycle events. |
+| `packages/sdk/src/tab.ts` | modify | Emit observe/action lifecycle events. |
+| `packages/sdk/src/high-level-action.ts` | modify | Emit high-level action transition events. |
+| `docs/troubleshooting.md` | modify | Document how agents query local dev logs. |
+| `crates/obu-node-repl/tests/` | modify/create | Dev-log writer, query, MCP tool, and stdout-clean tests. |
+| `packages/sdk/tests/` | modify/create | SDK event emission and redaction tests. |

--- a/packages/browser-control-core/package.json
+++ b/packages/browser-control-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/browser-control-core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "Pure browser-control protocol types, planners, and fixtures for open-browser-use.",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "open-browser-use user-facing command line tools.",
   "license": "MIT",

--- a/packages/cli/src/browser-paths.ts
+++ b/packages/cli/src/browser-paths.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 
 export type BrowserKind = "chrome" | "chrome-for-testing" | "edge" | "brave" | "arc" | "chromium";
 
+export function browserRuntimeKind(browser: BrowserKind): string {
+  return browser === "chrome-for-testing" ? "chrome" : browser;
+}
+
 export function browserInstallPath(browser: BrowserKind, platform: NodeJS.Platform): string | undefined {
   if (platform === "darwin") {
     return {

--- a/packages/cli/src/browser-profile-discovery.test.ts
+++ b/packages/cli/src/browser-profile-discovery.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  discoverProfileCandidates,
+  enabledExtensionProfiles,
+  readLastUsedProfileName,
+} from "./browser-profile-discovery.js";
+
+const EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop";
+
+test("discoverProfileCandidates orders last used profile before default sort", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-profile-discovery-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeChromePreferences(path.join(root, "Default"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(root, "Profile 2"), EXTENSION_ID, 1);
+  await writeFile(path.join(root, "Local State"), JSON.stringify({
+    profile: { last_used: "Profile 2" },
+  }), "utf8");
+
+  assert.equal(await readLastUsedProfileName(root), "Profile 2");
+  const candidates = await discoverProfileCandidates(root, EXTENSION_ID);
+
+  assert.deepEqual(candidates.map((candidate) => path.basename(candidate.path)), [
+    "Profile 2",
+    "Default",
+  ]);
+});
+
+test("enabledExtensionProfiles keeps only installed and enabled extension profiles", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-profile-discovery-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeChromePreferences(path.join(root, "Default"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(root, "Profile 2"), EXTENSION_ID, 0);
+  await writeChromePreferences(path.join(root, "Profile 4"), EXTENSION_ID, 1, { permissions_increase: true });
+  await writeChromePreferences(path.join(root, "Profile 5"), EXTENSION_ID, 1, ["corrupt_permissions"]);
+  await mkdir(path.join(root, "Profile 3"), { recursive: true });
+  await writeFile(path.join(root, "Profile 3", "Preferences"), JSON.stringify({ extensions: { settings: {} } }), "utf8");
+
+  const candidates = await discoverProfileCandidates(root, EXTENSION_ID);
+  const enabled = enabledExtensionProfiles(candidates);
+
+  assert.deepEqual(enabled.map((candidate) => path.basename(candidate.path)), ["Default"]);
+  assert.equal(candidates.find((candidate) => path.basename(candidate.path) === "Profile 2")?.extensionEnabled, "disabled");
+  assert.equal(candidates.find((candidate) => path.basename(candidate.path) === "Profile 3")?.extensionInstalled, "missing");
+  assert.equal(candidates.find((candidate) => path.basename(candidate.path) === "Profile 4")?.extensionEnabled, "disabled");
+  assert.equal(candidates.find((candidate) => path.basename(candidate.path) === "Profile 5")?.extensionEnabled, "disabled");
+});
+
+async function writeChromePreferences(
+  profilePath: string,
+  extensionId: string,
+  state: number,
+  disableReasons: unknown = 0,
+): Promise<void> {
+  await mkdir(profilePath, { recursive: true });
+  const preferences = {
+    extensions: {
+      settings: {
+        [extensionId]: {
+          state,
+          disable_reasons: disableReasons,
+        },
+      },
+    },
+  };
+  await writeFile(path.join(profilePath, "Preferences"), JSON.stringify(preferences), "utf8");
+}

--- a/packages/cli/src/browser-profile-discovery.ts
+++ b/packages/cli/src/browser-profile-discovery.ts
@@ -1,0 +1,222 @@
+import { constants } from "node:fs";
+import { access, lstat, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+export type ComponentState =
+  | "pass"
+  | "warn"
+  | "fail"
+  | "missing"
+  | "unreadable"
+  | "disabled"
+  | "stale"
+  | "invalid"
+  | "not_checked";
+
+export type ProfileCandidate = {
+  path: string;
+  profileExists: ComponentState;
+  extensionInstalled: ComponentState;
+  extensionEnabled: ComponentState;
+  reasons?: Record<string, string>;
+};
+
+export async function discoverProfileCandidates(root: string, extensionId: string): Promise<ProfileCandidate[]> {
+  const profilePaths = await defaultProfileCandidates(root);
+  const candidates = await Promise.all(profilePaths.map((candidate) => inspectProfileCandidate(candidate, extensionId)));
+  return orderCandidatesByLastUsed(root, candidates);
+}
+
+export function enabledExtensionProfiles(candidates: ProfileCandidate[]): ProfileCandidate[] {
+  return candidates.filter((candidate) =>
+    candidate.profileExists === "pass" &&
+    candidate.extensionInstalled === "pass" &&
+    candidate.extensionEnabled === "pass"
+  );
+}
+
+export async function readLastUsedProfileName(root: string): Promise<string | undefined> {
+  const localState = await readJson(path.join(root, "Local State")).catch(() => undefined);
+  if (!isRecord(localState)) return undefined;
+  const profile = localState.profile;
+  if (!isRecord(profile)) return undefined;
+  return typeof profile.last_used === "string" && profile.last_used.length > 0
+    ? profile.last_used
+    : undefined;
+}
+
+export async function defaultProfileCandidates(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  const candidates: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(root, entry.name);
+    if (entry.name === "NativeMessagingHosts") continue;
+    if (entry.name === "Default" || /^Profile \d+$/.test(entry.name)) {
+      candidates.push(candidate);
+      continue;
+    }
+    if (await access(path.join(candidate, "Preferences"), constants.R_OK).then(() => true).catch(() => false)) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates.sort(compareProfilePaths);
+}
+
+export async function inspectProfileCandidate(profilePath: string, extensionId: string): Promise<ProfileCandidate> {
+  const stats = await lstat(profilePath).catch((error) => error as NodeJS.ErrnoException);
+  if (stats instanceof Error) {
+    const missing = stats.code === "ENOENT";
+    return {
+      path: profilePath,
+      profileExists: missing ? "missing" : "unreadable",
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        profileExists: missing ? "profile path does not exist" : `profile path cannot be inspected: ${stats.message}`,
+        extensionInstalled: "extension state cannot be inspected until the profile exists and is readable",
+        extensionEnabled: "extension state cannot be inspected until the profile exists and is readable",
+      },
+    };
+  }
+  if (!stats.isDirectory()) {
+    return {
+      path: profilePath,
+      profileExists: "unreadable",
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        profileExists: "profile path is not a directory",
+        extensionInstalled: "extension state cannot be inspected until the profile path is a readable directory",
+        extensionEnabled: "extension state cannot be inspected until the profile path is a readable directory",
+      },
+    };
+  }
+  if (!await access(profilePath, constants.R_OK).then(() => true).catch(() => false)) {
+    return {
+      path: profilePath,
+      profileExists: "unreadable",
+      extensionInstalled: "not_checked",
+      extensionEnabled: "not_checked",
+      reasons: {
+        profileExists: "profile directory is not readable",
+        extensionInstalled: "extension state cannot be inspected until the profile is readable",
+        extensionEnabled: "extension state cannot be inspected until the profile is readable",
+      },
+    };
+  }
+
+  const preferenceFiles = [
+    path.join(profilePath, "Preferences"),
+    path.join(profilePath, "Secure Preferences"),
+  ];
+  let sawPreferenceFile = false;
+  for (const file of preferenceFiles) {
+    const preferences = await readJson(file).catch((error) => {
+      const nodeError = error as NodeJS.ErrnoException;
+      if (nodeError.code === "ENOENT") return undefined;
+      return { __obu_read_error: nodeError.message ?? String(error) };
+    });
+    if (preferences === undefined) continue;
+    sawPreferenceFile = true;
+    if (isRecord(preferences) && typeof preferences.__obu_read_error === "string") {
+      return {
+        path: profilePath,
+        profileExists: "unreadable",
+        extensionInstalled: "not_checked",
+        extensionEnabled: "not_checked",
+        reasons: {
+          profileExists: `profile preferences cannot be read: ${preferences.__obu_read_error}`,
+          extensionInstalled: "extension state cannot be inspected until profile preferences are readable",
+          extensionEnabled: "extension state cannot be inspected until profile preferences are readable",
+        },
+      };
+    }
+    const settings = extensionSettings(preferences, extensionId);
+    if (!settings) continue;
+    if (settings.state === 0 || hasDisableReasons(settings.disable_reasons)) {
+      return {
+        path: profilePath,
+        profileExists: "pass",
+        extensionInstalled: "pass",
+        extensionEnabled: "disabled",
+        reasons: {
+          extensionEnabled: `extension is disabled in ${file}`,
+        },
+      };
+    }
+    return {
+      path: profilePath,
+      profileExists: "pass",
+      extensionInstalled: "pass",
+      extensionEnabled: "pass",
+    };
+  }
+
+  return {
+    path: profilePath,
+    profileExists: "pass",
+    extensionInstalled: "missing",
+    extensionEnabled: "not_checked",
+    reasons: {
+      extensionInstalled: sawPreferenceFile
+        ? `extension ${extensionId} was not found in profile preferences`
+        : "profile preferences do not exist yet",
+      extensionEnabled: "enablement was not inspected because the extension is missing",
+    },
+  };
+}
+
+function orderCandidatesByLastUsed(root: string, candidates: ProfileCandidate[]): Promise<ProfileCandidate[]> {
+  return readLastUsedProfileName(root).then((lastUsed) => {
+    if (!lastUsed) return candidates;
+    return [...candidates].sort((left, right) => {
+      const leftLast = path.basename(left.path) === lastUsed ? 0 : 1;
+      const rightLast = path.basename(right.path) === lastUsed ? 0 : 1;
+      if (leftLast !== rightLast) return leftLast - rightLast;
+      return compareProfilePaths(left.path, right.path);
+    });
+  });
+}
+
+function extensionSettings(preferences: unknown, extensionId: string): Record<string, any> | undefined {
+  if (!isRecord(preferences)) return undefined;
+  const extensions = preferences.extensions;
+  if (!isRecord(extensions)) return undefined;
+  const settings = extensions.settings;
+  if (!isRecord(settings)) return undefined;
+  const extension = settings[extensionId];
+  return isRecord(extension) ? extension : undefined;
+}
+
+function hasDisableReasons(value: unknown): boolean {
+  if (value === undefined || value === null || value === false || value === 0) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true;
+}
+
+function compareProfilePaths(left: string, right: string): number {
+  const leftName = path.basename(left);
+  const rightName = path.basename(right);
+  const leftRank = profileSortRank(leftName);
+  const rightRank = profileSortRank(rightName);
+  if (leftRank[0] !== rightRank[0]) return leftRank[0] - rightRank[0];
+  if (leftRank[1] !== rightRank[1]) return leftRank[1] - rightRank[1];
+  return path.resolve(left).localeCompare(path.resolve(right));
+}
+
+function profileSortRank(name: string): [number, number] {
+  if (name === "Default") return [0, 0];
+  const profile = /^Profile (\d+)$/.exec(name);
+  if (profile) return [1, Number(profile[1])];
+  return [2, 0];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJson(file: string): Promise<unknown> {
+  return JSON.parse(await readFile(file, "utf8"));
+}

--- a/packages/cli/src/browser-runtime-activation.test.ts
+++ b/packages/cli/src/browser-runtime-activation.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+
+import { activateBrowserRuntime } from "./browser-runtime-activation.js";
+import { browserProfileRoot } from "./browser-paths.js";
+
+const EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop";
+
+test("activateBrowserRuntime opens only enabled extension profiles up to the default limit", async (t) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "obu-activation-home-"));
+  t.after(() => rm(homeDir, { recursive: true, force: true }));
+  withIsolatedXdgConfigHome(t, homeDir);
+  const profileRoot = browserProfileRoot("chrome", process.platform, homeDir);
+  await writeChromePreferences(path.join(profileRoot, "Default"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 2"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 3"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 4"), EXTENSION_ID, 1);
+
+  const opened: string[] = [];
+  const result = await activateBrowserRuntime({
+    browser: "chrome",
+    extensionId: EXTENSION_ID,
+    homeDir,
+    runtimeDir: path.join(homeDir, "runtime"),
+    hasActiveDescriptor: async () => opened.length >= 2,
+    openPopup: async (target) => {
+      opened.push(path.basename(target.profilePath));
+    },
+    now: fakeClock().now,
+    sleep: async () => undefined,
+  });
+
+  assert.equal(result.result, "ready");
+  assert.deepEqual(opened, ["Default", "Profile 2"]);
+  assert.equal(result.openedCount, 2);
+  assert.equal(result.profileLimit, 3);
+});
+
+test("activateBrowserRuntime never opens more than the default profile limit", async (t) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "obu-activation-home-"));
+  t.after(() => rm(homeDir, { recursive: true, force: true }));
+  withIsolatedXdgConfigHome(t, homeDir);
+  const profileRoot = browserProfileRoot("chrome", process.platform, homeDir);
+  await writeChromePreferences(path.join(profileRoot, "Default"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 2"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 3"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 4"), EXTENSION_ID, 1);
+  const clock = fakeClock();
+  const opened: string[] = [];
+
+  const result = await activateBrowserRuntime({
+    browser: "chrome",
+    extensionId: EXTENSION_ID,
+    homeDir,
+    runtimeDir: path.join(homeDir, "runtime"),
+    timeoutMs: 1000,
+    intervalMs: 250,
+    hasActiveDescriptor: async () => false,
+    openPopup: async (target) => {
+      opened.push(path.basename(target.profilePath));
+    },
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.result, "timeout");
+  assert.deepEqual(opened, ["Default", "Profile 2", "Profile 3"]);
+  assert.equal(result.openedCount, 3);
+  assert.equal(result.profileLimit, 3);
+});
+
+test("activateBrowserRuntime stops after 5 seconds when no descriptor appears", async (t) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "obu-activation-home-"));
+  t.after(() => rm(homeDir, { recursive: true, force: true }));
+  withIsolatedXdgConfigHome(t, homeDir);
+  const profileRoot = browserProfileRoot("chrome", process.platform, homeDir);
+  await writeChromePreferences(path.join(profileRoot, "Default"), EXTENSION_ID, 1);
+  const clock = fakeClock();
+  const opened: string[] = [];
+
+  const result = await activateBrowserRuntime({
+    browser: "chrome",
+    extensionId: EXTENSION_ID,
+    homeDir,
+    runtimeDir: path.join(homeDir, "runtime"),
+    timeoutMs: 5000,
+    intervalMs: 500,
+    hasActiveDescriptor: async () => false,
+    openPopup: async (target) => {
+      opened.push(path.basename(target.profilePath));
+    },
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.result, "timeout");
+  assert.deepEqual(opened, ["Default"]);
+  assert.equal(result.timeoutMs, 5000);
+  assert.equal(clock.elapsed(), 5000);
+});
+
+test("activateBrowserRuntime reports no_candidates without opening a browser", async (t) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "obu-activation-home-"));
+  t.after(() => rm(homeDir, { recursive: true, force: true }));
+  withIsolatedXdgConfigHome(t, homeDir);
+  const profileRoot = browserProfileRoot("chrome", process.platform, homeDir);
+  await writeChromePreferences(path.join(profileRoot, "Default"), EXTENSION_ID, 0);
+  let openCount = 0;
+
+  const result = await activateBrowserRuntime({
+    browser: "chrome",
+    extensionId: EXTENSION_ID,
+    homeDir,
+    runtimeDir: path.join(homeDir, "runtime"),
+    hasActiveDescriptor: async () => false,
+    openPopup: async () => {
+      openCount += 1;
+    },
+    now: fakeClock().now,
+    sleep: async () => undefined,
+  });
+
+  assert.equal(result.result, "no_candidates");
+  assert.equal(openCount, 0);
+  assert.equal(result.candidates.some((candidate) => candidate.extensionEnabled === "disabled"), true);
+});
+
+async function writeChromePreferences(profilePath: string, extensionId: string, state: number): Promise<void> {
+  await mkdir(profilePath, { recursive: true });
+  const preferences = {
+    extensions: {
+      settings: {
+        [extensionId]: {
+          state,
+          disable_reasons: 0,
+        },
+      },
+    },
+  };
+  await writeFile(path.join(profilePath, "Preferences"), JSON.stringify(preferences), "utf8");
+}
+
+function fakeClock(): {
+  now(): number;
+  sleep(ms: number): Promise<void>;
+  elapsed(): number;
+} {
+  let current = 0;
+  return {
+    now: () => current,
+    sleep: async (ms: number) => {
+      current += ms;
+    },
+    elapsed: () => current,
+  };
+}
+
+function withIsolatedXdgConfigHome(t: TestContext, homeDir: string): void {
+  const previous = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = path.join(homeDir, ".config");
+  t.after(() => {
+    if (previous === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = previous;
+    }
+  });
+}

--- a/packages/cli/src/browser-runtime-activation.test.ts
+++ b/packages/cli/src/browser-runtime-activation.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
@@ -19,6 +20,7 @@ test("activateBrowserRuntime opens only enabled extension profiles up to the def
   await writeChromePreferences(path.join(profileRoot, "Profile 3"), EXTENSION_ID, 1);
   await writeChromePreferences(path.join(profileRoot, "Profile 4"), EXTENSION_ID, 1);
 
+  const clock = fakeClock();
   const opened: string[] = [];
   const result = await activateBrowserRuntime({
     browser: "chrome",
@@ -29,14 +31,46 @@ test("activateBrowserRuntime opens only enabled extension profiles up to the def
     openPopup: async (target) => {
       opened.push(path.basename(target.profilePath));
     },
-    now: fakeClock().now,
-    sleep: async () => undefined,
+    now: clock.now,
+    sleep: clock.sleep,
   });
 
   assert.equal(result.result, "ready");
   assert.deepEqual(opened, ["Default", "Profile 2"]);
   assert.equal(result.openedCount, 2);
   assert.equal(result.profileLimit, 3);
+});
+
+test("activateBrowserRuntime does not open later profiles when descriptor appears after first popup", async (t) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "obu-activation-home-"));
+  t.after(() => rm(homeDir, { recursive: true, force: true }));
+  withIsolatedXdgConfigHome(t, homeDir);
+  const profileRoot = browserProfileRoot("chrome", process.platform, homeDir);
+  await writeChromePreferences(path.join(profileRoot, "Default"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 2"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 3"), EXTENSION_ID, 1);
+  const clock = fakeClock();
+  const opened: string[] = [];
+
+  const result = await activateBrowserRuntime({
+    browser: "chrome",
+    extensionId: EXTENSION_ID,
+    homeDir,
+    runtimeDir: path.join(homeDir, "runtime"),
+    timeoutMs: 1000,
+    intervalMs: 250,
+    hasActiveDescriptor: async () => opened.length > 0 && clock.elapsed() >= 250,
+    openPopup: async (target) => {
+      opened.push(path.basename(target.profilePath));
+    },
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.result, "ready");
+  assert.deepEqual(opened, ["Default"]);
+  assert.equal(result.openedCount, 1);
+  assert.equal(clock.elapsed(), 250);
 });
 
 test("activateBrowserRuntime never opens more than the default profile limit", async (t) => {
@@ -70,6 +104,40 @@ test("activateBrowserRuntime never opens more than the default profile limit", a
   assert.deepEqual(opened, ["Default", "Profile 2", "Profile 3"]);
   assert.equal(result.openedCount, 3);
   assert.equal(result.profileLimit, 3);
+});
+
+test("activateBrowserRuntime continues after open failures and counts only opened profiles", async (t) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "obu-activation-home-"));
+  t.after(() => rm(homeDir, { recursive: true, force: true }));
+  withIsolatedXdgConfigHome(t, homeDir);
+  const profileRoot = browserProfileRoot("chrome", process.platform, homeDir);
+  await writeChromePreferences(path.join(profileRoot, "Default"), EXTENSION_ID, 1);
+  await writeChromePreferences(path.join(profileRoot, "Profile 2"), EXTENSION_ID, 1);
+  const clock = fakeClock();
+  const opened: string[] = [];
+
+  const result = await activateBrowserRuntime({
+    browser: "chrome",
+    extensionId: EXTENSION_ID,
+    homeDir,
+    runtimeDir: path.join(homeDir, "runtime"),
+    timeoutMs: 1000,
+    intervalMs: 250,
+    hasActiveDescriptor: async () => opened.includes("Profile 2"),
+    openPopup: async (target) => {
+      const profile = path.basename(target.profilePath);
+      if (profile === "Default") throw new Error("cannot open default");
+      opened.push(profile);
+    },
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.result, "ready");
+  assert.deepEqual(result.attemptedProfiles.map((profilePath) => path.basename(profilePath)), ["Default", "Profile 2"]);
+  assert.deepEqual(opened, ["Profile 2"]);
+  assert.equal(result.openedCount, 1);
+  assert.match(result.errors[0] ?? "", /cannot open default/);
 });
 
 test("activateBrowserRuntime stops after 5 seconds when no descriptor appears", async (t) => {
@@ -128,6 +196,33 @@ test("activateBrowserRuntime reports no_candidates without opening a browser", a
   assert.equal(result.candidates.some((candidate) => candidate.extensionEnabled === "disabled"), true);
 });
 
+test("activateBrowserRuntime ignores an active descriptor for a different browser", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("Unix socket descriptor fixture is POSIX-only");
+    return;
+  }
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "obu-activation-home-"));
+  t.after(() => rm(homeDir, { recursive: true, force: true }));
+  const runtimeDir = path.join(homeDir, "runtime");
+  await writeRuntimeDescriptorFixture(t, runtimeDir, {
+    browserKind: "chrome",
+    extensionId: EXTENSION_ID,
+  });
+
+  const result = await activateBrowserRuntime({
+    browser: "edge",
+    extensionId: EXTENSION_ID,
+    homeDir,
+    runtimeDir,
+    openPopup: async () => {
+      throw new Error("activation should not open a browser when no edge candidates exist");
+    },
+  });
+
+  assert.equal(result.result, "no_candidates");
+  assert.equal(result.openedCount, 0);
+});
+
 async function writeChromePreferences(profilePath: string, extensionId: string, state: number): Promise<void> {
   await mkdir(profilePath, { recursive: true });
   const preferences = {
@@ -141,6 +236,94 @@ async function writeChromePreferences(profilePath: string, extensionId: string, 
     },
   };
   await writeFile(path.join(profilePath, "Preferences"), JSON.stringify(preferences), "utf8");
+}
+
+async function writeRuntimeDescriptorFixture(
+  t: TestContext,
+  runtimeDir: string,
+  metadata: { browserKind: string; extensionId: string },
+): Promise<void> {
+  const descriptorDir = path.join(runtimeDir, "webextension");
+  await mkdir(descriptorDir, { recursive: true, mode: 0o700 });
+  await chmod(descriptorDir, 0o700);
+  const socketPath = path.join(runtimeDir, `${metadata.browserKind}.sock`);
+  await startRuntimeDescriptorServer(t, socketPath, metadata);
+  const descriptorPath = path.join(descriptorDir, `${metadata.browserKind}.json`);
+  await writeFile(descriptorPath, JSON.stringify({
+    schema_version: 1,
+    type: "webextension",
+    name: metadata.browserKind,
+    socketPath,
+    sdk_auth_token: "token",
+    pid: process.pid,
+    metadata: {
+      browser_kind: metadata.browserKind,
+      extension_id: metadata.extensionId,
+    },
+  }), { encoding: "utf8", mode: 0o600 });
+  await chmod(descriptorPath, 0o600);
+}
+
+async function startRuntimeDescriptorServer(
+  t: TestContext,
+  socketPath: string,
+  metadata: { browserKind: string; extensionId: string },
+): Promise<void> {
+  const server = net.createServer((socket) => {
+    let authenticated = false;
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (buffer.length >= 4) {
+        const length = buffer.readUInt32LE(0);
+        if (buffer.length < 4 + length) return;
+        const request = JSON.parse(buffer.subarray(4, 4 + length).toString("utf8"));
+        buffer = buffer.subarray(4 + length);
+        if (request.method === "auth") {
+          authenticated = true;
+          socket.write(encodeTestFrame({ jsonrpc: "2.0", id: request.id, result: null }));
+          continue;
+        }
+        if (authenticated && request.method === "getInfo") {
+          socket.write(encodeTestFrame({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              type: "webextension",
+              name: metadata.browserKind,
+              metadata: {
+                backend: {
+                  browser_kind: metadata.browserKind,
+                  extension_id: metadata.extensionId,
+                },
+              },
+            },
+          }));
+          continue;
+        }
+        socket.write(encodeTestFrame({ jsonrpc: "2.0", id: request.id, error: { code: -32601, message: "method not found" } }));
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  await chmod(socketPath, 0o600);
+  t.after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+}
+
+function encodeTestFrame(payload: Record<string, unknown>): Buffer {
+  const body = Buffer.from(JSON.stringify(payload));
+  const frame = Buffer.alloc(4 + body.length);
+  frame.writeUInt32LE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
 }
 
 function fakeClock(): {

--- a/packages/cli/src/browser-runtime-activation.ts
+++ b/packages/cli/src/browser-runtime-activation.ts
@@ -3,7 +3,7 @@ import { constants } from "node:fs";
 import { access } from "node:fs/promises";
 import path from "node:path";
 
-import { browserInstallPath, browserProfileRoot, type BrowserKind } from "./browser-paths.js";
+import { browserInstallPath, browserProfileRoot, browserRuntimeKind, type BrowserKind } from "./browser-paths.js";
 import {
   discoverProfileCandidates,
   enabledExtensionProfiles,
@@ -54,7 +54,10 @@ export async function activateBrowserRuntime(options: BrowserRuntimeActivationOp
   const now = options.now ?? Date.now;
   const sleep = options.sleep ?? defaultSleep;
   const hasActiveDescriptor = options.hasActiveDescriptor ?? (() =>
-    hasActiveWebExtensionRuntimeDescriptor(options.runtimeDir, { extensionId: options.extensionId })
+    hasActiveWebExtensionRuntimeDescriptor(options.runtimeDir, {
+      extensionId: options.extensionId,
+      browserKind: browserRuntimeKind(options.browser),
+    })
   );
   const openPopup = options.openPopup ?? openBrowserPopup;
   const root = browserProfileRoot(options.browser, process.platform, options.homeDir);
@@ -62,6 +65,7 @@ export async function activateBrowserRuntime(options: BrowserRuntimeActivationOp
   const enabled = enabledExtensionProfiles(candidates).slice(0, profileLimit);
   const attemptedProfiles: string[] = [];
   const errors: string[] = [];
+  let openedCount = 0;
 
   if (await hasActiveDescriptor()) {
     return {
@@ -90,8 +94,11 @@ export async function activateBrowserRuntime(options: BrowserRuntimeActivationOp
   }
 
   const url = `chrome-extension://${options.extensionId}/popup.html`;
-  for (const candidate of enabled) {
+  const deadline = now() + timeoutMs;
+  for (let index = 0; index < enabled.length && now() < deadline; index += 1) {
+    const candidate = enabled[index]!;
     attemptedProfiles.push(candidate.path);
+    let opened = false;
     try {
       await openPopup({
         browser: options.browser,
@@ -99,6 +106,8 @@ export async function activateBrowserRuntime(options: BrowserRuntimeActivationOp
         profilePath: candidate.path,
         url,
       });
+      opened = true;
+      openedCount += 1;
     } catch (error) {
       errors.push(`${candidate.path}: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -110,17 +119,22 @@ export async function activateBrowserRuntime(options: BrowserRuntimeActivationOp
         profileLimit,
         candidates,
         attemptedProfiles,
-        openedCount: attemptedProfiles.length,
+        openedCount,
         errors,
       };
     }
-  }
-
-  const deadline = now() + timeoutMs;
-  while (now() < deadline) {
-    const remaining = Math.max(0, deadline - now());
-    await sleep(Math.min(intervalMs, remaining));
-    if (await hasActiveDescriptor()) {
+    if (!opened) continue;
+    const remainingMs = Math.max(0, deadline - now());
+    const remainingProfiles = enabled.length - index;
+    const profileWaitMs = Math.max(intervalMs, Math.ceil(remainingMs / remainingProfiles));
+    const profileDeadline = Math.min(deadline, now() + profileWaitMs);
+    if (await waitForDescriptor({
+      deadline: profileDeadline,
+      intervalMs,
+      now,
+      sleep,
+      hasActiveDescriptor,
+    })) {
       return {
         result: "ready",
         timeoutMs,
@@ -128,22 +142,57 @@ export async function activateBrowserRuntime(options: BrowserRuntimeActivationOp
         profileLimit,
         candidates,
         attemptedProfiles,
-        openedCount: attemptedProfiles.length,
+        openedCount,
         errors,
       };
     }
   }
 
+  if (openedCount > 0 && await waitForDescriptor({
+    deadline,
+    intervalMs,
+    now,
+    sleep,
+    hasActiveDescriptor,
+  })) {
+    return {
+      result: "ready",
+      timeoutMs,
+      intervalMs,
+      profileLimit,
+      candidates,
+      attemptedProfiles,
+      openedCount,
+      errors,
+    };
+  }
+
   return {
-    result: errors.length === attemptedProfiles.length ? "open_failed" : "timeout",
+    result: openedCount === 0 ? "open_failed" : "timeout",
     timeoutMs,
     intervalMs,
     profileLimit,
     candidates,
     attemptedProfiles,
-    openedCount: attemptedProfiles.length,
+    openedCount,
     errors,
   };
+}
+
+async function waitForDescriptor(input: {
+  deadline: number;
+  intervalMs: number;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  hasActiveDescriptor: () => Promise<boolean>;
+}): Promise<boolean> {
+  while (input.now() < input.deadline) {
+    const remaining = Math.max(0, input.deadline - input.now());
+    if (remaining === 0) break;
+    await input.sleep(Math.min(input.intervalMs, remaining));
+    if (await input.hasActiveDescriptor()) return true;
+  }
+  return false;
 }
 
 export async function openBrowserPopup(target: BrowserActivationTarget): Promise<void> {

--- a/packages/cli/src/browser-runtime-activation.ts
+++ b/packages/cli/src/browser-runtime-activation.ts
@@ -1,0 +1,195 @@
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import path from "node:path";
+
+import { browserInstallPath, browserProfileRoot, type BrowserKind } from "./browser-paths.js";
+import {
+  discoverProfileCandidates,
+  enabledExtensionProfiles,
+  type ProfileCandidate,
+} from "./browser-profile-discovery.js";
+import { hasActiveWebExtensionRuntimeDescriptor } from "./doctor-browser.js";
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_INTERVAL_MS = 250;
+const DEFAULT_PROFILE_LIMIT = 3;
+
+export type BrowserActivationTarget = {
+  browser: BrowserKind;
+  extensionId: string;
+  profilePath: string;
+  url: string;
+};
+
+export type BrowserRuntimeActivationResult = {
+  result: "ready" | "timeout" | "no_candidates" | "open_failed";
+  timeoutMs: number;
+  intervalMs: number;
+  profileLimit: number;
+  candidates: ProfileCandidate[];
+  attemptedProfiles: string[];
+  openedCount: number;
+  errors: string[];
+};
+
+export type BrowserRuntimeActivationOptions = {
+  browser: BrowserKind;
+  extensionId: string;
+  homeDir: string;
+  runtimeDir: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+  profileLimit?: number;
+  openPopup?: (target: BrowserActivationTarget) => Promise<void>;
+  hasActiveDescriptor?: () => Promise<boolean>;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+export async function activateBrowserRuntime(options: BrowserRuntimeActivationOptions): Promise<BrowserRuntimeActivationResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const profileLimit = options.profileLimit ?? DEFAULT_PROFILE_LIMIT;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const hasActiveDescriptor = options.hasActiveDescriptor ?? (() =>
+    hasActiveWebExtensionRuntimeDescriptor(options.runtimeDir, { extensionId: options.extensionId })
+  );
+  const openPopup = options.openPopup ?? openBrowserPopup;
+  const root = browserProfileRoot(options.browser, process.platform, options.homeDir);
+  const candidates = await discoverProfileCandidates(root, options.extensionId);
+  const enabled = enabledExtensionProfiles(candidates).slice(0, profileLimit);
+  const attemptedProfiles: string[] = [];
+  const errors: string[] = [];
+
+  if (await hasActiveDescriptor()) {
+    return {
+      result: "ready",
+      timeoutMs,
+      intervalMs,
+      profileLimit,
+      candidates,
+      attemptedProfiles,
+      openedCount: 0,
+      errors,
+    };
+  }
+
+  if (enabled.length === 0) {
+    return {
+      result: "no_candidates",
+      timeoutMs,
+      intervalMs,
+      profileLimit,
+      candidates,
+      attemptedProfiles,
+      openedCount: 0,
+      errors,
+    };
+  }
+
+  const url = `chrome-extension://${options.extensionId}/popup.html`;
+  for (const candidate of enabled) {
+    attemptedProfiles.push(candidate.path);
+    try {
+      await openPopup({
+        browser: options.browser,
+        extensionId: options.extensionId,
+        profilePath: candidate.path,
+        url,
+      });
+    } catch (error) {
+      errors.push(`${candidate.path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (await hasActiveDescriptor()) {
+      return {
+        result: "ready",
+        timeoutMs,
+        intervalMs,
+        profileLimit,
+        candidates,
+        attemptedProfiles,
+        openedCount: attemptedProfiles.length,
+        errors,
+      };
+    }
+  }
+
+  const deadline = now() + timeoutMs;
+  while (now() < deadline) {
+    const remaining = Math.max(0, deadline - now());
+    await sleep(Math.min(intervalMs, remaining));
+    if (await hasActiveDescriptor()) {
+      return {
+        result: "ready",
+        timeoutMs,
+        intervalMs,
+        profileLimit,
+        candidates,
+        attemptedProfiles,
+        openedCount: attemptedProfiles.length,
+        errors,
+      };
+    }
+  }
+
+  return {
+    result: errors.length === attemptedProfiles.length ? "open_failed" : "timeout",
+    timeoutMs,
+    intervalMs,
+    profileLimit,
+    candidates,
+    attemptedProfiles,
+    openedCount: attemptedProfiles.length,
+    errors,
+  };
+}
+
+export async function openBrowserPopup(target: BrowserActivationTarget): Promise<void> {
+  const command = await browserLaunchCommand(target.browser);
+  const profileDirectory = path.basename(target.profilePath);
+  const args = [`--profile-directory=${profileDirectory}`, target.url];
+  await spawnDetached(command, args);
+}
+
+async function browserLaunchCommand(browser: BrowserKind): Promise<string> {
+  if (process.platform === "darwin") {
+    const appPath = browserInstallPath(browser, process.platform);
+    if (!appPath) throw new Error(`automatic activation is not supported for ${browser} on darwin`);
+    const executable = path.join(appPath, "Contents", "MacOS", path.basename(appPath, ".app"));
+    if (await access(executable, constants.X_OK).then(() => true).catch(() => false)) return executable;
+    throw new Error(`browser executable not found at ${executable}`);
+  }
+  if (process.platform === "win32") {
+    throw new Error(`automatic activation is not supported for ${browser} on win32 yet`);
+  }
+  const command = {
+    chrome: "google-chrome",
+    "chrome-for-testing": "google-chrome-for-testing",
+    edge: "microsoft-edge",
+    brave: "brave-browser",
+    chromium: "chromium",
+    arc: "",
+  }[browser];
+  if (!command) throw new Error(`automatic activation is not supported for ${browser}`);
+  return command;
+}
+
+function spawnDetached(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/src/human-output.ts
+++ b/packages/cli/src/human-output.ts
@@ -24,6 +24,12 @@ export function formatSetupSummary(report: SetupJson): string {
     rows.push("Setup failed.");
     rows.push(...formatFailedSteps(report.steps));
   }
+  const activationFailures = report.steps.filter((step) =>
+    step.id.startsWith("runtime-activation-") && step.status === "manual_action_required"
+  );
+  if (activationFailures.length > 0) {
+    rows.push("Browser runtime activation was attempted automatically but still needs browser follow-up.");
+  }
   rows.push(...formatNextActions(report.nextActions, report.dryRun ? "After applying, next actions would be:" : undefined));
   return rows.join("\n");
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -13,8 +13,6 @@ import { nativeHostWrapperContent, nativeHostWrapperPath } from "./native-host.j
 
 const cliEntry = fileURLToPath(new URL("./index.js", import.meta.url));
 
-process.env.OBU_TEST_RUNTIME_ACTIVATION_RESULT ??= "no_candidates";
-
 test("mcp-config print emits a runnable repo-mode invocation", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -1333,13 +1331,14 @@ test("setup summary preserves manual agent next actions", async (t) => {
   await writeFile(obuCommand, "#!/bin/sh\n", "utf8");
   await chmod(obuCommand, 0o755);
   const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  await writeActiveRuntimeDescriptor(t, runtimeDir, storeExtensionId);
 
   const result = await runCli(["setup", "--yes", "--channel=store", "--extension-id", storeExtensionId, "--agents=continue"], {
     HOME: home,
     OBU_COMMAND: obuCommand,
-    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_RUNTIME_DIR: runtimeDir,
     OBU_HOST_BIN: hostBin,
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 1);
@@ -1353,25 +1352,21 @@ test("setup summary preserves manual agent next actions", async (t) => {
   const recovery = await runCli(["setup", "--yes", "--recovery", "--channel=store", "--extension-id", storeExtensionId, "--agents=continue"], {
     HOME: home,
     OBU_COMMAND: obuCommand,
-    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_RUNTIME_DIR: runtimeDir,
     OBU_HOST_BIN: hostBin,
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
   assert.equal(recovery.code, 1);
   assert.match(recovery.stdout, new RegExp(`${escapeRegExp(obuCommand)} mcp-config --agent=continue --print`));
 });
 
-test("setup JSON includes runtime activation diagnostics when popup activation times out", async (t) => {
+test("setup JSON includes runtime activation diagnostics when no enabled profile is available", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
   t.after(() => rm(home, { recursive: true, force: true }));
   t.after(() => rm(bin, { recursive: true, force: true }));
-  withTestXdgConfigHome(t, home);
   const extensionId = "abcdefghijklmnopabcdefghijklmnop";
   const runtimeDir = path.join(home, "runtime");
   const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
-  const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
-  await writeChromePreferences(profilePath, extensionId, 1);
 
   const result = await runCli([
     "setup",
@@ -1384,19 +1379,19 @@ test("setup JSON includes runtime activation diagnostics when popup activation t
     HOME: home,
     OBU_HOST_BIN: hostBin,
     OBU_RUNTIME_DIR: runtimeDir,
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "timeout",
   });
 
   assert.equal(result.code, 1);
   const payload = JSON.parse(result.stdout);
   const activation = payload.steps.find((step: any) => step.id === "runtime-activation-chrome");
   assert.equal(activation.status, "manual_action_required");
+  assert.equal(activation.details.result, "no_candidates");
   assert.equal(activation.details.timeoutMs, 5000);
   assert.equal(activation.details.profileLimit, 3);
-  assert.equal(activation.details.openedCount >= 0, true);
+  assert.equal(activation.details.openedCount, 0);
 });
 
-test("setup human output explains runtime activation timeout", async (t) => {
+test("setup human output explains runtime activation follow-up", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -1414,12 +1409,40 @@ test("setup human output explains runtime activation timeout", async (t) => {
     HOME: home,
     OBU_HOST_BIN: hostBin,
     OBU_RUNTIME_DIR: path.join(home, "runtime"),
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "timeout",
   });
 
   assert.equal(result.code, 1);
   assert.match(result.stdout, /Setup needs 1 follow-up step/);
   assert.match(result.stdout, /Browser runtime activation was attempted automatically/);
+});
+
+test("setup CLI ignores legacy runtime activation test env overrides", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+
+  const result = await runCli([
+    "setup",
+    "--agents=none",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+    "--json",
+  ], {
+    HOME: home,
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
+  });
+
+  assert.equal(result.code, 1);
+  const payload = JSON.parse(result.stdout);
+  const activation = payload.steps.find((step: any) => step.id === "runtime-activation-chrome");
+  assert.equal(activation.status, "manual_action_required");
+  assert.equal(activation.details.result, "no_candidates");
 });
 
 test("bootstrap continues through manual agent setup and runs browser repair", async (t) => {
@@ -1514,14 +1537,15 @@ test("setup CLI accepts explicit auto and none agent modes", async (t) => {
   const hostBin = path.join(bin, "obu-host");
   await writeFile(hostBin, "#!/bin/sh\n", "utf8");
   await chmod(hostBin, 0o755);
+  const runtimeDir = path.join(home, "runtime");
   const env = {
     HOME: home,
-    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_RUNTIME_DIR: runtimeDir,
     OBU_HOST_BIN: hostBin,
     PATH: "",
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   };
   const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+  await writeActiveRuntimeDescriptor(t, runtimeDir, storeExtensionId);
 
   const auto = await runCli(["setup", "--yes", "--channel=store", "--extension-id", storeExtensionId, "--agents=auto", "--json"], env);
   assert.equal(auto.code, 0);
@@ -1554,13 +1578,14 @@ test("setup auto skips unreadable direct-edit agent config instead of aborting",
   await writeFile(hostBin, "#!/bin/sh\n", "utf8");
   await chmod(hostBin, 0o755);
   const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  await writeActiveRuntimeDescriptor(t, runtimeDir, storeExtensionId);
 
   const result = await runCli(["setup", "--yes", "--channel=store", "--extension-id", storeExtensionId, "--agents=auto", "--json"], {
     HOME: home,
     PATH: "",
-    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_RUNTIME_DIR: runtimeDir,
     OBU_HOST_BIN: hostBin,
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 0);
@@ -1633,7 +1658,6 @@ test("setup recovery mode exits zero for runtime activation manual boundary", as
     HOME: home,
     OBU_RUNTIME_DIR: path.join(home, "runtime"),
     OBU_HOST_BIN: hostBin,
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "timeout",
   });
 
   assert.equal(result.code, 0);
@@ -1728,12 +1752,12 @@ test("setup CLI supports Store channel without staging an unpacked extension", a
   await chmod(hostBin, 0o755);
   const runtimeDir = path.join(home, "runtime");
   const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+  await writeActiveRuntimeDescriptor(t, runtimeDir, storeExtensionId);
 
   const result = await runCli(["setup", "--yes", "--channel=store", "--extension-id", storeExtensionId, "--skip-agents", "--json"], {
     HOME: home,
     OBU_RUNTIME_DIR: runtimeDir,
     OBU_HOST_BIN: hostBin,
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 0);
@@ -1764,6 +1788,8 @@ test("setup can write Codex and Claude primary-browser instructions explicitly",
   await writeFile(claude, "#!/bin/sh\nexit 0\n", "utf8");
   await chmod(claude, 0o755);
   const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  await writeActiveRuntimeDescriptor(t, runtimeDir, storeExtensionId);
 
   const result = await runCli([
     "setup",
@@ -1777,9 +1803,8 @@ test("setup can write Codex and Claude primary-browser instructions explicitly",
   ], {
     HOME: home,
     PATH: bin,
-    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_RUNTIME_DIR: runtimeDir,
     OBU_HOST_BIN: hostBin,
-    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 0);
@@ -2143,6 +2168,42 @@ async function writeChromePreferences(profilePath: string, extensionId: string, 
 async function writeRuntimeDescriptor(file: string, value: Record<string, unknown>): Promise<void> {
   await writeFile(file, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
   await chmod(file, 0o600);
+}
+
+async function writeActiveRuntimeDescriptor(
+  t: { after: (fn: () => void | Promise<void>) => void },
+  runtimeDir: string,
+  extensionId: string,
+  browserKind = "chrome",
+): Promise<void> {
+  const descriptorDir = path.join(runtimeDir, "webextension");
+  await mkdir(descriptorDir, { recursive: true, mode: 0o700 });
+  await chmod(descriptorDir, 0o700);
+  const socketPath = path.join(runtimeDir, `${browserKind}.sock`);
+  await startRuntimeDescriptorServer(t, socketPath, {
+    getInfoResult: {
+      type: "webextension",
+      name: browserKind,
+      metadata: {
+        backend: {
+          browser_kind: browserKind,
+          extension_id: extensionId,
+        },
+      },
+    },
+  });
+  await writeRuntimeDescriptor(path.join(descriptorDir, `${browserKind}.json`), {
+    schema_version: 1,
+    type: "webextension",
+    name: browserKind,
+    socketPath,
+    sdk_auth_token: "token",
+    pid: process.pid,
+    metadata: {
+      browser_kind: browserKind,
+      extension_id: extensionId,
+    },
+  });
 }
 
 async function startRuntimeDescriptorServer(

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -13,6 +13,8 @@ import { nativeHostWrapperContent, nativeHostWrapperPath } from "./native-host.j
 
 const cliEntry = fileURLToPath(new URL("./index.js", import.meta.url));
 
+process.env.OBU_TEST_RUNTIME_ACTIVATION_RESULT ??= "no_candidates";
+
 test("mcp-config print emits a runnable repo-mode invocation", async (t) => {
   const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -1337,6 +1339,7 @@ test("setup summary preserves manual agent next actions", async (t) => {
     OBU_COMMAND: obuCommand,
     OBU_RUNTIME_DIR: path.join(home, "runtime"),
     OBU_HOST_BIN: hostBin,
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 1);
@@ -1352,9 +1355,71 @@ test("setup summary preserves manual agent next actions", async (t) => {
     OBU_COMMAND: obuCommand,
     OBU_RUNTIME_DIR: path.join(home, "runtime"),
     OBU_HOST_BIN: hostBin,
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
   assert.equal(recovery.code, 1);
   assert.match(recovery.stdout, new RegExp(`${escapeRegExp(obuCommand)} mcp-config --agent=continue --print`));
+});
+
+test("setup JSON includes runtime activation diagnostics when popup activation times out", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  withTestXdgConfigHome(t, home);
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const runtimeDir = path.join(home, "runtime");
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+  const profilePath = path.join(browserProfileRoot("chrome", process.platform, home), "Default");
+  await writeChromePreferences(profilePath, extensionId, 1);
+
+  const result = await runCli([
+    "setup",
+    "--agents=none",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+    "--json",
+  ], {
+    HOME: home,
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: runtimeDir,
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "timeout",
+  });
+
+  assert.equal(result.code, 1);
+  const payload = JSON.parse(result.stdout);
+  const activation = payload.steps.find((step: any) => step.id === "runtime-activation-chrome");
+  assert.equal(activation.status, "manual_action_required");
+  assert.equal(activation.details.timeoutMs, 5000);
+  assert.equal(activation.details.profileLimit, 3);
+  assert.equal(activation.details.openedCount >= 0, true);
+});
+
+test("setup human output explains runtime activation timeout", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+
+  const result = await runCli([
+    "setup",
+    "--agents=none",
+    "--browser=chrome",
+    "--channel=store",
+    `--extension-id=${extensionId}`,
+  ], {
+    HOME: home,
+    OBU_HOST_BIN: hostBin,
+    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "timeout",
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /Setup needs 1 follow-up step/);
+  assert.match(result.stdout, /Browser runtime activation was attempted automatically/);
 });
 
 test("bootstrap continues through manual agent setup and runs browser repair", async (t) => {
@@ -1454,6 +1519,7 @@ test("setup CLI accepts explicit auto and none agent modes", async (t) => {
     OBU_RUNTIME_DIR: path.join(home, "runtime"),
     OBU_HOST_BIN: hostBin,
     PATH: "",
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   };
   const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
 
@@ -1494,6 +1560,7 @@ test("setup auto skips unreadable direct-edit agent config instead of aborting",
     PATH: "",
     OBU_RUNTIME_DIR: path.join(home, "runtime"),
     OBU_HOST_BIN: hostBin,
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 0);
@@ -1544,6 +1611,35 @@ test("setup recovery mode exits zero for manual action but not failed setup", as
   });
   assert.equal(failedRecovery.code, 1);
   assert.match(failedRecovery.stdout, /Setup failed\./);
+});
+
+test("setup recovery mode exits zero for runtime activation manual boundary", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "obu-cli-home-"));
+  const bin = await mkdtemp(path.join(os.tmpdir(), "obu-cli-bin-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  t.after(() => rm(bin, { recursive: true, force: true }));
+  const hostBin = await writeExecutable(path.join(bin, "obu-host"), "#!/bin/sh\nexit 0\n");
+  const storeExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+
+  const result = await runCli([
+    "setup",
+    "--yes",
+    "--recovery",
+    "--channel=store",
+    `--extension-id=${storeExtensionId}`,
+    "--agents=none",
+    "--json",
+  ], {
+    HOME: home,
+    OBU_RUNTIME_DIR: path.join(home, "runtime"),
+    OBU_HOST_BIN: hostBin,
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "timeout",
+  });
+
+  assert.equal(result.code, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.result, "manual_action_required");
+  assert.equal(payload.steps.find((step: any) => step.id === "runtime-activation-chrome")?.status, "manual_action_required");
 });
 
 test("setup CLI runs deterministic steps before extension manual boundary", async (t) => {
@@ -1637,6 +1733,7 @@ test("setup CLI supports Store channel without staging an unpacked extension", a
     HOME: home,
     OBU_RUNTIME_DIR: runtimeDir,
     OBU_HOST_BIN: hostBin,
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 0);
@@ -1682,6 +1779,7 @@ test("setup can write Codex and Claude primary-browser instructions explicitly",
     PATH: bin,
     OBU_RUNTIME_DIR: path.join(home, "runtime"),
     OBU_HOST_BIN: hostBin,
+    OBU_TEST_RUNTIME_ACTIVATION_RESULT: "ready",
   });
 
   assert.equal(result.code, 0);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -716,6 +716,11 @@ function formatBootstrapSummary(setupReport: SetupJson, browserReport: DoctorRep
 
   const agentLine = bootstrapAgentSummary(setupReport);
   if (agentLine) rows.push(agentLine);
+  const activationSteps = setupReport.steps.filter((step) => step.id.startsWith("runtime-activation-"));
+  const activationFailures = activationSteps.filter((step) => step.status === "manual_action_required");
+  if (activationFailures.length > 0) {
+    rows.push("Browser runtime activation was attempted automatically but still needs browser follow-up.");
+  }
   if (browserResumeRequired(browserReport)) {
     rows.push("Open the extension popup; click Resume if it is enabled, otherwise wait for Connected and rerun verify.");
   }
@@ -759,7 +764,9 @@ function plural(count: number, label: string): string {
 
 function isBrowserRecoveryBoundary(report: SetupJson): boolean {
   const manualSteps = report.steps.filter((step) => step.status === "manual_action_required");
-  return manualSteps.length > 0 && manualSteps.every((step) => step.id === "runtime-descriptor-probe");
+  return manualSteps.length > 0 && manualSteps.every((step) =>
+    step.id === "runtime-descriptor-probe" || step.id.startsWith("runtime-activation-")
+  );
 }
 
 function doctorVerboseCommand(args: ParsedArgs, commandPrefix: string): string {

--- a/packages/cli/src/native-host.ts
+++ b/packages/cli/src/native-host.ts
@@ -3,7 +3,7 @@ import { access, chmod, lstat, mkdir, readFile, rename, rm, writeFile } from "no
 import os from "node:os";
 import path from "node:path";
 
-import { nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
+import { browserRuntimeKind, nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
 import { extensionManifestPath, readExtensionIdFromManifest } from "./extension-channel.js";
 import type { RuntimeLayout } from "./runtime-layout.js";
 
@@ -192,10 +192,6 @@ export async function writeIfChanged(file: string, content: string, mode: number
     throw error;
   }
   return true;
-}
-
-function browserRuntimeKind(browser: BrowserKind): string {
-  return browser === "chrome-for-testing" ? "chrome" : browser;
 }
 
 function shellQuote(value: string): string {

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -10,8 +10,6 @@ import type { RuntimeLayout } from "./runtime-layout.js";
 
 const EXTENSION_KEY = Buffer.from("open-browser-use setup test key").toString("base64");
 
-process.env.OBU_TEST_RUNTIME_ACTIVATION_RESULT ??= "no_candidates";
-
 test("setupOpenBrowserUse composes runtime, native host, extension update, and manual agent boundary", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "obu-setup-"));
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -10,6 +10,8 @@ import type { RuntimeLayout } from "./runtime-layout.js";
 
 const EXTENSION_KEY = Buffer.from("open-browser-use setup test key").toString("base64");
 
+process.env.OBU_TEST_RUNTIME_ACTIVATION_RESULT ??= "no_candidates";
+
 test("setupOpenBrowserUse composes runtime, native host, extension update, and manual agent boundary", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "obu-setup-"));
   t.after(() => rm(root, { recursive: true, force: true }));
@@ -96,6 +98,16 @@ test("setupOpenBrowserUse skips extension staging for Store channel", async (t) 
     extensionId: storeExtensionId,
     extensionIdSource: "explicit-argument",
     skipAgents: true,
+    runtimeActivation: async () => ({
+      result: "ready",
+      timeoutMs: 5000,
+      intervalMs: 250,
+      profileLimit: 3,
+      candidates: [],
+      attemptedProfiles: [],
+      openedCount: 0,
+      errors: [],
+    }),
   });
 
   assert.equal(result.result, "complete");
@@ -111,6 +123,156 @@ test("setupOpenBrowserUse skips extension staging for Store channel", async (t) 
     action.kind === "manual" &&
     action.value.includes(`${layout.openBrowserUseCommand} verify '--agent=<agent-id>' --browser=chrome --channel=store --extension-id=${storeExtensionId}`)
   ));
+});
+
+test("setupOpenBrowserUse completes when runtime activation finds a descriptor", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-setup-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const hostBin = path.join(root, "bin", "obu-host");
+  await mkdir(path.dirname(hostBin), { recursive: true });
+  await writeFile(hostBin, "#!/bin/sh\n", "utf8");
+  await chmod(hostBin, 0o755);
+  const sourceDir = await extensionSource(root, "0.9.0");
+  const layout = fakeLayout(root, hostBin, sourceDir);
+  const extensionId = extensionIdFromManifestKey(EXTENSION_KEY);
+
+  const result = await setupOpenBrowserUse({
+    layout,
+    obuVersion: "0.1.0",
+    browsers: ["chrome"],
+    agents: [],
+    server: mcpServer(root),
+    extensionChannel: "unpacked-dev",
+    extensionId,
+    extensionIdSource: "manifest-key",
+    extensionPath: sourceDir,
+    skipAgents: true,
+    runtimeActivation: async () => ({
+      result: "ready",
+      timeoutMs: 5000,
+      intervalMs: 250,
+      profileLimit: 3,
+      candidates: [],
+      attemptedProfiles: [path.join(root, "profile", "Default")],
+      openedCount: 1,
+      errors: [],
+    }),
+  });
+
+  assert.equal(result.result, "complete");
+  const activation = result.steps.find((step) => step.id === "runtime-activation-chrome");
+  assert.equal(activation?.status, "applied");
+  assert.equal(activation?.details?.result, "ready");
+  assert.equal(activation?.details?.timeoutMs, 5000);
+  assert.equal(result.steps.find((step) => step.id === "runtime-descriptor-probe")?.status, "skipped");
+  assert.equal(result.nextActions.some((action) => /chrome:\/\/extensions|Load unpacked|Reload/.test(action.value)), false);
+});
+
+test("setupOpenBrowserUse reports manual action when runtime activation times out", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-setup-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const hostBin = path.join(root, "bin", "obu-host");
+  await mkdir(path.dirname(hostBin), { recursive: true });
+  await writeFile(hostBin, "#!/bin/sh\n", "utf8");
+  await chmod(hostBin, 0o755);
+  const sourceDir = await extensionSource(root, "0.10.0");
+  const layout = fakeLayout(root, hostBin, sourceDir);
+  const extensionId = extensionIdFromManifestKey(EXTENSION_KEY);
+
+  const result = await setupOpenBrowserUse({
+    layout,
+    obuVersion: "0.1.0",
+    browsers: ["chrome"],
+    agents: [],
+    server: mcpServer(root),
+    extensionChannel: "unpacked-dev",
+    extensionId,
+    extensionIdSource: "manifest-key",
+    extensionPath: sourceDir,
+    skipAgents: true,
+    runtimeActivation: async () => ({
+      result: "timeout",
+      timeoutMs: 5000,
+      intervalMs: 250,
+      profileLimit: 3,
+      candidates: [],
+      attemptedProfiles: [path.join(root, "profile", "Default")],
+      openedCount: 1,
+      errors: [],
+    }),
+  });
+
+  assert.equal(result.result, "manual_action_required");
+  const activation = result.steps.find((step) => step.id === "runtime-activation-chrome");
+  assert.equal(activation?.status, "manual_action_required");
+  assert.match(activation?.message ?? "", /waited 5000ms/);
+  assert.equal(activation?.details?.openedCount, 1);
+  assert.equal(result.nextActions.some((action) => /chrome:\/\/extensions|Load unpacked|Reload/.test(action.value)), true);
+});
+
+test("setupOpenBrowserUse does not launch activation after native host install failure", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-setup-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const missingHostBin = path.join(root, "bin", "missing-obu-host");
+  const sourceDir = await extensionSource(root, "0.11.0");
+  const layout = fakeLayout(root, missingHostBin, sourceDir);
+  let activationCalls = 0;
+
+  const result = await setupOpenBrowserUse({
+    layout,
+    obuVersion: "0.1.0",
+    browsers: ["chrome"],
+    agents: [],
+    server: mcpServer(root),
+    extensionChannel: "unpacked-dev",
+    extensionId: extensionIdFromManifestKey(EXTENSION_KEY),
+    extensionIdSource: "manifest-key",
+    extensionPath: sourceDir,
+    skipAgents: true,
+    runtimeActivation: async () => {
+      activationCalls += 1;
+      throw new Error("activation must not run after native host failure");
+    },
+  });
+
+  assert.equal(result.result, "failed");
+  assert.equal(result.steps.find((step) => step.id === "native-host-chrome")?.status, "failed");
+  assert.equal(result.steps.some((step) => step.id === "runtime-activation-chrome"), false);
+  assert.equal(activationCalls, 0);
+});
+
+test("setupOpenBrowserUse does not launch activation after extension staging failure", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "obu-setup-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const hostBin = path.join(root, "bin", "obu-host");
+  await mkdir(path.dirname(hostBin), { recursive: true });
+  await writeFile(hostBin, "#!/bin/sh\n", "utf8");
+  await chmod(hostBin, 0o755);
+  const missingSourceDir = path.join(root, "missing-extension");
+  const layout = fakeLayout(root, hostBin, missingSourceDir);
+  let activationCalls = 0;
+
+  const result = await setupOpenBrowserUse({
+    layout,
+    obuVersion: "0.1.0",
+    browsers: ["chrome"],
+    agents: [],
+    server: mcpServer(root),
+    extensionChannel: "unpacked-dev",
+    extensionId: extensionIdFromManifestKey(EXTENSION_KEY),
+    extensionIdSource: "manifest-key",
+    extensionPath: missingSourceDir,
+    skipAgents: true,
+    runtimeActivation: async () => {
+      activationCalls += 1;
+      throw new Error("activation must not run after extension failure");
+    },
+  });
+
+  assert.equal(result.result, "failed");
+  assert.equal(result.steps.find((step) => step.id === "extension-source")?.status, "failed");
+  assert.equal(result.steps.some((step) => step.id === "runtime-activation-chrome"), false);
+  assert.equal(activationCalls, 0);
 });
 
 async function extensionSource(root: string, version: string): Promise<string> {

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 
+import {
+  activateBrowserRuntime,
+  type BrowserRuntimeActivationResult,
+} from "./browser-runtime-activation.js";
 import { installNativeHosts } from "./native-host.js";
 import { ensureRuntimeDir, type RuntimeLayout, writeUserConfig } from "./runtime-layout.js";
 import { updateExtension, type ExtensionUpdateStep } from "./extension-update.js";
@@ -46,6 +50,12 @@ export type SetupOptions = {
   env?: NodeJS.ProcessEnv;
   commandPrefix?: string;
   projectDir?: string;
+  runtimeActivation?: (input: {
+    browser: BrowserKind;
+    extensionId: string;
+    homeDir: string;
+    runtimeDir: string;
+  }) => Promise<BrowserRuntimeActivationResult>;
 };
 
 export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJson> {
@@ -101,6 +111,8 @@ export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJ
     });
   }
 
+  const extensionNextActions: SetupJson["nextActions"] = [];
+
   if (options.extensionChannel === "store") {
     steps.push({
       id: "extension-update",
@@ -122,6 +134,7 @@ export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJ
     const extension = await updateExtension({
       layout: options.layout,
       dryRun,
+      noWait: true,
       verifyTarget: {
         channel: options.extensionChannel,
         extensionId: options.extensionId,
@@ -129,8 +142,19 @@ export async function setupOpenBrowserUse(options: SetupOptions): Promise<SetupJ
       ...(options.extensionPath ? { sourceDir: options.extensionPath } : {}),
     });
     for (const step of extension.steps) steps.push(mapExtensionStep(step));
-    nextActions.push(...extension.nextActions);
+    extensionNextActions.push(...extension.nextActions);
   }
+
+  const activationSteps: SetupJson["steps"] = [];
+  if (shouldAttemptRuntimeActivation(options, steps, dryRun)) {
+    for (const browser of options.browsers) {
+      if (!browserActivationPrerequisitesReady(steps, browser)) continue;
+      const activation = await runRuntimeActivation(options, browser);
+      activationSteps.push(runtimeActivationStep(browser, activation));
+    }
+  }
+  steps.push(...activationSteps);
+  nextActions.push(...activationAwareExtensionNextActions(extensionNextActions, activationSteps));
 
   const agentHomeDir = path.dirname(path.dirname(options.layout.userConfigPath));
   const agents = options.skipAgents
@@ -210,6 +234,107 @@ function mapExtensionStep(step: ExtensionUpdateStep): SetupJson["steps"][number]
     status: setupStatus(step.status),
     message: step.message,
     ...(step.details ? { details: step.details } : {}),
+  };
+}
+
+function shouldAttemptRuntimeActivation(options: SetupOptions, steps: SetupJson["steps"], dryRun: boolean): boolean {
+  if (dryRun || options.skipExtension) return false;
+  return !steps.some((step) => step.id.startsWith("extension-") && step.status === "failed");
+}
+
+function browserActivationPrerequisitesReady(steps: SetupJson["steps"], browser: BrowserKind): boolean {
+  return steps.find((step) => step.id === `native-host-${browser}`)?.status !== "failed";
+}
+
+async function runRuntimeActivation(options: SetupOptions, browser: BrowserKind): Promise<BrowserRuntimeActivationResult> {
+  const homeDir = path.dirname(path.dirname(options.layout.userConfigPath));
+  if (options.runtimeActivation) {
+    return options.runtimeActivation({
+      browser,
+      extensionId: options.extensionId,
+      homeDir,
+      runtimeDir: options.layout.runtimeDir,
+    });
+  }
+  const testResult = options.env?.OBU_TEST_RUNTIME_ACTIVATION_RESULT ?? process.env.OBU_TEST_RUNTIME_ACTIVATION_RESULT;
+  if (testResult) {
+    return stubRuntimeActivationResult(testResult as BrowserRuntimeActivationResult["result"]);
+  }
+  return activateBrowserRuntime({
+    browser,
+    extensionId: options.extensionId,
+    homeDir,
+    runtimeDir: options.layout.runtimeDir,
+  });
+}
+
+function stubRuntimeActivationResult(result: BrowserRuntimeActivationResult["result"]): BrowserRuntimeActivationResult {
+  return {
+    result,
+    timeoutMs: 5000,
+    intervalMs: 250,
+    profileLimit: 3,
+    candidates: [],
+    attemptedProfiles: [],
+    openedCount: 0,
+    errors: [],
+  };
+}
+
+function activationAwareExtensionNextActions(
+  actions: SetupJson["nextActions"],
+  activationSteps: SetupJson["steps"],
+): SetupJson["nextActions"] {
+  const activationSucceeded = activationSteps.length > 0 &&
+    activationSteps.every((step) => step.id.startsWith("runtime-activation-") && step.status === "applied");
+  if (!activationSucceeded) return actions;
+  return actions.filter((action) => !isExtensionReloadAction(action));
+}
+
+function isExtensionReloadAction(action: SetupJson["nextActions"][number]): boolean {
+  return /chrome:\/\/extensions|Load unpacked|Reload/.test(action.value);
+}
+
+function runtimeActivationStep(browser: BrowserKind, activation: BrowserRuntimeActivationResult): SetupJson["steps"][number] {
+  const details = {
+    result: activation.result,
+    timeoutMs: activation.timeoutMs,
+    intervalMs: activation.intervalMs,
+    profileLimit: activation.profileLimit,
+    attemptedProfiles: activation.attemptedProfiles,
+    openedCount: activation.openedCount,
+    candidateCount: activation.candidates.length,
+    errors: activation.errors,
+  };
+  if (activation.result === "ready") {
+    return {
+      id: `runtime-activation-${browser}`,
+      status: "applied",
+      message: `activated ${browser} WebExtension runtime`,
+      details,
+    };
+  }
+  if (activation.result === "no_candidates") {
+    return {
+      id: `runtime-activation-${browser}`,
+      status: "manual_action_required",
+      message: `no enabled ${browser} profile has the open-browser-use extension installed`,
+      details,
+    };
+  }
+  if (activation.result === "open_failed") {
+    return {
+      id: `runtime-activation-${browser}`,
+      status: "manual_action_required",
+      message: `could not open the open-browser-use extension popup for ${browser}`,
+      details,
+    };
+  }
+  return {
+    id: `runtime-activation-${browser}`,
+    status: "manual_action_required",
+    message: `opened the open-browser-use extension popup for ${browser} and waited ${activation.timeoutMs}ms, but no active runtime descriptor appeared`,
+    details,
   };
 }
 

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -256,29 +256,12 @@ async function runRuntimeActivation(options: SetupOptions, browser: BrowserKind)
       runtimeDir: options.layout.runtimeDir,
     });
   }
-  const testResult = options.env?.OBU_TEST_RUNTIME_ACTIVATION_RESULT ?? process.env.OBU_TEST_RUNTIME_ACTIVATION_RESULT;
-  if (testResult) {
-    return stubRuntimeActivationResult(testResult as BrowserRuntimeActivationResult["result"]);
-  }
   return activateBrowserRuntime({
     browser,
     extensionId: options.extensionId,
     homeDir,
     runtimeDir: options.layout.runtimeDir,
   });
-}
-
-function stubRuntimeActivationResult(result: BrowserRuntimeActivationResult["result"]): BrowserRuntimeActivationResult {
-  return {
-    result,
-    timeoutMs: 5000,
-    intervalMs: 250,
-    profileLimit: 3,
-    candidates: [],
-    attemptedProfiles: [],
-    openedCount: 0,
-    errors: [],
-  };
 }
 
 function activationAwareExtensionNextActions(

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -13,6 +13,12 @@ import { appendShellArgs } from "./command-line.js";
 import { doctorBrowser } from "./doctor-browser.js";
 import { type ExtensionChannel, type ExtensionIdSource } from "./extension-channel.js";
 import { browserProfileRoot, nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
+import {
+  defaultProfileCandidates,
+  inspectProfileCandidate,
+  type ComponentState,
+  type ProfileCandidate,
+} from "./browser-profile-discovery.js";
 import { nativeHostWrapperContent, nativeHostWrapperPath, supportedNativeHostBrowsers } from "./native-host.js";
 import { PRODUCT_ERROR_SCHEMA } from "./product_errors.generated.js";
 import {
@@ -39,16 +45,6 @@ export type VerificationTarget = "cli" | "agent_runtime";
 export type VerifyResult = "ready" | "needs_browser_popup" | "needs_repair" | "needs_manual_action";
 export type VerifyCheckStatus = "pass" | "warn" | "fail" | "not_checked";
 export type ReadinessStatus = "ready" | "blocked" | "not_checked";
-export type ComponentState =
-  | "pass"
-  | "warn"
-  | "fail"
-  | "missing"
-  | "unreadable"
-  | "disabled"
-  | "stale"
-  | "invalid"
-  | "not_checked";
 type RuntimeBinding = "profile_verified" | "single_candidate" | "browser_extension_scope" | "not_available";
 export type VerifyLayer =
   | "target_support"
@@ -133,14 +129,6 @@ type ProductErrorSummary = {
   title: string;
   summary: string;
   nextAction: VerifyNextAction | null;
-};
-
-type ProfileCandidate = {
-  path: string;
-  profileExists: ComponentState;
-  extensionInstalled: ComponentState;
-  extensionEnabled: ComponentState;
-  reasons?: Record<string, string>;
 };
 
 type VerifyBrowserProfile = {
@@ -2012,144 +2000,6 @@ function descriptorFailure(
   };
 }
 
-async function defaultProfileCandidates(root: string): Promise<string[]> {
-  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
-  const candidates = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const candidate = path.join(root, entry.name);
-    if (entry.name === "NativeMessagingHosts") continue;
-    if (entry.name === "Default" || /^Profile \d+$/.test(entry.name)) {
-      candidates.push(candidate);
-      continue;
-    }
-    if (await access(path.join(candidate, "Preferences"), constants.R_OK).then(() => true).catch(() => false)) {
-      candidates.push(candidate);
-    }
-  }
-  return candidates.sort(compareProfilePaths);
-}
-
-async function inspectProfileCandidate(profilePath: string, extensionId: string): Promise<ProfileCandidate> {
-  const stats = await lstat(profilePath).catch((error) => error as NodeJS.ErrnoException);
-  if (stats instanceof Error) {
-    const missing = stats.code === "ENOENT";
-    return {
-      path: profilePath,
-      profileExists: missing ? "missing" : "unreadable",
-      extensionInstalled: "not_checked",
-      extensionEnabled: "not_checked",
-      reasons: {
-        profileExists: missing ? "profile path does not exist" : `profile path cannot be inspected: ${stats.message}`,
-        extensionInstalled: "extension state cannot be inspected until the profile exists and is readable",
-        extensionEnabled: "extension state cannot be inspected until the profile exists and is readable",
-      },
-    };
-  }
-  if (!stats.isDirectory()) {
-    return {
-      path: profilePath,
-      profileExists: "unreadable",
-      extensionInstalled: "not_checked",
-      extensionEnabled: "not_checked",
-      reasons: {
-        profileExists: "profile path is not a directory",
-        extensionInstalled: "extension state cannot be inspected until the profile path is a readable directory",
-        extensionEnabled: "extension state cannot be inspected until the profile path is a readable directory",
-      },
-    };
-  }
-  if (!await access(profilePath, constants.R_OK).then(() => true).catch(() => false)) {
-    return {
-      path: profilePath,
-      profileExists: "unreadable",
-      extensionInstalled: "not_checked",
-      extensionEnabled: "not_checked",
-      reasons: {
-        profileExists: "profile directory is not readable",
-        extensionInstalled: "extension state cannot be inspected until the profile is readable",
-        extensionEnabled: "extension state cannot be inspected until the profile is readable",
-      },
-    };
-  }
-
-  const preferenceFiles = [
-    path.join(profilePath, "Preferences"),
-    path.join(profilePath, "Secure Preferences"),
-  ];
-  let sawPreferenceFile = false;
-  for (const file of preferenceFiles) {
-    const preferences = await readJson(file).catch((error) => {
-      const nodeError = error as NodeJS.ErrnoException;
-      if (nodeError.code === "ENOENT") return undefined;
-      return { __obu_read_error: nodeError.message ?? String(error) };
-    });
-    if (preferences === undefined) continue;
-    sawPreferenceFile = true;
-    if (isRecord(preferences) && typeof preferences.__obu_read_error === "string") {
-      return {
-        path: profilePath,
-        profileExists: "unreadable",
-        extensionInstalled: "not_checked",
-        extensionEnabled: "not_checked",
-        reasons: {
-          profileExists: `profile preferences cannot be read: ${preferences.__obu_read_error}`,
-          extensionInstalled: "extension state cannot be inspected until profile preferences are readable",
-          extensionEnabled: "extension state cannot be inspected until profile preferences are readable",
-        },
-      };
-    }
-    const settings = extensionSettings(preferences, extensionId);
-    if (!settings) continue;
-    if (settings.state === 0 || hasDisableReasons(settings.disable_reasons)) {
-      return {
-        path: profilePath,
-        profileExists: "pass",
-        extensionInstalled: "pass",
-        extensionEnabled: "disabled",
-        reasons: {
-          extensionEnabled: `extension is disabled in ${file}`,
-        },
-      };
-    }
-    return {
-      path: profilePath,
-      profileExists: "pass",
-      extensionInstalled: "pass",
-      extensionEnabled: "pass",
-    };
-  }
-  return {
-    path: profilePath,
-    profileExists: "pass",
-    extensionInstalled: "missing",
-    extensionEnabled: "not_checked",
-    reasons: {
-      extensionInstalled: sawPreferenceFile
-        ? `extension ${extensionId} was not found in profile preferences`
-        : "profile preferences do not exist yet",
-      extensionEnabled: "enablement was not inspected because the extension is missing",
-    },
-  };
-}
-
-function extensionSettings(preferences: unknown, extensionId: string): Record<string, any> | undefined {
-  if (!isRecord(preferences)) return undefined;
-  const extensions = preferences.extensions;
-  if (!isRecord(extensions)) return undefined;
-  const settings = extensions.settings;
-  if (!isRecord(settings)) return undefined;
-  const extension = settings[extensionId];
-  return isRecord(extension) ? extension : undefined;
-}
-
-function hasDisableReasons(value: unknown): boolean {
-  if (value === undefined || value === null || value === false || value === 0) return false;
-  if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === "object") return Object.keys(value).length > 0;
-  return true;
-}
-
 function runtimeBindingForResolvedProfile(input: {
   options: VerifyOptions;
   descriptor: RuntimeDescriptorProbe;
@@ -2849,23 +2699,6 @@ function homeDirFromLayout(layout: RuntimeLayout): string | undefined {
 
 function runtimeBrowserKind(browser: BrowserKind): string {
   return browser === "chrome-for-testing" ? "chrome" : browser;
-}
-
-function compareProfilePaths(left: string, right: string): number {
-  const leftName = path.basename(left);
-  const rightName = path.basename(right);
-  const leftRank = profileSortRank(leftName);
-  const rightRank = profileSortRank(rightName);
-  if (leftRank[0] !== rightRank[0]) return leftRank[0] - rightRank[0];
-  if (leftRank[1] !== rightRank[1]) return leftRank[1] - rightRank[1];
-  return path.resolve(left).localeCompare(path.resolve(right));
-}
-
-function profileSortRank(name: string): [number, number] {
-  if (name === "Default") return [0, 0];
-  const profile = /^Profile (\d+)$/.exec(name);
-  if (profile) return [1, Number(profile[1])];
-  return [2, 0];
 }
 
 function samePath(left: string, right: string): boolean {

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -12,7 +12,7 @@ import { type AgentId, type McpServerInvocation } from "./agents/registry.js";
 import { appendShellArgs } from "./command-line.js";
 import { doctorBrowser } from "./doctor-browser.js";
 import { type ExtensionChannel, type ExtensionIdSource } from "./extension-channel.js";
-import { browserProfileRoot, nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
+import { browserProfileRoot, browserRuntimeKind, nativeMessagingHostDir, type BrowserKind } from "./browser-paths.js";
 import {
   defaultProfileCandidates,
   inspectProfileCandidate,
@@ -1892,9 +1892,9 @@ async function probeOneDescriptor(
     const metadata = mergedDescriptorMetadata(descriptor, info.result);
     const browserKind = stringFromPath(metadata, ["browser_kind"]) ?? String(descriptor.name ?? "");
     const extensionId = stringFromPath(metadata, ["extension_id"]) ?? "unknown";
-    if (browserKind !== runtimeBrowserKind(options.browser)) {
+    if (browserKind !== browserRuntimeKind(options.browser)) {
       return descriptorFailure(
-        `descriptor browser kind ${browserKind || "unknown"} does not match ${runtimeBrowserKind(options.browser)}`,
+        `descriptor browser kind ${browserKind || "unknown"} does not match ${browserRuntimeKind(options.browser)}`,
         "browser_popup_boundary",
         "needs_browser_popup",
         "descriptor_browser_kind_mismatch",
@@ -2126,7 +2126,7 @@ function normalizeBackend(value: unknown, options: VerifyOptions): NormalizedBac
   const browserKind = typeof metadata.browser_kind === "string" ? metadata.browser_kind : typeof row.name === "string" ? row.name : undefined;
   const extensionId = typeof metadata.extension_id === "string" ? metadata.extension_id : undefined;
   const verified = row.type === "webextension" &&
-    browserKind === runtimeBrowserKind(options.browser) &&
+    browserKind === browserRuntimeKind(options.browser) &&
     extensionId === options.extensionId;
   return {
     type: typeof row.type === "string" ? row.type : "unknown",
@@ -2695,10 +2695,6 @@ function verifyArgs(options: VerifyOptions, repair: boolean, extra: { agentRunti
 function homeDirFromLayout(layout: RuntimeLayout): string | undefined {
   const obuDir = path.dirname(layout.userConfigPath);
   return path.basename(obuDir) === ".obu" ? path.dirname(obuDir) : undefined;
-}
-
-function runtimeBrowserKind(browser: BrowserKind): string {
-  return browser === "chrome-for-testing" ? "chrome" : browser;
 }
 
 function samePath(left: string, right: string): boolean {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/extension",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "open-browser-use Chromium MV3 extension.",
   "license": "MIT",

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "default_locale": "en",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA19raOghahuNORvUNtnkVqp9T+fNn3TBxyajKRpHPsWwfNDLaruz73Wn9S7fvCPyyFROJ+lOYH/72Iw/njYHLpNiKhyxphQE8oON2izCzz3KNkRaEsdzZ4utBlsFMABgxKybMEu9osjmj2n91Q4fFMqBv5eCpdl2dEp5KPO6tnNLspRwQMttKU/KqBAjGDkbSBuAlaSKkaAC8IVBqrBBTzcvH7AYXYjOLL9ZJ5a01QnFkyXtEyDvnmxbNRDvF7/8pmryq3E+Ue/COBqHWp57EKUNFHH2r/0ZczELo+6rYlH0mDGdr1hpVIiAAnoGu8XTlQ5vp4GH60+VszbNa9zLi2QIDAQAB",
   "minimum_chrome_version": "116",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-browser-use/sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "open-browser-use agent-facing SDK: Playwright-shaped API over the open-browser-use broker wire.",
   "license": "MIT",
   "type": "module",

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "0.1.8";
+export const SDK_VERSION = "0.1.9";

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -107,7 +107,7 @@ the command output says the local install is corrupt or missing.
 | --- | --- |
 | `verify.result == "ready"` | Stop and report success. |
 | Verify asks for repair | Rerun the same verify command with `--repair`. Keep the same agent/browser/channel/id tuple. |
-| Browser popup boundary | Setup attempts browser runtime activation automatically. If verify still returns this boundary, tell the user setup already opened the extension popup and waited up to 5 seconds; ask them to confirm the popup shows Connected or click Resume if enabled, then rerun the same verify command. |
+| Browser popup boundary | Setup attempts browser runtime activation automatically. If verify still returns this boundary, inspect the `runtime-activation-*` step result, opened count, candidate count, and errors; ask the user to confirm the popup shows Connected or click Resume if enabled, then rerun the same verify command. |
 | Divergent MCP server | Show the exact conflict and ask the user what to keep. Do not overwrite it silently. |
 | `agent-runtime-status: not_checked` with `result: ready` | Treat as non-blocking for CLI verification. |
 | MCP server works but `browser_status.backends` is empty | Run verify with the same handoff tuple; repair only if verify asks for it. |

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -87,6 +87,11 @@ refresh the release CLI, configure one target agent, then verify readiness.
      --json
    ```
 
+   The installer may add open-browser-use to shell profiles and print an
+   activation hint for the current shell. Keep using the `"$OBU"` absolute path
+   in this handoff anyway; do not assume the parent shell's `PATH` has changed
+   during the current command sequence.
+
 3. Stop when `verify` returns `result: ready`.
 
    Report the concise final state to the user. Do not run `doctor`,
@@ -143,7 +148,8 @@ The MCP server contract is:
 ```
 
 On a standard release install, resolve `/absolute/path/to/obu` from
-`~/.obu/bin/obu`. Do not depend on `obu` being on `PATH`.
+`~/.obu/bin/obu`. Do not depend on `obu` being on `PATH`, even after the
+installer reports shell profile updates.
 
 Prefer the current client's native MCP add command. It should be equivalent to:
 
@@ -254,7 +260,7 @@ obvious persistent instruction surface exists, show the snippet to the user.
   must allow that exact browser extension origin.
 - Do not configure other agents unless the user explicitly names them.
 - Do not overwrite divergent MCP server settings without asking the user.
-- Do not make broad PATH, shell profile, or dotfile edits beyond explicit
-  installer instructions.
+- Do not make broad PATH, shell profile, or dotfile edits beyond the official
+  installer's own managed env/profile updates.
 - Do not commit, push, or modify application code unless the user separately
   asks.

--- a/prompts/agent-install-prompt.md
+++ b/prompts/agent-install-prompt.md
@@ -107,7 +107,7 @@ the command output says the local install is corrupt or missing.
 | --- | --- |
 | `verify.result == "ready"` | Stop and report success. |
 | Verify asks for repair | Rerun the same verify command with `--repair`. Keep the same agent/browser/channel/id tuple. |
-| Browser popup boundary | Ask the user to open this extension popup, click Resume if enabled, wait for Connected, then rerun the same verify command. |
+| Browser popup boundary | Setup attempts browser runtime activation automatically. If verify still returns this boundary, tell the user setup already opened the extension popup and waited up to 5 seconds; ask them to confirm the popup shows Connected or click Resume if enabled, then rerun the same verify command. |
 | Divergent MCP server | Show the exact conflict and ask the user what to keep. Do not overwrite it silently. |
 | `agent-runtime-status: not_checked` with `result: ready` | Treat as non-blocking for CLI verification. |
 | MCP server works but `browser_status.backends` is empty | Run verify with the same handoff tuple; repair only if verify asks for it. |

--- a/scripts/cargo-dist-smoke.mjs
+++ b/scripts/cargo-dist-smoke.mjs
@@ -24,7 +24,7 @@ const plan = JSON.parse(run(cargoDist, [
   "plan",
   "--output-format=json",
   "--tag",
-  "v0.1.8",
+  "v0.1.9",
   "--allow-dirty",
 ]).stdout);
 

--- a/scripts/setup-local-spine-smoke.mjs
+++ b/scripts/setup-local-spine-smoke.mjs
@@ -55,7 +55,8 @@ try {
   assertStep(report, "runtime-dir", "applied");
   assertStep(report, "native-host-chrome-for-testing", "applied");
   assertStep(report, "extension-current", "applied");
-  assertStep(report, "runtime-descriptor-probe", "manual_action_required");
+  assertStep(report, "runtime-descriptor-probe", "skipped");
+  assertStep(report, "runtime-activation-chrome-for-testing", "manual_action_required");
   assertStep(report, "agent-adapters", "skipped");
 
   const config = JSON.parse(await readFile(path.join(home, ".obu", "config.json"), "utf8"));
@@ -166,6 +167,7 @@ function run(command, args, env = {}, options = {}) {
   const result = spawnSync(command, args, {
     encoding: "utf8",
     env: { ...process.env, ...env },
+    cwd: options.cwd ?? temp,
   });
   if (result.error) throw result.error;
   if (!options.allowFailure && result.status !== 0) {
@@ -179,6 +181,7 @@ function runAsync(command, args, env = {}, options = {}) {
     const child = spawn(command, args, {
       encoding: "utf8",
       env: { ...process.env, ...env },
+      cwd: options.cwd ?? temp,
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";


### PR DESCRIPTION
## Summary

- Add browser runtime auto-activation support and repair the activation readiness fixes found in review.
- Match runtime descriptors by both extension id and browser runtime kind, remove the production test-env activation stub, and serialize profile popup activation so setup stops after the first matching descriptor appears.
- Clarify the agent install prompt wording for cases where automatic activation was attempted but manual popup activation may still be required.
- Bump release versions to `0.1.9` so the merged main packaging run can produce `v0.1.9` artifacts.

## Scope note

This branch is based on local `main` at `fadb4d2`, while `origin/main` is currently `38bb289`. As a result, this PR also includes the two local main commits before the feature work:

- `aba4a16` docs: clarify install prompt path handling
- `fadb4d2` docs: design agent-queryable dev logs

The review/fix loop itself was for `fadb4d2..dffa928` and follow-up fix commit `9579de8`.

## Validation

- `pnpm --filter @open-browser-use/cli typecheck`
- `pnpm --filter @open-browser-use/cli test` (171 tests passed)
- `pnpm -r typecheck`
- `git diff --cached --check`
